### PR TITLE
feat: coscli v0.1 MVP — AI エージェント親和的 Cosense CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Lint / Type Check / Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 依存パッケージのインストール
+        run: bun install --frozen-lockfile
+
+      - name: Lint チェック
+        run: bunx biome ci src tests
+
+      - name: 型チェック
+        run: bun run typecheck
+
+      - name: テスト実行
+        run: bun test --coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            os: macos-latest
+            output: cos-darwin-arm64
+          - target: bun-darwin-x64
+            os: macos-latest
+            output: cos-darwin-x64
+          - target: bun-linux-x64
+            os: ubuntu-latest
+            output: cos-linux-x64
+          - target: bun-linux-arm64
+            os: ubuntu-latest
+            output: cos-linux-arm64
+          - target: bun-windows-x64
+            os: windows-latest
+            output: cos-windows-x64.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 依存パッケージのインストール
+        run: bun install --frozen-lockfile
+
+      - name: バイナリのビルド
+        run: bun build src/cli.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.output }}
+
+      - name: アーティファクトのアップロード
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.output }}
+          path: dist/${{ matrix.output }}
+
+  release:
+    name: GitHub Release の作成
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: バイナリのビルド
-        run: bun build src/cli.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.output }}
+        run: bun build src/cli.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.output }} --define 'VERSION="${{ github.ref_name }}"'
 
       - name: アーティファクトのアップロード
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log
+.bun/
+coverage/
+.DS_Store
+*.bak
+*.bun-build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# coscli CLAUDE.md
+
+## プロジェクト概要
+
+Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI。バイナリ名 `cos`。
+
+## 言語・スタイル
+
+- コメント・TSDoc・README・エラーメッセージは**日本語**で記述する
+- 変数名・関数名・型名は英語
+- エクスポート関数のコメント形式: `/** <関数名> は...を返す。 */`
+
+## 開発規約
+
+### TDD (厳格必須)
+
+**実装コードを書く前に、必ずテストを先に書くこと。実装ファーストは禁止。**
+
+サイクル: RED (失敗するテスト) → GREEN (最小限の実装) → REFACTOR (整理)
+
+### Gitワークフロー
+
+- **main ブランチへの直接コミット禁止**
+- ブランチ命名: `feature/<topic>`, `fix/<issue>`, `chore/<topic>`
+- PR 必須
+
+### 品質チェック (コミット前に必ず実行)
+
+```bash
+bunx biome check src tests   # Lint 警告ゼロ必須
+bun run typecheck            # 型エラーゼロ必須
+bun test                     # テスト全件 pass 必須
+```
+
+### コマンド追加ルール
+
+新コマンドを追加する際は以下を**同一 PR** に含める:
+1. `src/commands/<noun>/<verb>.ts` — 実装
+2. `tests/unit/commands/<noun>/<verb>.test.ts` — テスト
+3. alias がある場合は `src/cli.ts` の両方の登録箇所を更新
+
+### alias ルール
+
+トップレベル alias は citty で別 command として二重登録している。
+alias を追加・変更する際は `src/cli.ts` の「エイリアス登録」セクションを必ず同時に更新すること。
+
+## ディレクトリ構造
+
+```
+src/
+├── cli.ts           # citty エントリポイント。ルートフラグと sandbox の合流点
+├── commands/        # noun-verb ごとに 1 ファイル
+│   ├── page/
+│   ├── project/
+│   ├── auth/
+│   └── config/
+├── core/            # ドメインロジック (CLI から独立)
+│   ├── api/
+│   │   ├── encoder.ts    # title→slug 変換
+│   │   ├── rest.ts       # REST 読み取り + CSRF + リトライ
+│   │   └── ws.ts         # ScrapboxWriter interface + @cosense/std ラッパ
+│   ├── auth/
+│   │   ├── session.ts
+│   │   └── store.ts      # TokenStore interface
+│   ├── pages.ts
+│   ├── projects.ts
+│   ├── search.ts
+│   └── sandbox.ts        # --enable-commands / --disable-commands
+├── infra/
+│   ├── keychain/         # OS別 keychain 実装
+│   ├── config.ts         # JSON5 設定読み書き
+│   ├── logger.ts
+│   ├── retry.ts
+│   └── color.ts
+├── presenter/
+│   ├── json.ts           # envelope + --results-only + --select
+│   └── plain.ts
+└── schemas/              # zod スキーマ
+```
+
+## 依存ライブラリ
+
+- **citty** — CLI フレームワーク
+- **@cosense/std** (JSR) — Cosense REST + WebSocket commit
+- **@cosense/types** (JSR) — Cosense 型定義
+- **zod** — スキーマ検証
+- **json5** — 設定ファイル
+- **picocolors** — 色付け
+- **@clack/prompts** — 対話入力 (`--no-input` 時は即エラー)
+- **Biome** — Lint + Format
+
+## テスト
+
+- **`bun test`** をメインに使用
+- REST モック: `msw/node`
+- WS 層テスト: `ScrapboxWriter` のモック実装を注入
+- フィクスチャ: `tests/fixtures/` に sanitize 済み実 API レスポンス
+
+## sandbox
+
+`--enable-commands` / `--disable-commands` の仕様:
+- 形式: `noun.verb` (例: `page.list`, `page.delete`)
+- 両方指定時: enable で絞ってから disable で削る
+- 違反時: exit 7 (PolicyDenied)、stderr に `[denied] <command> is disabled by policy`
+
+## 終了コード
+
+| code | 意味 |
+|---|---|
+| 0 | 成功 |
+| 1 | 一般エラー |
+| 2 | 認証エラー (401) |
+| 3 | 権限エラー (403) |
+| 4 | NotFound (404) |
+| 5 | バリデーションエラー |
+| 6 | 楽観ロック競合 |
+| 7 | sandbox 違反 |
+| 124 | timeout |

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
+      },
+      "style": {
+        "useConst": "error",
+        "useTemplate": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "asNeeded"
+    }
+  },
+  "files": {
+    "ignore": ["node_modules", "dist", "*.d.ts"]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,250 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "coscli",
+      "dependencies": {
+        "@clack/prompts": "^0.10.1",
+        "@cosense/std": "npm:@jsr/cosense__std",
+        "@cosense/types": "npm:@jsr/cosense__types",
+        "citty": "^0.1.6",
+        "cli-table3": "^0.6.5",
+        "json5": "^2.2.3",
+        "picocolors": "^1.1.1",
+        "zod": "^3.25.17",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@types/bun": "latest",
+        "@types/json5": "^2.2.0",
+        "msw": "^2.7.5",
+        "typescript": "^5.8.3",
+      },
+    },
+  },
+  "trustedDependencies": [
+    "@biomejs/biome",
+  ],
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@clack/core": ["@clack/core@0.4.2", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg=="],
+
+    "@clack/prompts": ["@clack/prompts@0.10.1", "", { "dependencies": { "@clack/core": "0.4.2", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@cosense/std": ["@jsr/cosense__std@0.31.0", "https://npm.jsr.io/~/11/@jsr/cosense__std/0.31.0.tgz", { "dependencies": { "@jsr/core__iterutil": "^0.9.0", "@jsr/core__unknownutil": "^4.3.0", "@jsr/cosense__types": "^0.11.3", "@jsr/progfay__scrapbox-parser": "^10.0.2", "@jsr/std__async": "^1.0.14", "@jsr/std__encoding": "^1.0.10", "@jsr/std__http": "^1.0.20", "@jsr/std__json": "^1.0.2", "@jsr/std__testing": "^1.0.15", "@jsr/takker__md5": "0.1", "option-t": "53", "socket.io-client": "^4.8.1" } }, "sha512-uRqN2JP7y01sEuMFsj/5dGtF+bH7umsDW2FlbhvtcM6r+4yQX/F9fMcWrHQZfAgnOSH2N7myRkNYLmEQ8k44LQ=="],
+
+    "@cosense/types": ["@jsr/cosense__types@0.11.7", "https://npm.jsr.io/~/11/@jsr/cosense__types/0.11.7.tgz", {}, "sha512-SPYTcw768YycC2hCG+sAeG3c8Fsotu0E7fN+2Q+thkzq4wJ9HldcBRV4ln1IE4m32ugAtdhxat7QXgHXPvK9ag=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "@jsr/core__iterutil": ["@jsr/core__iterutil@0.9.0", "https://npm.jsr.io/~/11/@jsr/core__iterutil/0.9.0.tgz", {}, "sha512-4m89zR5WOKLz3YGyB+OaSgXuv0ddC9U0RpRTC21i/BXjr1RcRdePenUNpML+XrE3IAy/w2uOX3bg1JIVMjIZRw=="],
+
+    "@jsr/core__unknownutil": ["@jsr/core__unknownutil@4.3.0", "https://npm.jsr.io/~/11/@jsr/core__unknownutil/4.3.0.tgz", {}, "sha512-Rs+fY0+WX4pYG6B93M3/C9MVpE77Jlr69iYTC2PU+hTLOyu5CcwN17Og7titcWRoTdEJhFHYb4T5q+1bnEGZfQ=="],
+
+    "@jsr/cosense__types": ["@jsr/cosense__types@0.11.7", "https://npm.jsr.io/~/11/@jsr/cosense__types/0.11.7.tgz", {}, "sha512-SPYTcw768YycC2hCG+sAeG3c8Fsotu0E7fN+2Q+thkzq4wJ9HldcBRV4ln1IE4m32ugAtdhxat7QXgHXPvK9ag=="],
+
+    "@jsr/progfay__scrapbox-parser": ["@jsr/progfay__scrapbox-parser@10.1.1", "https://npm.jsr.io/~/11/@jsr/progfay__scrapbox-parser/10.1.1.tgz", {}, "sha512-xBtB64xW0aNSX1vM5FykbqeR2rzmY2ZHAOIMc+lj+ev4x9xrOkxnAGfViO4+qQcyiLkyeCbrsfSX4qdSNuT99g=="],
+
+    "@jsr/std__assert": ["@jsr/std__assert@1.0.19", "https://npm.jsr.io/~/11/@jsr/std__assert/1.0.19.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-pEj6RPkGbqlgRmyKwATp4cUs6+ijxtdrv3bq8v1d2I2CEcMEyPaO8cVKro61wGRDH4cNg8Zx6haztvK/9m7gkA=="],
+
+    "@jsr/std__async": ["@jsr/std__async@1.3.0", "https://npm.jsr.io/~/11/@jsr/std__async/1.3.0.tgz", { "dependencies": { "@jsr/std__data-structures": "^1.0.11" } }, "sha512-wi9lF+oZAtpvYWs4PKVF1U0ePNuRme37B7xsY0LRX0GnnuvRWxMZeNEeE2lD+kouj/NlMR2RsPEvFPQ/MvHGqQ=="],
+
+    "@jsr/std__bytes": ["@jsr/std__bytes@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz", {}, "sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA=="],
+
+    "@jsr/std__cli": ["@jsr/std__cli@1.0.29", "https://npm.jsr.io/~/11/@jsr/std__cli/1.0.29.tgz", { "dependencies": { "@jsr/std__fmt": "^1.0.10", "@jsr/std__internal": "^1.0.13" } }, "sha512-mPAJwNxtX5JwK5vrrxWLkPxkJUNULdw/8WJzbKTLG94PTSflvq+/09Dpou5+ltb4oSKMF2nTP6NvVxnMwFfMNA=="],
+
+    "@jsr/std__data-structures": ["@jsr/std__data-structures@1.0.11", "https://npm.jsr.io/~/11/@jsr/std__data-structures/1.0.11.tgz", { "dependencies": { "@jsr/std__assert": "^1.0.19" } }, "sha512-SeQ3rBVo+sj8e8XVfW3eTMJY3ygY69HW2H29j73tFJ5kHjnTMOURWX4PMiN1AOBcnNPm+l2UcQMmh6FDegUrnQ=="],
+
+    "@jsr/std__encoding": ["@jsr/std__encoding@1.0.10", "https://npm.jsr.io/~/11/@jsr/std__encoding/1.0.10.tgz", {}, "sha512-WK2njnDTyKefroRNk2Ooq7GStp6Y0ccAvr4To+Z/zecRAGe7+OSvH9DbiaHpAKwEi2KQbmpWMOYsdNt+TsdmSw=="],
+
+    "@jsr/std__fmt": ["@jsr/std__fmt@1.0.10", "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.10.tgz", {}, "sha512-Q2N8XDNkh/c1IKTi+sO4Vm64M5m4W0o47qTURmMX0vgHm9AJ6jL7jEQ2kw0M1T2rBZiwAY78eUbYzFyOYWaCqQ=="],
+
+    "@jsr/std__fs": ["@jsr/std__fs@1.0.23", "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.23.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12", "@jsr/std__path": "^1.1.4" } }, "sha512-e8jspB3M44E5YhWiLCTqibBBTwVmxQaHN06WvFa/elAKm5E/LfAe8Hj5XGNC8P7a0MIPASlNJsnF1bgO/g+aqg=="],
+
+    "@jsr/std__html": ["@jsr/std__html@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__html/1.0.6.tgz", {}, "sha512-okF5FAJ/erV1np18z5BHKyfxBFf9QiXqRAg4829Sn0VzqiGSfbXcNld3dXYnGV0jooXawngyemDHvqJnp+rhpQ=="],
+
+    "@jsr/std__http": ["@jsr/std__http@1.1.0", "https://npm.jsr.io/~/11/@jsr/std__http/1.1.0.tgz", { "dependencies": { "@jsr/std__cli": "^1.0.29", "@jsr/std__encoding": "^1.0.10", "@jsr/std__fmt": "^1.0.10", "@jsr/std__fs": "^1.0.23", "@jsr/std__html": "^1.0.6", "@jsr/std__media-types": "^1.1.0", "@jsr/std__net": "^1.0.6", "@jsr/std__path": "^1.1.4", "@jsr/std__streams": "^1.1.0" } }, "sha512-YOwuwffCdvlRlG5B1EgJuOPAEJT3aSAas8utJkQqBSGYTsy9TMUkr8P2FeOwTDH0c6DwKbubc4w981u7Sgz30w=="],
+
+    "@jsr/std__internal": ["@jsr/std__internal@1.0.13", "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.13.tgz", {}, "sha512-FIyYlSZkAwdupuTybRiU53MnrQUsyulhf6bPZ4bBILl1KqHCkKUlJ5TnLIATNezA5Yg7fAn64EE4vuHep2Urog=="],
+
+    "@jsr/std__json": ["@jsr/std__json@1.1.0", "https://npm.jsr.io/~/11/@jsr/std__json/1.1.0.tgz", { "dependencies": { "@jsr/std__streams": "^1.1.0" } }, "sha512-a9Eylh7ox33tFn5RxhESnvI4akpefQP5Qn+ePz3Ih4IJ/EPA8p0SKq0aztRfN1sGDhfyWMPWwlUcwNxONt+Ncg=="],
+
+    "@jsr/std__media-types": ["@jsr/std__media-types@1.1.0", "https://npm.jsr.io/~/11/@jsr/std__media-types/1.1.0.tgz", {}, "sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw=="],
+
+    "@jsr/std__net": ["@jsr/std__net@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__net/1.0.6.tgz", {}, "sha512-mh27Fw4UMCjGSIMoOhjia5cS5fNP9M9DZYhGB7EYSZNnzf/eguFiarii/W4oDwYMmnxCMouUzhc6Y7jFuwTzcg=="],
+
+    "@jsr/std__path": ["@jsr/std__path@1.1.4", "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA=="],
+
+    "@jsr/std__streams": ["@jsr/std__streams@1.1.0", "https://npm.jsr.io/~/11/@jsr/std__streams/1.1.0.tgz", { "dependencies": { "@jsr/std__bytes": "^1.0.6" } }, "sha512-0yP/bIRAgcpdIg1o/XSYnVmCs3a7rtfKfhPPiKo7GFEtvF2qngWKJ80u8xN+D8o3otsrf/Ta90XiNj5WZJfFgg=="],
+
+    "@jsr/std__testing": ["@jsr/std__testing@1.0.18", "https://npm.jsr.io/~/11/@jsr/std__testing/1.0.18.tgz", { "dependencies": { "@jsr/std__assert": "^1.0.19", "@jsr/std__async": "^1.3.0", "@jsr/std__data-structures": "^1.0.11", "@jsr/std__fs": "^1.0.23", "@jsr/std__internal": "^1.0.13", "@jsr/std__path": "^1.1.4" } }, "sha512-xtWpm+MZReSVqB3gJQM6QHbDsywiWvn69PVn7lozX14X3GJR8VqkiGIF6b36D1EPEnKFSg03g//SqAd2vNAIuw=="],
+
+    "@jsr/takker__md5": ["@jsr/takker__md5@0.1.0", "https://npm.jsr.io/~/11/@jsr/takker__md5/0.1.0.tgz", {}, "sha512-PPE9oWxXq17shmtlml2Tl48Cq5ENM9AWk2i1caWCgqp2/Nn00ew8KZU0v/a563ulrapjm2XHLHgo/Ebm4BsX3Q=="],
+
+    "@mswjs/interceptors": ["@mswjs/interceptors@0.41.6", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q=="],
+
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
+
+    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
+
+    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/json5": ["@types/json5@2.2.0", "", { "dependencies": { "json5": "*" } }, "sha512-NrVug5woqbvNZ0WX+Gv4R+L4TGddtmFek2u8RtccAgFZWtS9QXF2xCXY22/M4nzkaKF0q9Fc6M/5rxLDhfwc/A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
+
+    "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "engine.io-client": ["engine.io-client@6.6.4", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
+
+    "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "msw": ["msw@2.13.6", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-GAJbQy8Ra/Ydjt0Hb2MGT2qhzd83J3+QZMHdH85uW7r/XkKc846+Ma2PLif5hGvTm5Yqa+wkcstpim0WeLZU9g=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "option-t": ["option-t@53.0.0", "", {}, "sha512-qsyo1cFXfUN1MVnxTrpcy+V4tJYEBvEQmeiDkC6m5W/V2JiNfs4V/qXmDGZg4k9XRR1EWkv3jT8TXSZnhGPBLA=="],
+
+    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "rettime": ["rettime@0.11.8", "", {}, "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+# カバレッジ設定
+coverage = true
+coverageThreshold = { line = 80, function = 80 }
+# テストファイルのパターン
+include = ["tests/**/*.test.ts", "src/**/*.test.ts"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "coscli",
+  "version": "0.1.0",
+  "description": "Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI",
+  "bin": {
+    "cos": "./dist/cos"
+  },
+  "module": "src/cli.ts",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run src/cli.ts",
+    "build": "bun run scripts/build.ts",
+    "build:dev": "bun build src/cli.ts --outdir dist --target bun",
+    "test": "bun test",
+    "test:coverage": "bun test --coverage",
+    "lint": "bunx biome check src tests",
+    "lint:fix": "bunx biome check --write src tests",
+    "format": "bunx biome format --write src tests",
+    "typecheck": "tsc --noEmit",
+    "ci": "bun run lint && bun run typecheck && bun test --coverage"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.10.1",
+    "@cosense/std": "npm:@jsr/cosense__std",
+    "@cosense/types": "npm:@jsr/cosense__types",
+    "citty": "^0.1.6",
+    "cli-table3": "^0.6.5",
+    "json5": "^2.2.3",
+    "picocolors": "^1.1.1",
+    "zod": "^3.25.17"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/bun": "latest",
+    "@types/json5": "^2.2.0",
+    "msw": "^2.7.5",
+    "typescript": "^5.8.3"
+  },
+  "trustedDependencies": [
+    "@biomejs/biome"
+  ]
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,50 @@
+/**
+ * build.ts — bun build --compile を複数ターゲットで実行するビルドスクリプト。
+ *
+ * 使用方法: bun run scripts/build.ts
+ * 単一ターゲット: bun run scripts/build.ts --target=bun-darwin-arm64
+ */
+
+export {}
+
+const VERSION = process.env["VERSION"] ?? "dev"
+
+const targets = [
+  { target: "bun-darwin-arm64", output: "cos-darwin-arm64" },
+  { target: "bun-darwin-x64", output: "cos-darwin-x64" },
+  { target: "bun-linux-x64", output: "cos-linux-x64" },
+  { target: "bun-linux-arm64", output: "cos-linux-arm64" },
+  { target: "bun-windows-x64", output: "cos-windows-x64.exe" },
+]
+
+const singleTarget = process.argv.find((a) => a.startsWith("--target="))?.split("=")[1]
+const buildTargets = singleTarget ? targets.filter((t) => t.target === singleTarget) : targets
+
+if (buildTargets.length === 0) {
+  console.error(`不明なターゲット: ${singleTarget}`)
+  process.exit(1)
+}
+
+for (const { target, output } of buildTargets) {
+  console.log(`ビルド中: ${target} → dist/${output}`)
+  const proc = Bun.spawn(
+    [
+      "bun",
+      "build",
+      "src/cli.ts",
+      "--compile",
+      `--target=${target}`,
+      `--outfile=dist/${output}`,
+      "--define",
+      `VERSION="${VERSION}"`,
+    ],
+    { stdout: "inherit", stderr: "inherit" },
+  )
+  const exit = await proc.exited
+  if (exit !== 0) {
+    console.error(`ビルド失敗: ${target}`)
+    process.exit(exit)
+  }
+}
+
+console.log("ビルド完了")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,142 @@
+/**
+ * cli.ts — coscli エントリポイント。
+ *
+ * citty で noun-verb 階層のコマンドツリーを構築し、
+ * ルートフラグ (--project, --json, --dry-run 等) と
+ * sandbox (--enable-commands/--disable-commands) を一元管理する。
+ */
+
+import { initColor } from "@/infra/color"
+import { defineCommand, runMain } from "citty"
+
+// bun build --define 'VERSION="x.y.z"' でビルド時に注入される
+declare const VERSION: string
+
+import { pageAppendCommand } from "@/commands/page/append"
+import { pageCodeCommand } from "@/commands/page/code"
+import { pageDeleteCommand } from "@/commands/page/delete"
+import { pageEditCommand } from "@/commands/page/edit"
+import { pageGetCommand } from "@/commands/page/get"
+// ページコマンド
+import { pageListCommand } from "@/commands/page/list"
+import { pageNewCommand } from "@/commands/page/new"
+import { pageTextCommand } from "@/commands/page/text"
+import { pageUrlCommand } from "@/commands/page/url"
+
+import { projectInfoCommand } from "@/commands/project/info"
+// プロジェクトコマンド
+import { projectListCommand } from "@/commands/project/list"
+
+// 検索コマンド
+import { searchCommand } from "@/commands/search"
+
+// 認証コマンド
+import { authLoginCommand } from "@/commands/auth/login"
+import { authLogoutCommand } from "@/commands/auth/logout"
+import { authWhoamiCommand } from "@/commands/auth/whoami"
+
+// 設定コマンド
+import { configGetCommand } from "@/commands/config/get"
+import { configPathCommand } from "@/commands/config/path"
+import { configSetCommand } from "@/commands/config/set"
+
+/** page サブコマンドグループ */
+const pageCommand = defineCommand({
+  meta: { description: "ページ操作コマンド" },
+  subCommands: {
+    list: pageListCommand,
+    ls: pageListCommand,
+    get: pageGetCommand,
+    text: pageTextCommand,
+    code: pageCodeCommand,
+    url: pageUrlCommand,
+    new: pageNewCommand,
+    create: pageNewCommand,
+    edit: pageEditCommand,
+    ed: pageEditCommand,
+    append: pageAppendCommand,
+    delete: pageDeleteCommand,
+    rm: pageDeleteCommand,
+  },
+})
+
+/** project サブコマンドグループ */
+const projectCommand = defineCommand({
+  meta: { description: "プロジェクト操作コマンド" },
+  subCommands: {
+    list: projectListCommand,
+    ls: projectListCommand,
+    info: projectInfoCommand,
+  },
+})
+
+/** auth サブコマンドグループ */
+const authCommand = defineCommand({
+  meta: { description: "認証コマンド" },
+  subCommands: {
+    login: authLoginCommand,
+    logout: authLogoutCommand,
+    whoami: authWhoamiCommand,
+    me: authWhoamiCommand,
+  },
+})
+
+/** config サブコマンドグループ */
+const configCommand = defineCommand({
+  meta: { description: "設定コマンド" },
+  subCommands: {
+    get: configGetCommand,
+    set: configSetCommand,
+    path: configPathCommand,
+  },
+})
+
+/** ルートコマンド */
+const main = defineCommand({
+  meta: {
+    name: "cos",
+    version: VERSION,
+    description: "AI エージェント親和的 Cosense (Scrapbox) CLI",
+  },
+  args: {
+    "enable-commands": {
+      type: "string",
+      description: "許可するコマンドリスト (カンマ区切り: page.list,page.get)",
+    },
+    "disable-commands": {
+      type: "string",
+      description: "禁止するコマンドリスト (カンマ区切り: page.delete)",
+    },
+    color: {
+      type: "string",
+      description: "色設定 (auto/always/never)",
+      default: process.env["COS_COLOR"] ?? "auto",
+    },
+  },
+  setup({ args }) {
+    // 色初期化
+    const colorMode = (args.color ?? "auto") as "auto" | "always" | "never"
+    initColor(colorMode)
+
+    // sandbox ポリシーのプリセット設定を環境変数に反映する
+    // 実際の判定は各コマンドの checkSandbox() で行う
+    if (args["enable-commands"]) {
+      process.env["COS_ENABLE_COMMANDS"] = args["enable-commands"]
+    }
+    if (args["disable-commands"]) {
+      process.env["COS_DISABLE_COMMANDS"] = args["disable-commands"]
+    }
+  },
+  subCommands: {
+    page: pageCommand,
+    project: projectCommand,
+    search: searchCommand,
+    find: searchCommand,
+    auth: authCommand,
+    login: authLoginCommand,
+    me: authWhoamiCommand,
+    config: configCommand,
+  },
+})
+
+runMain(main)

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -1,0 +1,186 @@
+/**
+ * _shared.ts — コマンド間で共有するフラグ定義とクライアント生成ヘルパー。
+ *
+ * 各コマンドはここで定義した commonArgs を引数に含めることで、
+ * ルートフラグを統一して受け取れる。
+ */
+
+import { CosenseRestClient } from "@/core/api/rest"
+import { createScrapboxWriter } from "@/core/api/ws"
+import { loadSession } from "@/core/auth/session"
+import { PolicyError, createPolicy } from "@/core/sandbox"
+import { loadConfig } from "@/infra/config"
+import { createTokenStore } from "@/infra/keychain/index"
+import { Logger } from "@/infra/logger"
+import { writeErrorJson } from "@/presenter/json"
+import type { JsonOutputOptions } from "@/presenter/json"
+
+/** commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義。 */
+export const commonArgs = {
+  project: {
+    type: "string" as const,
+    alias: "p",
+    description: "プロジェクト名 (環境変数 COS_PROJECT でも指定可)",
+  },
+  profile: {
+    type: "string" as const,
+    description: "認証プロファイル名 (デフォルト: default)",
+  },
+  json: {
+    type: "boolean" as const,
+    alias: "J",
+    description: "JSON 出力",
+    default: false,
+  },
+  plain: {
+    type: "boolean" as const,
+    alias: "P",
+    description: "プレーンテキスト出力 (TSV)",
+    default: false,
+  },
+  "results-only": {
+    type: "boolean" as const,
+    description: "--json 時に data のみ返す",
+    default: false,
+  },
+  select: {
+    type: "string" as const,
+    description: "出力セレクタ (例: pages[].title)",
+  },
+  "dry-run": {
+    type: "boolean" as const,
+    description: "書き込み計画のみ表示して実行しない",
+    default: false,
+  },
+  "enable-commands": {
+    type: "string" as const,
+    description: "許可するコマンドリスト (カンマ区切り)",
+  },
+  "disable-commands": {
+    type: "string" as const,
+    description: "禁止するコマンドリスト (カンマ区切り)",
+  },
+  verbose: {
+    type: "string" as const,
+    alias: "v",
+    description: "詳細出力 (-v / -vv)",
+  },
+  quiet: {
+    type: "boolean" as const,
+    alias: "q",
+    description: "成功時の人間向けメッセージを抑制",
+    default: false,
+  },
+} as const
+
+/** CommonArgs はコマンドが受け取る共通フラグの型。 */
+export type CommonArgs = {
+  project?: string
+  profile?: string
+  json: boolean
+  plain: boolean
+  "results-only": boolean
+  select?: string
+  "dry-run": boolean
+  "enable-commands"?: string
+  "disable-commands"?: string
+  verbose?: string
+  quiet: boolean
+}
+
+/** buildLogger はフラグからロガーを生成する。 */
+export function buildLogger(args: CommonArgs): Logger {
+  const verboseLevel =
+    args.verbose === "vv" || args.verbose === "2"
+      ? 2
+      : args.verbose === "v" || args.verbose === "1"
+        ? 1
+        : 0
+  return new Logger({
+    quiet: args.quiet,
+    json: args.json,
+    plain: args.plain,
+    verbose: verboseLevel,
+  })
+}
+
+/**
+ * checkSandbox はサンドボックスポリシーを確認する。
+ * 拒否された場合は exit 7 で終了する。
+ */
+export function checkSandbox(commandName: string, args: CommonArgs): void {
+  const config = loadConfig()
+  const enableStr = args["enable-commands"] ?? process.env["COS_ENABLE_COMMANDS"]
+  const disableStr =
+    args["disable-commands"] ??
+    process.env["COS_DISABLE_COMMANDS"] ??
+    config.agent?.defaultDisableCommands?.join(",")
+
+  if (!enableStr && !disableStr) return
+
+  const policyOpts: Parameters<typeof createPolicy>[0] = {}
+  if (enableStr !== undefined) policyOpts.enableStr = enableStr
+  if (disableStr !== undefined) policyOpts.disableStr = disableStr
+  const policy = createPolicy(policyOpts)
+  const denied = policy.allow(commandName)
+  if (denied instanceof PolicyError) {
+    writeErrorJson(
+      "POLICY_DENIED",
+      `[denied] ${commandName} is disabled by policy`,
+      "--enable-commands フラグで明示的に許可してください",
+    )
+    process.exit(7)
+  }
+}
+
+/**
+ * buildJsonOpts は CommonArgs から JsonOutputOptions を安全に生成する。
+ * exactOptionalPropertyTypes に対応するため undefined を持つプロパティを除外する。
+ */
+export function buildJsonOpts(args: CommonArgs): JsonOutputOptions {
+  const opts: JsonOutputOptions = { resultsOnly: args["results-only"] }
+  if (args.select !== undefined) opts.select = args.select
+  return opts
+}
+
+/** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
+export async function requireSid(profile?: string): Promise<string> {
+  const store = createTokenStore()
+  const sessionOpts = profile !== undefined ? { profile } : {}
+  const sid = await loadSession(store, sessionOpts)
+  if (!sid) {
+    writeErrorJson(
+      "AUTH_REQUIRED",
+      "認証情報が見つかりません",
+      "`cos auth login` を実行してログインしてください",
+    )
+    process.exit(2)
+  }
+  return sid
+}
+
+/** requireProject はプロジェクト名を取得し、未指定の場合はエラーで終了する。 */
+export function requireProject(args: CommonArgs): string {
+  const project = args.project ?? process.env["COS_PROJECT"]
+  if (!project) {
+    writeErrorJson(
+      "PROJECT_REQUIRED",
+      "プロジェクト名が指定されていません",
+      "--project (-p) フラグか COS_PROJECT 環境変数でプロジェクトを指定してください",
+    )
+    process.exit(5)
+  }
+  return project
+}
+
+/** buildRestClient は認証済み REST クライアントを生成する。 */
+export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClient> {
+  const sid = await requireSid(args.profile)
+  return new CosenseRestClient({ sid })
+}
+
+/** buildWriter は ScrapboxWriter を生成する。 */
+export async function buildWriter(args: CommonArgs) {
+  const sid = await requireSid(args.profile)
+  return createScrapboxWriter({ sid, dryRun: args["dry-run"] })
+}

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,0 +1,72 @@
+/**
+ * auth/login.ts — `cos auth login` コマンド。
+ *
+ * connect.sid を対話入力または --sid フラグで受け取り、
+ * /api/users/me で検証後に TokenStore に保存する。
+ * --no-input 時は --sid フラグが必須。
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { CosenseRestClient } from "@/core/api/rest"
+import { saveSession } from "@/core/auth/session"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const authLoginCommand = defineCommand({
+  meta: { description: "Cosense に認証ログインする" },
+  args: {
+    ...commonArgs,
+    sid: {
+      type: "string",
+      description: "connect.sid の値 (--no-input 時に使用)",
+    },
+    "no-input": {
+      type: "boolean",
+      description: "対話入力を禁止 (CI/エージェント向け)",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { sid?: string; "no-input": boolean }
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+    const profile = a.profile ?? "default"
+
+    let sid: string
+    if (a.sid) {
+      sid = a.sid
+    } else if (a["no-input"]) {
+      writeErrorJson("SID_REQUIRED", "--no-input モードでは --sid フラグが必要です")
+      process.exit(5)
+    } else {
+      // 対話入力
+      const { password, intro, outro, isCancel } = await import("@clack/prompts")
+      intro("Cosense ログイン")
+      process.stderr.write(
+        "ブラウザで Cosense にログイン後、DevTools > Application > Cookies から\n" +
+          '"connect.sid" の値をコピーして貼り付けてください。\n',
+      )
+      const input = await password({ message: "connect.sid:" })
+      if (isCancel(input)) {
+        outro("キャンセルしました")
+        process.exit(0)
+      }
+      sid = input as string
+    }
+
+    logger.info("認証情報を確認中...")
+
+    const client = new CosenseRestClient({ sid })
+    const me = await client.getMe()
+
+    const store = createTokenStore()
+    await saveSession(store, { profile, sid })
+
+    logger.success(`${me.name} としてログインしました (プロファイル: ${profile})`)
+
+    if (a.json) {
+      writeJson({ profile, name: me.name }, { command: "auth.login", startTime }, buildJsonOpts(a))
+    }
+  },
+})

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -6,7 +6,13 @@
  * --no-input 時は --sid フラグが必須。
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
 import { saveSession } from "@/core/auth/session"
 import { createTokenStore } from "@/infra/keychain/index"
@@ -29,6 +35,7 @@ export const authLoginCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { sid?: string; "no-input": boolean }
+    checkSandbox("auth.login", a)
     const logger = buildLogger(a)
     const startTime = Date.now()
     const profile = a.profile ?? "default"

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,0 +1,35 @@
+/**
+ * auth/logout.ts — `cos auth logout` コマンド。
+ *
+ * 指定したプロファイルの connect.sid を TokenStore から削除する。
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { deleteSession } from "@/core/auth/session"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const authLogoutCommand = defineCommand({
+  meta: { description: "認証情報を削除する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs
+    const logger = buildLogger(a)
+    const profile = a.profile ?? "default"
+    const startTime = Date.now()
+
+    const store = createTokenStore()
+    await deleteSession(store, { profile })
+
+    logger.success(`プロファイル "${profile}" からログアウトしました`)
+
+    if (a.json) {
+      writeJson(
+        { profile, loggedOut: true },
+        { command: "auth.logout", startTime },
+        buildJsonOpts(a),
+      )
+    }
+  },
+})

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -4,7 +4,13 @@
  * 指定したプロファイルの connect.sid を TokenStore から削除する。
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { deleteSession } from "@/core/auth/session"
 import { createTokenStore } from "@/infra/keychain/index"
 import { writeJson } from "@/presenter/json"
@@ -15,6 +21,7 @@ export const authLogoutCommand = defineCommand({
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs
+    checkSandbox("auth.logout", a)
     const logger = buildLogger(a)
     const profile = a.profile ?? "default"
     const startTime = Date.now()

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -1,0 +1,53 @@
+/**
+ * auth/whoami.ts — `cos auth whoami` コマンド。
+ *
+ * 現在の認証ユーザー情報を取得して出力する。
+ * alias: `cos me`
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { CosenseRestClient } from "@/core/api/rest"
+import { loadSession } from "@/core/auth/session"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writePlainTable } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const authWhoamiCommand = defineCommand({
+  meta: { description: "現在の認証ユーザー情報を取得する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+
+    const store = createTokenStore()
+    const sid = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
+    if (!sid) {
+      writeErrorJson(
+        "AUTH_REQUIRED",
+        "認証情報が見つかりません",
+        "`cos auth login` を実行してログインしてください",
+      )
+      process.exit(2)
+    }
+
+    logger.info("ユーザー情報を取得中...")
+
+    const client = new CosenseRestClient({ sid })
+    const me = await client.getMe()
+
+    if (a.json || !a.plain) {
+      writeJson(me, { command: "auth.whoami", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    writePlainTable(
+      ["フィールド", "値"],
+      [
+        ["名前", me.name],
+        ["ID", me.id],
+      ],
+    )
+  },
+})

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -5,7 +5,13 @@
  * alias: `cos me`
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
 import { loadSession } from "@/core/auth/session"
 import { createTokenStore } from "@/infra/keychain/index"
@@ -18,6 +24,7 @@ export const authWhoamiCommand = defineCommand({
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs
+    checkSandbox("auth.whoami", a)
     const logger = buildLogger(a)
     const startTime = Date.now()
 

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -5,7 +5,13 @@
  * キーはドット区切りのパス (例: output.color)。
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { getConfigValue, loadConfig } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -22,6 +28,7 @@ export const configGetCommand = defineCommand({
   },
   run({ args }) {
     const a = args as CommonArgs & { key: string }
+    checkSandbox("config.get", a)
     const logger = buildLogger(a)
     const startTime = Date.now()
 
@@ -32,7 +39,7 @@ export const configGetCommand = defineCommand({
       writeErrorJson(
         "KEY_NOT_FOUND",
         `設定キー "${a.key}" が見つかりません`,
-        "`cos config list` で設定一覧を確認してください",
+        "`cos config path` で設定ファイルのパスを確認し、直接編集してください",
       )
       process.exit(4)
     }

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -1,0 +1,48 @@
+/**
+ * config/get.ts — `cos config get <key>` コマンド。
+ *
+ * 設定ファイルから指定したキーの値を取得する。
+ * キーはドット区切りのパス (例: output.color)。
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { getConfigValue, loadConfig } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const configGetCommand = defineCommand({
+  meta: { description: "設定値を取得する" },
+  args: {
+    ...commonArgs,
+    key: {
+      type: "positional",
+      description: "設定キー (例: output.color, defaultProject)",
+      required: true,
+    },
+  },
+  run({ args }) {
+    const a = args as CommonArgs & { key: string }
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+
+    const config = loadConfig()
+    const value = getConfigValue(config, a.key)
+
+    if (value === undefined) {
+      writeErrorJson(
+        "KEY_NOT_FOUND",
+        `設定キー "${a.key}" が見つかりません`,
+        "`cos config list` で設定一覧を確認してください",
+      )
+      process.exit(4)
+    }
+
+    if (a.json || !a.plain) {
+      writeJson({ key: a.key, value }, { command: "config.get", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.verbose(`${a.key} = ${JSON.stringify(value)}`)
+    process.stdout.write(`${JSON.stringify(value)}\n`)
+  },
+})

--- a/src/commands/config/path.ts
+++ b/src/commands/config/path.ts
@@ -1,0 +1,31 @@
+/**
+ * config/path.ts — `cos config path` コマンド。
+ *
+ * 設定ファイルのパスを出力する。
+ * エディタで直接開きたい場合などに使う。
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { defaultConfigPath } from "@/infra/config"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const configPathCommand = defineCommand({
+  meta: { description: "設定ファイルのパスを表示する" },
+  args: { ...commonArgs },
+  run({ args }) {
+    const a = args as CommonArgs
+    const logger = buildLogger(a)
+    const path = defaultConfigPath()
+    const startTime = Date.now()
+
+    logger.verbose(`設定ファイル: ${path}`)
+
+    if (a.json) {
+      writeJson({ path }, { command: "config.path", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${path}\n`)
+  },
+})

--- a/src/commands/config/path.ts
+++ b/src/commands/config/path.ts
@@ -5,7 +5,13 @@
  * エディタで直接開きたい場合などに使う。
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { defaultConfigPath } from "@/infra/config"
 import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -15,6 +21,7 @@ export const configPathCommand = defineCommand({
   args: { ...commonArgs },
   run({ args }) {
     const a = args as CommonArgs
+    checkSandbox("config.path", a)
     const logger = buildLogger(a)
     const path = defaultConfigPath()
     const startTime = Date.now()

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -1,0 +1,65 @@
+/**
+ * config/set.ts — `cos config set <key> <value>` コマンド。
+ *
+ * 設定ファイルにキーと値を保存する。
+ * キーはドット区切りのパス (例: output.color)。
+ * 値は JSON として解釈し、失敗した場合は文字列として扱う。
+ */
+
+import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import { loadConfig, saveConfig, setConfigValue } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const configSetCommand = defineCommand({
+  meta: { description: "設定値を保存する" },
+  args: {
+    ...commonArgs,
+    key: {
+      type: "positional",
+      description: "設定キー (例: output.color)",
+      required: true,
+    },
+    value: {
+      type: "positional",
+      description: "設定値 (JSON または文字列)",
+      required: true,
+    },
+  },
+  run({ args }) {
+    const a = args as CommonArgs & { key: string; value: string }
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+
+    // JSON として解釈を試みる (数値・真偽値・null 対応)
+    let parsedValue: unknown
+    try {
+      parsedValue = JSON.parse(a.value)
+    } catch {
+      parsedValue = a.value
+    }
+
+    const config = loadConfig()
+    let updated: ReturnType<typeof setConfigValue>
+    try {
+      updated = setConfigValue(config, a.key, parsedValue)
+    } catch (err) {
+      writeErrorJson(
+        "INVALID_VALUE",
+        `設定値が不正です: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      process.exit(5)
+    }
+
+    saveConfig(updated)
+    logger.success(`${a.key} = ${JSON.stringify(parsedValue)} を保存しました`)
+
+    if (a.json) {
+      writeJson(
+        { key: a.key, value: parsedValue },
+        { command: "config.set", startTime },
+        buildJsonOpts(a),
+      )
+    }
+  },
+})

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -6,7 +6,13 @@
  * 値は JSON として解釈し、失敗した場合は文字列として扱う。
  */
 
-import { type CommonArgs, buildJsonOpts, buildLogger, commonArgs } from "@/commands/_shared"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
 import { loadConfig, saveConfig, setConfigValue } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -28,6 +34,7 @@ export const configSetCommand = defineCommand({
   },
   run({ args }) {
     const a = args as CommonArgs & { key: string; value: string }
+    checkSandbox("config.set", a)
     const logger = buildLogger(a)
     const startTime = Date.now()
 

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -11,6 +11,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildWriter,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -38,6 +39,7 @@ export const pageAppendCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string; line?: string; "from-file"?: string }
+    checkSandbox("page.append", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
@@ -46,7 +48,7 @@ export const pageAppendCommand = defineCommand({
     if (a.line) {
       lines = a.line.split("\\n")
     } else if (a["from-file"] === "-") {
-      const content = readFileSync("/dev/stdin", "utf-8")
+      const content = readFileSync(0, "utf-8")
       lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
     } else if (a["from-file"]) {
       const content = readFileSync(a["from-file"], "utf-8")

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -1,0 +1,77 @@
+/**
+ * page/append.ts — `cos page append <title>` コマンド。
+ *
+ * ページ末尾に行を追加する。
+ * --line で直接テキスト指定、- で stdin から読み込む。
+ */
+
+import { readFileSync } from "node:fs"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { appendToPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageAppendCommand = defineCommand({
+  meta: { description: "ページ末尾に行を追加する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "追加する行テキスト (複数行は \\n で区切る)",
+    },
+    "from-file": {
+      type: "string",
+      description: "追加行のファイルパス (- で stdin)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; line?: string; "from-file"?: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    let lines: string[] = []
+    if (a.line) {
+      lines = a.line.split("\\n")
+    } else if (a["from-file"] === "-") {
+      const content = readFileSync("/dev/stdin", "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    } else if (a["from-file"]) {
+      const content = readFileSync(a["from-file"], "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    }
+
+    if (lines.length === 0) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "追加する行が指定されていません",
+        "--line または --from-file でコンテンツを指定してください",
+      )
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" に行を追加中...`)
+
+    const writer = await buildWriter(a)
+    const result = await appendToPage(writer, { project, title: a.title, lines })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.append", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" に追加しました`)
+  },
+})

--- a/src/commands/page/code.ts
+++ b/src/commands/page/code.ts
@@ -9,6 +9,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -33,6 +34,7 @@ export const pageCodeCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string; filename: string }
+    checkSandbox("page.code", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()

--- a/src/commands/page/code.ts
+++ b/src/commands/page/code.ts
@@ -1,0 +1,52 @@
+/**
+ * page/code.ts — `cos page code <title> <filename>` コマンド。
+ *
+ * ページ内のコードブロックを取得して stdout に出力する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { getCodeBlock } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageCodeCommand = defineCommand({
+  meta: { description: "ページ内のコードブロックを取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    filename: {
+      type: "positional",
+      description: "コードブロックのファイル名",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; filename: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" の ${a.filename} を取得中...`)
+
+    const client = await buildRestClient(a)
+    const code = await getCodeBlock(client, { project, title: a.title, filename: a.filename })
+
+    if (a.json) {
+      writeJson({ code }, { command: "page.code", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${code}\n`)
+  },
+})

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -1,0 +1,74 @@
+/**
+ * page/delete.ts — `cos page delete <title>` コマンド。
+ *
+ * ページを削除する。--force なしの場合は確認プロンプトを表示する。
+ * --no-input 時は --force が必須。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { deletePage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageDeleteCommand = defineCommand({
+  meta: { description: "ページを削除する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    force: {
+      type: "boolean",
+      alias: "y",
+      description: "確認プロンプトをスキップ",
+      default: false,
+    },
+    "no-input": {
+      type: "boolean",
+      description: "対話入力を禁止 (CI/エージェント向け)",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; force: boolean; "no-input": boolean }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    if (!a.force && !a["no-input"] && !a["dry-run"]) {
+      // 対話確認 (--force または --no-input 未指定時)
+      const { confirm } = await import("@clack/prompts")
+      const yes = await confirm({
+        message: `"${a.title}" を削除しますか？この操作は取り消せません。`,
+      })
+      if (!yes) {
+        logger.info("キャンセルしました")
+        process.exit(0)
+      }
+    } else if (!a.force && a["no-input"] && !a["dry-run"]) {
+      writeErrorJson("CONFIRMATION_REQUIRED", "--no-input モードでは --force (-y) フラグが必要です")
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" を削除中...`)
+
+    const writer = await buildWriter(a)
+    const result = await deletePage(writer, { project, title: a.title })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.delete", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" を削除しました`)
+  },
+})

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -10,6 +10,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildWriter,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -40,6 +41,7 @@ export const pageDeleteCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string; force: boolean; "no-input": boolean }
+    checkSandbox("page.delete", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -1,0 +1,68 @@
+/**
+ * page/edit.ts — `cos page edit <title>` コマンド。
+ *
+ * ページの内容を全置換する。
+ * --from-file でファイルから、- で stdin から新しい本文を読み込む。
+ * --dry-run で変更内容のプレビューのみ表示する。
+ */
+
+import { readFileSync } from "node:fs"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { editPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageEditCommand = defineCommand({
+  meta: { description: "ページ内容を全置換する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    "from-file": {
+      type: "string",
+      description: "新しい本文ファイルパス (- で stdin)",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; "from-file": string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    let content: string
+    if (a["from-file"] === "-") {
+      content = readFileSync("/dev/stdin", "utf-8")
+    } else {
+      content = readFileSync(a["from-file"], "utf-8")
+    }
+    const lines = content.split("\n").filter((_, i, arr) => i < arr.length - 1 || arr[i] !== "")
+
+    if (lines.length === 0) {
+      writeErrorJson("CONTENT_REQUIRED", "新しい本文が空です")
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" を編集中...`)
+
+    const writer = await buildWriter(a)
+    const result = await editPage(writer, { project, title: a.title, lines })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.edit", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" を更新しました`)
+  },
+})

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -12,6 +12,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildWriter,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -36,13 +37,14 @@ export const pageEditCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string; "from-file": string }
+    checkSandbox("page.edit", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
     let content: string
     if (a["from-file"] === "-") {
-      content = readFileSync("/dev/stdin", "utf-8")
+      content = readFileSync(0, "utf-8")
     } else {
       content = readFileSync(a["from-file"], "utf-8")
     }

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -9,6 +9,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -28,6 +29,7 @@ export const pageGetCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string }
+    checkSandbox("page.get", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -1,0 +1,50 @@
+/**
+ * page/get.ts — `cos page get <title>` コマンド。
+ *
+ * 指定したタイトルのページ詳細 (行データ、メタ情報) を取得して出力する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { getPage } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageGetCommand = defineCommand({
+  meta: { description: "ページ詳細を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" を取得中...`)
+
+    const client = await buildRestClient(a)
+    const page = await getPage(client, { project, title: a.title })
+
+    if (a.json || !a.plain) {
+      writeJson(page, { command: "page.get", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${page.title}\n`)
+    for (const line of page.lines) {
+      process.stdout.write(`${line.text}\n`)
+    }
+  },
+})

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -10,6 +10,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -37,6 +38,7 @@ export const pageListCommand = defineCommand({
   },
   async run({ args }) {
     const commonArgs = args as CommonArgs & { limit?: string; skip?: string; sort?: string }
+    checkSandbox("page.list", commonArgs)
     const logger = buildLogger(commonArgs)
     const project = requireProject(commonArgs)
     const startTime = Date.now()

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -1,0 +1,81 @@
+/**
+ * page/list.ts — `cos page list` コマンド。
+ *
+ * プロジェクトのページ一覧を取得して出力する。
+ * --json で envelope 形式、--plain で TSV 出力。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { listPages } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable, writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const pageListCommand = defineCommand({
+  meta: { description: "ページ一覧を取得する" },
+  args: {
+    ...commonArgs,
+    limit: {
+      type: "string",
+      description: "取得件数 (デフォルト: 30)",
+    },
+    skip: {
+      type: "string",
+      description: "スキップ件数",
+    },
+    sort: {
+      type: "string",
+      description: "ソート順 (updated/created/accessed/pageRank/links/views/title)",
+    },
+  },
+  async run({ args }) {
+    const commonArgs = args as CommonArgs & { limit?: string; skip?: string; sort?: string }
+    const logger = buildLogger(commonArgs)
+    const project = requireProject(commonArgs)
+    const startTime = Date.now()
+
+    logger.info(`${project} のページ一覧を取得中...`)
+
+    const client = await buildRestClient(commonArgs)
+    const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
+    if (commonArgs.limit) listOpts.limit = Number(commonArgs.limit)
+    if (commonArgs.skip) listOpts.skip = Number(commonArgs.skip)
+    if (commonArgs.sort) listOpts.sort = commonArgs.sort
+    const result = await listPages(client, listOpts)
+
+    if (commonArgs.json) {
+      writeJson(result, { command: "page.list", startTime }, buildJsonOpts(commonArgs))
+      return
+    }
+
+    if (commonArgs.plain) {
+      writeTsv(
+        ["title", "updated", "views", "linked"],
+        result.pages.map((p) => [
+          p.title,
+          new Date(p.updated * 1000).toISOString(),
+          String(p.views),
+          String(p.linked),
+        ]),
+      )
+      return
+    }
+
+    writePlainTable(
+      ["タイトル", "更新日時", "閲覧数", "被リンク"],
+      result.pages.map((p) => [
+        p.title,
+        new Date(p.updated * 1000).toLocaleString("ja-JP"),
+        String(p.views),
+        String(p.linked),
+      ]),
+    )
+  },
+})

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -11,6 +11,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildWriter,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -38,6 +39,7 @@ export const pageNewCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string; "from-file"?: string; line?: string }
+    checkSandbox("page.new", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
@@ -45,7 +47,7 @@ export const pageNewCommand = defineCommand({
     let lines: string[] = []
     if (a["from-file"] === "-") {
       // stdin から読み込む
-      const content = readFileSync("/dev/stdin", "utf-8")
+      const content = readFileSync(0, "utf-8")
       lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
     } else if (a["from-file"]) {
       const content = readFileSync(a["from-file"], "utf-8")

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -1,0 +1,78 @@
+/**
+ * page/new.ts — `cos page new <title>` コマンド。
+ *
+ * 新しいページを作成する。
+ * --from-file でファイルから、- で stdin から本文を読み込む。
+ */
+
+import { readFileSync } from "node:fs"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { createPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageNewCommand = defineCommand({
+  meta: { description: "新しいページを作成する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    "from-file": {
+      type: "string",
+      description: "本文ファイルパス (- で stdin)",
+    },
+    line: {
+      type: "string",
+      description: "追加する行テキスト",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; "from-file"?: string; line?: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    let lines: string[] = []
+    if (a["from-file"] === "-") {
+      // stdin から読み込む
+      const content = readFileSync("/dev/stdin", "utf-8")
+      lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
+    } else if (a["from-file"]) {
+      const content = readFileSync(a["from-file"], "utf-8")
+      lines = content.split("\n")
+    } else if (a.line) {
+      lines = [a.line]
+    }
+
+    if (lines.length === 0) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "ページ本文が指定されていません",
+        "--from-file または --line でコンテンツを指定してください",
+      )
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" を作成中...`)
+
+    const writer = await buildWriter(a)
+    const result = await createPage(writer, { project, title: a.title, lines })
+
+    if (a.json) {
+      writeJson(result, { command: "page.new", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" を作成しました`)
+  },
+})

--- a/src/commands/page/text.ts
+++ b/src/commands/page/text.ts
@@ -1,0 +1,48 @@
+/**
+ * page/text.ts — `cos page text <title>` コマンド。
+ *
+ * ページのプレーンテキスト本文を取得して stdout に出力する。
+ * パイプや他ツールとの連携に使う。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { getPageText } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageTextCommand = defineCommand({
+  meta: { description: "ページのテキスト本文を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" のテキストを取得中...`)
+
+    const client = await buildRestClient(a)
+    const text = await getPageText(client, { project, title: a.title })
+
+    if (a.json) {
+      writeJson({ text }, { command: "page.text", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${text}\n`)
+  },
+})

--- a/src/commands/page/text.ts
+++ b/src/commands/page/text.ts
@@ -10,6 +10,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -29,6 +30,7 @@ export const pageTextCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { title: string }
+    checkSandbox("page.text", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()

--- a/src/commands/page/url.ts
+++ b/src/commands/page/url.ts
@@ -9,6 +9,7 @@ import {
   type CommonArgs,
   buildJsonOpts,
   buildLogger,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -28,6 +29,7 @@ export const pageUrlCommand = defineCommand({
   },
   run({ args }) {
     const a = args as CommonArgs & { title: string }
+    checkSandbox("page.url", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()

--- a/src/commands/page/url.ts
+++ b/src/commands/page/url.ts
@@ -1,0 +1,46 @@
+/**
+ * page/url.ts — `cos page url <title>` コマンド。
+ *
+ * ページの URL をローカルで算出して stdout に出力する。
+ * API 呼び出しは行わない。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { buildPageUrl } from "@/core/api/encoder"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageUrlCommand = defineCommand({
+  meta: { description: "ページの URL を生成する (API 呼び出しなし)" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.verbose(`URL を生成: ${a.title}`)
+
+    const url = buildPageUrl(project, a.title)
+
+    if (a.json) {
+      writeJson({ url }, { command: "page.url", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${url}\n`)
+  },
+})

--- a/src/commands/project/info.ts
+++ b/src/commands/project/info.ts
@@ -10,6 +10,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -29,6 +30,7 @@ export const projectInfoCommand = defineCommand({
   },
   async run({ args }) {
     const a = args as CommonArgs & { name?: string }
+    checkSandbox("project.info", a)
     const logger = buildLogger(a)
     const project = a.name ?? requireProject(a)
     const startTime = Date.now()

--- a/src/commands/project/info.ts
+++ b/src/commands/project/info.ts
@@ -1,0 +1,56 @@
+/**
+ * project/info.ts — `cos project info [<name>]` コマンド。
+ *
+ * プロジェクトの詳細情報を取得して出力する。
+ * プロジェクト名省略時は --project フラグのプロジェクトを使う。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const projectInfoCommand = defineCommand({
+  meta: { description: "プロジェクト詳細情報を取得する" },
+  args: {
+    ...commonArgs,
+    name: {
+      type: "positional",
+      description: "プロジェクト名 (省略時は --project フラグを使用)",
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { name?: string }
+    const logger = buildLogger(a)
+    const project = a.name ?? requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`プロジェクト "${project}" の情報を取得中...`)
+
+    const client = await buildRestClient(a)
+    const info = await client.getProject(project)
+
+    if (a.json || !a.plain) {
+      writeJson(info, { command: "project.info", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    writePlainTable(
+      ["フィールド", "値"],
+      [
+        ["名前", info.name],
+        ["表示名", info.displayName],
+        ["公開", String(info.publicVisible)],
+        ["メンバー", String(info.isMember)],
+      ],
+    )
+  },
+})

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -9,6 +9,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
 } from "@/commands/_shared"
 import { writeJson } from "@/presenter/json"
@@ -20,6 +21,7 @@ export const projectListCommand = defineCommand({
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs
+    checkSandbox("project.list", a)
     const logger = buildLogger(a)
     const startTime = Date.now()
 

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -1,0 +1,49 @@
+/**
+ * project/list.ts — `cos project list` コマンド。
+ *
+ * 参加中のプロジェクト一覧を取得して出力する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+} from "@/commands/_shared"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable, writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const projectListCommand = defineCommand({
+  meta: { description: "参加中のプロジェクト一覧を取得する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+
+    logger.info("プロジェクト一覧を取得中...")
+
+    const client = await buildRestClient(a)
+    const result = await client.listProjects()
+
+    if (a.json) {
+      writeJson(result, { command: "project.list", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    if (a.plain) {
+      writeTsv(
+        ["name", "displayName", "publicVisible"],
+        result.projects.map((p) => [p.name, p.displayName, String(p.publicVisible)]),
+      )
+      return
+    }
+
+    writePlainTable(
+      ["名前", "表示名", "公開"],
+      result.projects.map((p) => [p.name, p.displayName, p.publicVisible ? "✓" : "✗"]),
+    )
+  },
+})

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,74 @@
+/**
+ * search.ts — `cos search <query>` コマンド。
+ *
+ * プロジェクト内のページをキーワード検索する。
+ * --titles-only で高速なタイトル検索モードに切り替える。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { writeJson } from "@/presenter/json"
+import { writePlainList, writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const searchCommand = defineCommand({
+  meta: { description: "ページをキーワード検索する" },
+  args: {
+    ...commonArgs,
+    query: {
+      type: "positional",
+      description: "検索キーワード",
+      required: true,
+    },
+    limit: {
+      type: "string",
+      description: "最大件数",
+    },
+    "titles-only": {
+      type: "boolean",
+      description: "タイトルのみ検索 (高速)",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { query: string; limit?: string; "titles-only": boolean }
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.query}" を検索中...`)
+
+    const client = await buildRestClient(a)
+    const searchOpts: { limit?: number } = {}
+    if (a.limit) searchOpts.limit = Number(a.limit)
+    const result = await client.searchPages(project, a.query, searchOpts)
+
+    if (a.json) {
+      writeJson(result, { command: "search", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    if (a.plain) {
+      if (a["titles-only"]) {
+        writeTsv(
+          ["title"],
+          result.pages.map((p) => [p.title]),
+        )
+      } else {
+        writeTsv(
+          ["title"],
+          result.pages.map((p) => [p.title]),
+        )
+      }
+      return
+    }
+
+    writePlainList(result.pages.map((p) => p.title))
+  },
+})

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,7 +2,6 @@
  * search.ts — `cos search <query>` コマンド。
  *
  * プロジェクト内のページをキーワード検索する。
- * --titles-only で高速なタイトル検索モードに切り替える。
  */
 
 import {
@@ -10,6 +9,7 @@ import {
   buildJsonOpts,
   buildLogger,
   buildRestClient,
+  checkSandbox,
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
@@ -30,14 +30,10 @@ export const searchCommand = defineCommand({
       type: "string",
       description: "最大件数",
     },
-    "titles-only": {
-      type: "boolean",
-      description: "タイトルのみ検索 (高速)",
-      default: false,
-    },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { query: string; limit?: string; "titles-only": boolean }
+    const a = args as CommonArgs & { query: string; limit?: string }
+    checkSandbox("search", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
@@ -55,17 +51,10 @@ export const searchCommand = defineCommand({
     }
 
     if (a.plain) {
-      if (a["titles-only"]) {
-        writeTsv(
-          ["title"],
-          result.pages.map((p) => [p.title]),
-        )
-      } else {
-        writeTsv(
-          ["title"],
-          result.pages.map((p) => [p.title]),
-        )
-      }
+      writeTsv(
+        ["title"],
+        result.pages.map((p) => [p.title]),
+      )
       return
     }
 

--- a/src/core/api/encoder.ts
+++ b/src/core/api/encoder.ts
@@ -1,0 +1,27 @@
+/**
+ * encoder.ts — Cosense ページタイトルの URL スラッグ変換ユーティリティ。
+ *
+ * Cosense の URL 規則: 半角スペースを `_` に置換した後 encodeURIComponent する。
+ * パーセントエンコードした `_` (%5F) とリテラルの `_` は区別されないため、
+ * アンダースコアそのものは RFC 3986 の unreserved 文字としてそのまま使う。
+ */
+
+const BASE_URL = "https://scrapbox.io"
+
+/** encodePageTitle はページタイトルを Cosense URL スラッグ形式に変換する。 */
+export function encodePageTitle(title: string): string {
+  // 半角スペースのみアンダースコアに置換し、その後 encodeURIComponent する
+  return encodeURIComponent(title.replaceAll(" ", "_")).replaceAll("%5F", "_")
+}
+
+/** decodePageTitle は Cosense URL スラッグをページタイトルに戻す。 */
+export function decodePageTitle(slug: string): string {
+  return decodeURIComponent(slug.replaceAll("_", " "))
+}
+
+/** buildPageUrl はプロジェクト名とタイトルから Cosense ページ URL を生成する。 */
+export function buildPageUrl(project: string, title: string): string {
+  if (!project) throw new Error("プロジェクト名を指定してください")
+  if (!title) throw new Error("タイトルを指定してください")
+  return `${BASE_URL}/${encodeURIComponent(project)}/${encodePageTitle(title)}`
+}

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -1,0 +1,196 @@
+/**
+ * rest.ts — Cosense REST API の薄いクライアント実装。
+ *
+ * connect.sid Cookie を付与して各エンドポイントを叩き、
+ * zod スキーマで検証して型安全なレスポンスを返す。
+ */
+
+import { encodePageTitle } from "@/core/api/encoder"
+import { PageListResponseSchema, PageSchema, SearchResultSchema } from "@/schemas/page"
+import type { Page, PageListResponse, SearchResult } from "@/schemas/page"
+import { ProjectListResponseSchema, ProjectSchema } from "@/schemas/project"
+import type { Project, ProjectListResponse } from "@/schemas/project"
+import { type Me, MeSchema } from "@/schemas/user"
+
+const BASE_URL = "https://scrapbox.io"
+
+/** CosenseApiError は API エラーの基底クラス。 */
+export class CosenseApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = "CosenseApiError"
+  }
+}
+
+/** AuthError は 401 認証エラー。 */
+export class AuthError extends CosenseApiError {
+  constructor() {
+    super(401, "認証が必要です。`cos auth login` を実行してください。")
+    this.name = "AuthError"
+  }
+}
+
+/** ForbiddenError は 403 権限エラー。 */
+export class ForbiddenError extends CosenseApiError {
+  constructor() {
+    super(403, "このリソースへのアクセス権限がありません。")
+    this.name = "ForbiddenError"
+  }
+}
+
+/** NotFoundError は 404 エラー。 */
+export class NotFoundError extends CosenseApiError {
+  constructor(resource: string) {
+    super(404, `見つかりません: ${resource}`)
+    this.name = "NotFoundError"
+  }
+}
+
+/** RateLimitError は 429 レート制限エラー。 */
+export class RateLimitError extends CosenseApiError {
+  constructor() {
+    super(429, "レート制限に達しました。しばらく待ってから再試行してください。")
+    this.name = "RateLimitError"
+  }
+}
+
+/** CosenseRestClientOptions は REST クライアントの設定オプション。 */
+export interface CosenseRestClientOptions {
+  /** connect.sid 値 (URLエンコード済みまたは生の値) */
+  sid: string
+  /** リクエストタイムアウト (ミリ秒、デフォルト 30000) */
+  timeout?: number
+}
+
+/** CosenseRestClient は Cosense REST API を叩くクライアント。 */
+export class CosenseRestClient {
+  private readonly sid: string
+  private readonly timeout: number
+
+  constructor(opts: CosenseRestClientOptions) {
+    this.sid = opts.sid
+    this.timeout = opts.timeout ?? 30_000
+  }
+
+  /** getMe は /api/users/me を叩いてユーザー情報を返す。 */
+  async getMe(): Promise<Me> {
+    const data = await this.fetchJson(`${BASE_URL}/api/users/me`)
+    return MeSchema.parse(data)
+  }
+
+  /** listPages は /api/pages/:project を叩いてページ一覧を返す。 */
+  async listPages(
+    project: string,
+    opts: { skip?: number; limit?: number; sort?: string } = {},
+  ): Promise<PageListResponse> {
+    const params = new URLSearchParams()
+    if (opts.skip !== undefined) params.set("skip", String(opts.skip))
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit))
+    if (opts.sort) params.set("sort", opts.sort)
+    const query = params.size > 0 ? `?${params.toString()}` : ""
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}${query}`,
+    )
+    return PageListResponseSchema.parse(data)
+  }
+
+  /** getPage は /api/pages/:project/:title を叩いてページ詳細を返す。 */
+  async getPage(project: string, title: string): Promise<Page> {
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/${encodePageTitle(title)}`,
+    )
+    return PageSchema.parse(data)
+  }
+
+  /** getPageText は /api/pages/:project/:title/text を叩いてプレーンテキストを返す。 */
+  async getPageText(project: string, title: string): Promise<string> {
+    return this.fetchText(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/${encodePageTitle(title)}/text`,
+    )
+  }
+
+  /** getCodeBlock は /api/code/:project/:title/:filename を叩いてコードブロックを返す。 */
+  async getCodeBlock(project: string, title: string, filename: string): Promise<string> {
+    return this.fetchText(
+      `${BASE_URL}/api/code/${encodeURIComponent(project)}/${encodePageTitle(title)}/${encodeURIComponent(filename)}`,
+    )
+  }
+
+  /** searchPages は /api/pages/:project/search/query を叩いて全文検索する。 */
+  async searchPages(
+    project: string,
+    query: string,
+    opts: { limit?: number } = {},
+  ): Promise<SearchResult> {
+    const params = new URLSearchParams({ q: query })
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit))
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/query?${params.toString()}`,
+    )
+    return SearchResultSchema.parse(data)
+  }
+
+  /** getProject は /api/projects/:project を叩いてプロジェクト情報を返す。 */
+  async getProject(project: string): Promise<Project> {
+    const data = await this.fetchJson(`${BASE_URL}/api/projects/${encodeURIComponent(project)}`)
+    return ProjectSchema.parse(data)
+  }
+
+  /** listProjects は /api/projects を叩いて参加プロジェクト一覧を返す。 */
+  async listProjects(): Promise<ProjectListResponse> {
+    const data = await this.fetchJson(`${BASE_URL}/api/projects`)
+    return ProjectListResponseSchema.parse(data)
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    }
+    if (this.sid) {
+      headers["Cookie"] = `connect.sid=${this.sid}`
+    }
+    return headers
+  }
+
+  private async fetchJson(url: string): Promise<unknown> {
+    const response = await this.doFetch(url)
+    return response.json()
+  }
+
+  private async fetchText(url: string): Promise<string> {
+    const response = await this.doFetch(url)
+    return response.text()
+  }
+
+  private async doFetch(url: string): Promise<Response> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeout)
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        headers: this.buildHeaders(),
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (!response.ok) {
+      await this.handleError(response, url)
+    }
+
+    return response
+  }
+
+  private async handleError(response: Response, url: string): Promise<never> {
+    if (response.status === 401) throw new AuthError()
+    if (response.status === 403) throw new ForbiddenError()
+    if (response.status === 404) throw new NotFoundError(url)
+    if (response.status === 429) throw new RateLimitError()
+    throw new CosenseApiError(response.status, `API エラー: ${response.status} ${url}`)
+  }
+}

--- a/src/core/api/ws.ts
+++ b/src/core/api/ws.ts
@@ -1,0 +1,190 @@
+/**
+ * ws.ts — Cosense WebSocket 書き込みの薄いラッパー。
+ *
+ * @cosense/std の patch()/deletePage() を ScrapboxWriter interface でラップし、
+ * --dry-run 対応と依存性注入 (テスト容易化) を提供する。
+ *
+ * 実際の WebSocket 接続は @cosense/std/websocket に委譲するため、
+ * このファイルでは Socket.IO の詳細を扱わない。
+ */
+
+import type { Line } from "@/schemas/page"
+
+/** ScrapboxWriterStdClient は @cosense/std の API 関数群の interface。 */
+export interface ScrapboxWriterStdClient {
+  patch(
+    project: string,
+    title: string,
+    update: (lines: Line[]) => Promise<string[]>,
+    options?: { sid?: string; maxRetry?: number },
+  ): Promise<{ commitId: string; pageId: string } | unknown>
+}
+
+/** DryRunResult は --dry-run 時に実際のコミットをしないで返す結果型。 */
+export interface DryRunResult {
+  dryRun: true
+  project: string
+  title: string
+  previewLines?: string[]
+}
+
+/** PatchOptions は patch() に渡すオプション。 */
+export interface PatchOptions {
+  project: string
+  title: string
+  update: (lines: Line[]) => string[] | Promise<string[]>
+  maxRetry?: number
+}
+
+/** InsertLinesOptions は insertLines() に渡すオプション。 */
+export interface InsertLinesOptions {
+  project: string
+  title: string
+  lines: string[]
+  afterLineId?: string
+}
+
+/** DeletePageOptions は deletePage() に渡すオプション。 */
+export interface DeletePageOptions {
+  project: string
+  title: string
+}
+
+/** ScrapboxWriter は Cosense への書き込み操作を抽象化する interface。 */
+export interface ScrapboxWriter {
+  patch(opts: PatchOptions): Promise<{ commitId: string; pageId: string } | DryRunResult>
+
+  insertLines(opts: InsertLinesOptions): Promise<{ commitId: string } | DryRunResult>
+
+  deletePage(opts: DeletePageOptions): Promise<{ title: string } | DryRunResult>
+}
+
+/** CosenseWriterOptions は CosenseWriter のオプション。 */
+export interface CosenseWriterOptions {
+  dryRun?: boolean
+  sid?: string
+  maxRetry?: number
+}
+
+/**
+ * CosenseWriter は @cosense/std を使った ScrapboxWriter の本番実装。
+ *
+ * コンストラクタで stdClient を受け取ることで、テスト時にモックを注入できる。
+ */
+export class CosenseWriter implements ScrapboxWriter {
+  constructor(
+    private readonly stdClient: ScrapboxWriterStdClient,
+    private readonly opts: CosenseWriterOptions = {},
+  ) {}
+
+  async patch(
+    patchOpts: PatchOptions,
+  ): Promise<{ commitId: string; pageId: string } | DryRunResult> {
+    if (this.opts.dryRun) {
+      return {
+        dryRun: true,
+        project: patchOpts.project,
+        title: patchOpts.title,
+      }
+    }
+
+    const patchOptions: { sid?: string; maxRetry?: number } = {}
+    if (this.opts.sid !== undefined) patchOptions.sid = this.opts.sid
+    const maxRetry = patchOpts.maxRetry ?? this.opts.maxRetry
+    if (maxRetry !== undefined) patchOptions.maxRetry = maxRetry
+
+    const result = await this.stdClient.patch(
+      patchOpts.project,
+      patchOpts.title,
+      async (lines: Line[]) => {
+        const updated = await patchOpts.update(lines)
+        return updated
+      },
+      patchOptions,
+    )
+
+    // @cosense/std の Result 型から値を取り出す
+    return result as { commitId: string; pageId: string }
+  }
+
+  async insertLines(opts: InsertLinesOptions): Promise<{ commitId: string } | DryRunResult> {
+    if (this.opts.dryRun) {
+      return { dryRun: true, project: opts.project, title: opts.title }
+    }
+
+    // insertLines は patch の特殊ケース: 現在の末尾に行を追加する
+    return this.patch({
+      project: opts.project,
+      title: opts.title,
+      update: (lines: Line[]) => [...lines.map((l) => l.text), ...opts.lines],
+    }) as Promise<{ commitId: string }>
+  }
+
+  async deletePage(opts: DeletePageOptions): Promise<{ title: string } | DryRunResult> {
+    if (this.opts.dryRun) {
+      return { dryRun: true, project: opts.project, title: opts.title }
+    }
+
+    // delete は update で空配列を返すことで実現する
+    await this.patch({
+      project: opts.project,
+      title: opts.title,
+      update: () => [],
+    })
+    return { title: opts.title }
+  }
+}
+
+/**
+ * DryRunWriter は常に dryRun: true を返す ScrapboxWriter の実装。
+ *
+ * --dry-run フラグが指定された時に使う。
+ * 実際の WebSocket 接続を一切行わない。
+ */
+export class DryRunWriter implements ScrapboxWriter {
+  async patch(opts: PatchOptions): Promise<DryRunResult> {
+    return { dryRun: true, project: opts.project, title: opts.title }
+  }
+
+  async insertLines(opts: InsertLinesOptions): Promise<DryRunResult> {
+    return { dryRun: true, project: opts.project, title: opts.title }
+  }
+
+  async deletePage(opts: DeletePageOptions): Promise<DryRunResult> {
+    return { dryRun: true, project: opts.project, title: opts.title }
+  }
+}
+
+/**
+ * createScrapboxWriter は設定に応じた ScrapboxWriter を返すファクトリ。
+ *
+ * --dry-run フラグが指定された場合は DryRunWriter を返す。
+ * そうでない場合は @cosense/std の patch 等を使った CosenseWriter を返す。
+ */
+export async function createScrapboxWriter(opts: {
+  dryRun?: boolean
+  sid: string
+  maxRetry?: number
+}): Promise<ScrapboxWriter> {
+  if (opts.dryRun) return new DryRunWriter()
+
+  // @cosense/std は動的 import で読み込み (バイナリサイズ最適化)
+  const { patch } = await import("@cosense/std/websocket")
+
+  const stdClient: ScrapboxWriterStdClient = {
+    patch: (project, title, update, options) =>
+      patch(
+        project,
+        title,
+        update as Parameters<typeof patch>[2],
+        {
+          sid: options?.sid,
+          retry: options?.maxRetry,
+        } as Parameters<typeof patch>[3],
+      ),
+  }
+
+  const writerOpts: CosenseWriterOptions = { sid: opts.sid }
+  if (opts.maxRetry !== undefined) writerOpts.maxRetry = opts.maxRetry
+  return new CosenseWriter(stdClient, writerOpts)
+}

--- a/src/core/auth/session.ts
+++ b/src/core/auth/session.ts
@@ -1,0 +1,35 @@
+/**
+ * session.ts — connect.sid セッションの取得・保存ユースケース。
+ *
+ * TokenStore を通じてプロファイル別に connect.sid を管理する。
+ * プロファイル未指定時は "default" を使用する。
+ */
+
+import type { TokenStore } from "@/core/auth/store"
+
+const DEFAULT_PROFILE = "default"
+
+/** saveSession は connect.sid を TokenStore に保存する。 */
+export async function saveSession(
+  store: TokenStore,
+  opts: { profile?: string; sid: string },
+): Promise<void> {
+  const profile = opts.profile ?? DEFAULT_PROFILE
+  await store.save(profile, opts.sid)
+}
+
+/** loadSession は TokenStore から connect.sid を取得する。 */
+export async function loadSession(
+  store: TokenStore,
+  opts: { profile?: string },
+): Promise<string | undefined> {
+  const profile = opts.profile ?? DEFAULT_PROFILE
+  const token = await store.load(profile)
+  return token ?? undefined
+}
+
+/** deleteSession は TokenStore から connect.sid を削除する。 */
+export async function deleteSession(store: TokenStore, opts: { profile?: string }): Promise<void> {
+  const profile = opts.profile ?? DEFAULT_PROFILE
+  await store.delete(profile)
+}

--- a/src/core/auth/store.ts
+++ b/src/core/auth/store.ts
@@ -1,0 +1,39 @@
+/**
+ * store.ts — セッション ID の永続化抽象層。
+ *
+ * TokenStore interface を実装することで、OS keychain / ファイル / インメモリ
+ * など異なるバックエンドに切り替え可能にする。
+ */
+
+/** TokenStore はセッション ID の CRUD 操作を抽象化する interface。 */
+export interface TokenStore {
+  /** save はプロファイル名に紐づいてセッション ID を保存する。 */
+  save(profile: string, sid: string): Promise<void>
+  /** load はプロファイル名に紐づいたセッション ID を返す。見つからない場合は null。 */
+  load(profile: string): Promise<string | null>
+  /** delete はプロファイルのセッション ID を削除する。 */
+  delete(profile: string): Promise<void>
+  /** list は保存済みプロファイル名の一覧を返す。 */
+  list(): Promise<string[]>
+}
+
+/** InMemoryTokenStore はテスト用のインメモリ実装。 */
+export class InMemoryTokenStore implements TokenStore {
+  private readonly store = new Map<string, string>()
+
+  async save(profile: string, sid: string): Promise<void> {
+    this.store.set(profile, sid)
+  }
+
+  async load(profile: string): Promise<string | null> {
+    return this.store.get(profile) ?? null
+  }
+
+  async delete(profile: string): Promise<void> {
+    this.store.delete(profile)
+  }
+
+  async list(): Promise<string[]> {
+    return [...this.store.keys()]
+  }
+}

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -1,0 +1,80 @@
+/**
+ * pages.ts — ページ操作のユースケース層。
+ *
+ * REST 読み取りと WebSocket 書き込みを統合し、
+ * コマンド実装から直接呼び出せるシンプルな関数を提供する。
+ */
+
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+
+/** listPages はプロジェクトのページ一覧を取得する。 */
+export async function listPages(
+  client: CosenseRestClient,
+  opts: { project: string; limit?: number; skip?: number; sort?: string },
+) {
+  const { project, ...restOpts } = opts
+  return client.listPages(project, restOpts)
+}
+
+/** getPage は指定タイトルのページ詳細を取得する。 */
+export async function getPage(client: CosenseRestClient, opts: { project: string; title: string }) {
+  return client.getPage(opts.project, opts.title)
+}
+
+/** getPageText はページのテキスト本文を取得する。 */
+export async function getPageText(
+  client: CosenseRestClient,
+  opts: { project: string; title: string },
+) {
+  return client.getPageText(opts.project, opts.title)
+}
+
+/** getCodeBlock はページ内のコードブロックを取得する。 */
+export async function getCodeBlock(
+  client: CosenseRestClient,
+  opts: { project: string; title: string; filename: string },
+) {
+  return client.getCodeBlock(opts.project, opts.title, opts.filename)
+}
+
+/** createPage は新規ページを作成する (WebSocket commit)。 */
+export async function createPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; lines: string[] },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: () => [opts.title, ...opts.lines],
+  })
+}
+
+/** appendToPage はページ末尾に行を追加する (WebSocket commit)。 */
+export async function appendToPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; lines: string[] },
+) {
+  return writer.insertLines({
+    project: opts.project,
+    title: opts.title,
+    lines: opts.lines,
+  })
+}
+
+/** editPage はページの内容を全置換する (WebSocket commit)。 */
+export async function editPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; lines: string[] },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: () => [opts.title, ...opts.lines],
+  })
+}
+
+/** deletePage はページを削除する (WebSocket commit)。 */
+export async function deletePage(writer: ScrapboxWriter, opts: { project: string; title: string }) {
+  return writer.deletePage({ project: opts.project, title: opts.title })
+}

--- a/src/core/sandbox.ts
+++ b/src/core/sandbox.ts
@@ -1,0 +1,88 @@
+/**
+ * sandbox.ts — コマンド実行許可ポリシー。
+ *
+ * --enable-commands / --disable-commands によって、
+ * AI エージェントが実行できるコマンドを制限する。
+ *
+ * ルール:
+ *   1. enable リストが指定された場合、そのリストのみ許可 (ワイルドカード "page" で "page.*" 全体)
+ *   2. disable リストが指定された場合、そのエントリを拒否
+ *   3. 両方指定時: enable で絞ってから disable で削る
+ */
+
+/** PolicyError は sandbox ポリシー違反を表すエラー。 */
+export class PolicyError extends Error {
+  constructor(public readonly command: string) {
+    super(`[denied] ${command} is disabled by policy`)
+    this.name = "PolicyError"
+  }
+}
+
+/** PolicyOptions は createPolicy に渡す設定オプション。 */
+export interface PolicyOptions {
+  /** 許可するコマンドのリスト (例: ["page.list", "page.get"] または ["page"]) */
+  enable?: string[]
+  /** 拒否するコマンドのリスト */
+  disable?: string[]
+  /** カンマ区切り文字列での enable 指定 (CLI フラグ用) */
+  enableStr?: string
+  /** カンマ区切り文字列での disable 指定 (CLI フラグ用) */
+  disableStr?: string
+}
+
+/** Policy は allow メソッドでコマンドの実行可否を判定する。 */
+export interface Policy {
+  /**
+   * allow はコマンドが許可されているか判定する。
+   * 許可の場合は undefined を返し、拒否の場合は PolicyError を返す。
+   */
+  allow(command: string): PolicyError | undefined
+}
+
+/**
+ * createPolicy は PolicyOptions からポリシーインスタンスを生成する。
+ * enable/disable が未指定の場合は全コマンドを許可する。
+ */
+export function createPolicy(opts: PolicyOptions): Policy {
+  const enable = mergeList(opts.enable, opts.enableStr)
+  const disable = mergeList(opts.disable, opts.disableStr)
+
+  return {
+    allow(command: string): PolicyError | undefined {
+      // enable リストが空でなければ、許可リストでフィルタ
+      if (enable.length > 0 && !isAllowed(command, enable)) {
+        return new PolicyError(command)
+      }
+      // disable リストに含まれていれば拒否
+      if (disable.length > 0 && isAllowed(command, disable)) {
+        return new PolicyError(command)
+      }
+      return undefined
+    },
+  }
+}
+
+/** mergeList は配列とカンマ区切り文字列をマージして正規化する。 */
+function mergeList(list: string[] | undefined, str: string | undefined): string[] {
+  const fromList = list ?? []
+  const fromStr = str
+    ? str
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : []
+  return [...fromList, ...fromStr]
+}
+
+/**
+ * isAllowed はコマンドがパターンリストにマッチするか判定する。
+ * パターンが "page" のように noun のみの場合、"page.*" 全体にマッチする。
+ */
+function isAllowed(command: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    if (pattern === command) return true
+    // "page" は "page.list", "page.delete" 等にマッチ
+    if (!pattern.includes(".") && command.startsWith(`${pattern}.`)) return true
+    return false
+  })
+}

--- a/src/infra/color.ts
+++ b/src/infra/color.ts
@@ -1,0 +1,40 @@
+/**
+ * color.ts — picocolors ラッパー。
+ *
+ * --color=auto|always|never フラグと TTY 検出に基づき、
+ * 色付け関数を提供する。
+ */
+
+import pc from "picocolors"
+
+export type ColorMode = "auto" | "always" | "never"
+
+let _enabled: boolean | null = null
+
+/**
+ * initColor は色付けを初期化する。
+ * 呼び出し前はデフォルト (auto: TTY 検出) が使われる。
+ */
+export function initColor(mode: ColorMode): void {
+  if (mode === "always") _enabled = true
+  else if (mode === "never") _enabled = false
+  else _enabled = process.stdout.isTTY // auto
+}
+
+/** isColorEnabled は現在の色付け設定を返す。 */
+export function isColorEnabled(): boolean {
+  if (_enabled !== null) return _enabled
+  return process.stdout.isTTY ?? false
+}
+
+/** color は色付け関数のラッパーオブジェクト。 */
+export const color = {
+  bold: (s: string) => (isColorEnabled() ? pc.bold(s) : s),
+  dim: (s: string) => (isColorEnabled() ? pc.dim(s) : s),
+  red: (s: string) => (isColorEnabled() ? pc.red(s) : s),
+  green: (s: string) => (isColorEnabled() ? pc.green(s) : s),
+  yellow: (s: string) => (isColorEnabled() ? pc.yellow(s) : s),
+  blue: (s: string) => (isColorEnabled() ? pc.blue(s) : s),
+  cyan: (s: string) => (isColorEnabled() ? pc.cyan(s) : s),
+  gray: (s: string) => (isColorEnabled() ? pc.gray(s) : s),
+}

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -1,0 +1,98 @@
+/**
+ * config.ts — ~/.config/coscli/config.json5 の読み書き。
+ *
+ * JSON5 形式なのでコメントや末尾カンマが使える。
+ * 設定ファイルにはシークレット (connect.sid) を含めない。
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import JSON5 from "json5"
+import { z } from "zod"
+
+/** ProjectConfig はプロジェクト固有の設定。 */
+const ProjectConfigSchema = z.object({
+  defaultSort: z.string().optional(),
+  defaultLimit: z.number().optional(),
+})
+
+/** AgentConfig は AI エージェント向けの設定。 */
+const AgentConfigSchema = z.object({
+  defaultDisableCommands: z.array(z.string()).optional(),
+  maxChangesPerCommit: z.number().optional(),
+})
+
+/** CoscliConfig は設定ファイル全体のスキーマ。 */
+export const CoscliConfigSchema = z.object({
+  defaultProject: z.string().optional(),
+  defaultProfile: z.string().optional(),
+  projects: z.record(z.string(), ProjectConfigSchema).optional(),
+  agent: AgentConfigSchema.optional(),
+  output: z
+    .object({
+      color: z.enum(["auto", "always", "never"]).optional(),
+      json: z.boolean().optional(),
+      plain: z.boolean().optional(),
+    })
+    .optional(),
+})
+export type CoscliConfig = z.infer<typeof CoscliConfigSchema>
+
+/** defaultConfigPath は OS 規約に従ったデフォルト設定ファイルパスを返す。 */
+export function defaultConfigPath(): string {
+  const xdgConfig = process.env["XDG_CONFIG_HOME"]
+  const base = xdgConfig ?? join(process.env["HOME"] ?? "~", ".config")
+  return join(base, "coscli", "config.json5")
+}
+
+/** loadConfig は設定ファイルを読み込んで検証した Config を返す。 */
+export function loadConfig(filePath: string = defaultConfigPath()): CoscliConfig {
+  if (!existsSync(filePath)) return {}
+  try {
+    const raw = readFileSync(filePath, "utf-8")
+    const parsed = JSON5.parse(raw) as unknown
+    return CoscliConfigSchema.parse(parsed)
+  } catch (err) {
+    throw new Error(
+      `設定ファイルの読み込みに失敗しました: ${filePath}\n${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
+
+/** saveConfig は Config を JSON5 ファイルに保存する。 */
+export function saveConfig(config: CoscliConfig, filePath: string = defaultConfigPath()): void {
+  const dir = dirname(filePath)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  // JSON5 形式のヘッダコメントを付与
+  const header = "// coscli 設定ファイル (JSON5形式 — コメント・末尾カンマ可)\n"
+  writeFileSync(filePath, header + JSON.stringify(config, null, 2))
+}
+
+/** getConfigValue は設定のネストしたキーを . 区切りで取得する。 */
+export function getConfigValue(config: CoscliConfig, key: string): unknown {
+  const parts = key.split(".")
+  let current: unknown = config
+  for (const part of parts) {
+    if (current === null || typeof current !== "object") return undefined
+    current = (current as Record<string, unknown>)[part]
+  }
+  return current
+}
+
+/** setConfigValue は設定のネストしたキーを . 区切りで設定する。 */
+export function setConfigValue(config: CoscliConfig, key: string, value: unknown): CoscliConfig {
+  const parts = key.split(".")
+  const updated = structuredClone(config) as Record<string, unknown>
+  let current = updated
+  for (const part of parts.slice(0, -1)) {
+    if (typeof current[part] !== "object" || current[part] === null) {
+      current[part] = {}
+    }
+    current = current[part] as Record<string, unknown>
+  }
+  const lastKey = parts.at(-1)
+  if (lastKey !== undefined) {
+    current[lastKey] = value
+  }
+  return CoscliConfigSchema.parse(updated)
+}

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -6,6 +6,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import JSON5 from "json5"
 import { z } from "zod"
@@ -41,7 +42,7 @@ export type CoscliConfig = z.infer<typeof CoscliConfigSchema>
 /** defaultConfigPath は OS 規約に従ったデフォルト設定ファイルパスを返す。 */
 export function defaultConfigPath(): string {
   const xdgConfig = process.env["XDG_CONFIG_HOME"]
-  const base = xdgConfig ?? join(process.env["HOME"] ?? "~", ".config")
+  const base = xdgConfig ?? join(homedir(), ".config")
   return join(base, "coscli", "config.json5")
 }
 

--- a/src/infra/keychain/file.ts
+++ b/src/infra/keychain/file.ts
@@ -1,0 +1,59 @@
+/**
+ * file.ts — ファイルベースの TokenStore フォールバック実装。
+ *
+ * OS の keychain が利用できない環境向けに、
+ * ~/.config/coscli/secrets.json にセッション ID を保存する。
+ * このストアは平文保存なので --insecure-file-store フラグを明示した場合のみ使用する。
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import type { TokenStore } from "@/core/auth/store"
+
+/** FileTokenStore はファイルに平文で connect.sid を保存する (フォールバック用)。 */
+export class FileTokenStore implements TokenStore {
+  constructor(private readonly filePath: string = defaultSecretsPath()) {}
+
+  async save(profile: string, sid: string): Promise<void> {
+    const data = this.read()
+    data[profile] = sid
+    this.write(data)
+  }
+
+  async load(profile: string): Promise<string | null> {
+    const data = this.read()
+    return data[profile] ?? null
+  }
+
+  async delete(profile: string): Promise<void> {
+    const data = this.read()
+    delete data[profile]
+    this.write(data)
+  }
+
+  async list(): Promise<string[]> {
+    return Object.keys(this.read())
+  }
+
+  private read(): Record<string, string> {
+    if (!existsSync(this.filePath)) return {}
+    try {
+      return JSON.parse(readFileSync(this.filePath, "utf-8")) as Record<string, string>
+    } catch {
+      return {}
+    }
+  }
+
+  private write(data: Record<string, string>): void {
+    const dir = dirname(this.filePath)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    writeFileSync(this.filePath, JSON.stringify(data, null, 2), { mode: 0o600 })
+  }
+}
+
+/** defaultSecretsPath は OS の規約に従ったデフォルト保存パスを返す。 */
+function defaultSecretsPath(): string {
+  const xdgConfig = process.env["XDG_CONFIG_HOME"]
+  const base = xdgConfig ?? join(process.env["HOME"] ?? "~", ".config")
+  return join(base, "coscli", "secrets.json")
+}

--- a/src/infra/keychain/file.ts
+++ b/src/infra/keychain/file.ts
@@ -7,6 +7,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { TokenStore } from "@/core/auth/store"
 
@@ -54,6 +55,6 @@ export class FileTokenStore implements TokenStore {
 /** defaultSecretsPath は OS の規約に従ったデフォルト保存パスを返す。 */
 function defaultSecretsPath(): string {
   const xdgConfig = process.env["XDG_CONFIG_HOME"]
-  const base = xdgConfig ?? join(process.env["HOME"] ?? "~", ".config")
+  const base = xdgConfig ?? join(homedir(), ".config")
   return join(base, "coscli", "secrets.json")
 }

--- a/src/infra/keychain/index.ts
+++ b/src/infra/keychain/index.ts
@@ -1,0 +1,28 @@
+/**
+ * index.ts — OS に応じた TokenStore 実装を返すファクトリ。
+ *
+ * OS を判定して macOS / Linux / Windows の keychain 実装を返す。
+ * 各 keychain が利用できない場合はファイルフォールバックに移行する。
+ */
+
+import type { TokenStore } from "@/core/auth/store"
+import { FileTokenStore } from "./file"
+import { LinuxKeychainStore } from "./linux"
+import { MacOSKeychainStore } from "./macos"
+import { WindowsKeychainStore } from "./windows"
+
+export type { TokenStore }
+export { FileTokenStore, LinuxKeychainStore, MacOSKeychainStore, WindowsKeychainStore }
+
+/** createTokenStore は現在の OS に最適な TokenStore インスタンスを返す。 */
+export function createTokenStore(opts: { insecureFileStore?: boolean } = {}): TokenStore {
+  if (opts.insecureFileStore) return new FileTokenStore()
+
+  const platform = process.platform
+  if (platform === "darwin") return new MacOSKeychainStore()
+  if (platform === "linux") return new LinuxKeychainStore()
+  if (platform === "win32") return new WindowsKeychainStore()
+
+  // 未知の OS はファイルフォールバック
+  return new FileTokenStore()
+}

--- a/src/infra/keychain/index.ts
+++ b/src/infra/keychain/index.ts
@@ -2,7 +2,7 @@
  * index.ts — OS に応じた TokenStore 実装を返すファクトリ。
  *
  * OS を判定して macOS / Linux / Windows の keychain 実装を返す。
- * 各 keychain が利用できない場合はファイルフォールバックに移行する。
+ * 未知の OS の場合のみファイルフォールバックに移行する。keychain 実行失敗時は各実装がエラーを throw する。
  */
 
 import type { TokenStore } from "@/core/auth/store"

--- a/src/infra/keychain/linux.ts
+++ b/src/infra/keychain/linux.ts
@@ -1,0 +1,60 @@
+/**
+ * linux.ts — Linux の secret-tool (libsecret) を使った TokenStore 実装。
+ */
+
+import type { TokenStore } from "@/core/auth/store"
+
+const SERVICE = "coscli"
+
+/** LinuxKeychainStore は Linux の secret-tool コマンド経由で Secret Service にアクセスする。 */
+export class LinuxKeychainStore implements TokenStore {
+  async save(profile: string, sid: string): Promise<void> {
+    const proc = Bun.spawn(
+      ["secret-tool", "store", "--label=coscli", "service", SERVICE, "account", profile],
+      {
+        stdin: new TextEncoder().encode(sid),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    )
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      throw new Error(`secret-tool への保存に失敗しました: ${stderr}`)
+    }
+  }
+
+  async load(profile: string): Promise<string | null> {
+    const proc = Bun.spawn(["secret-tool", "lookup", "service", SERVICE, "account", profile], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    if (exitCode !== 0) return null
+    return stdout.trim() || null
+  }
+
+  async delete(profile: string): Promise<void> {
+    const proc = Bun.spawn(["secret-tool", "clear", "service", SERVICE, "account", profile], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    await proc.exited
+  }
+
+  async list(): Promise<string[]> {
+    const proc = Bun.spawn(["secret-tool", "search", "--all", "service", SERVICE], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    if (exitCode !== 0) return []
+
+    const profiles: string[] = []
+    for (const line of stdout.split("\n")) {
+      const match = line.match(/attribute\.account\s*=\s*(.+)/)
+      if (match?.[1]) profiles.push(match[1].trim())
+    }
+    return profiles
+  }
+}

--- a/src/infra/keychain/macos.ts
+++ b/src/infra/keychain/macos.ts
@@ -1,0 +1,86 @@
+/**
+ * macos.ts — macOS Keychain (security コマンド) を使った TokenStore 実装。
+ */
+
+import type { TokenStore } from "@/core/auth/store"
+
+const SERVICE = "coscli"
+
+/** MacOSKeychainStore は macOS の security コマンド経由で Keychain にアクセスする。 */
+export class MacOSKeychainStore implements TokenStore {
+  async save(profile: string, sid: string): Promise<void> {
+    // すでに存在する場合は update、なければ add
+    const updateResult = await run([
+      "security",
+      "add-generic-password",
+      "-s",
+      SERVICE,
+      "-a",
+      profile,
+      "-w",
+      sid,
+      "-U",
+    ])
+    if (!updateResult.success) {
+      throw new Error(`Keychain への保存に失敗しました: ${updateResult.stderr}`)
+    }
+  }
+
+  async load(profile: string): Promise<string | null> {
+    const result = await run([
+      "security",
+      "find-generic-password",
+      "-s",
+      SERVICE,
+      "-a",
+      profile,
+      "-w",
+    ])
+    if (!result.success) return null
+    return result.stdout.trim() || null
+  }
+
+  async delete(profile: string): Promise<void> {
+    await run(["security", "delete-generic-password", "-s", SERVICE, "-a", profile])
+    // 存在しない場合も成功扱いにする
+  }
+
+  async list(): Promise<string[]> {
+    // security コマンドでサービス名を指定して全アカウント名を取得する
+    const result = await run(["security", "dump-keychain"])
+    if (!result.success) return []
+
+    const lines = result.stdout.split("\n")
+    const profiles: string[] = []
+    let inCosenseEntry = false
+
+    for (const line of lines) {
+      if (line.includes(`"svce"<blob>="${SERVICE}"`)) {
+        inCosenseEntry = true
+      }
+      if (inCosenseEntry && line.includes('"acct"<blob>=')) {
+        const match = line.match(/"acct"<blob>="([^"]+)"/)
+        if (match?.[1]) {
+          profiles.push(match[1])
+          inCosenseEntry = false
+        }
+      }
+    }
+
+    return profiles
+  }
+}
+
+/** run は外部コマンドを実行してその結果を返す。 */
+async function run(cmd: string[]): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { success: exitCode === 0, stdout, stderr }
+}

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -21,8 +21,13 @@ export class WindowsKeychainStore implements TokenStore {
   }
 
   async load(profile: string): Promise<string | null> {
-    // Windows の cmdkey は直接値を読み出せないため PowerShell を使う
+    // cmdkey は直接パスワードを読み出せないため PowerShell + CredentialManager モジュールを試みる。
+    // Get-StoredCredential が未インストールの場合は FileTokenStore への移行を案内するエラーを throw する。
     const script = `
+      if (-not (Get-Command Get-StoredCredential -ErrorAction SilentlyContinue)) {
+        Write-Error 'CredentialManager module not found. Install it with: Install-Module CredentialManager -Scope CurrentUser'
+        exit 2
+      }
       $cred = Get-StoredCredential -Target '${SERVICE}:${profile}'
       if ($cred) { $cred.GetNetworkCredential().Password }
     `
@@ -30,7 +35,16 @@ export class WindowsKeychainStore implements TokenStore {
       stdout: "pipe",
       stderr: "pipe",
     })
-    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    if (exitCode === 2) {
+      throw new Error(
+        `Windows Credential Manager の読み出しに失敗しました。\nPowerShell で次を実行してモジュールをインストールしてください:\n  Install-Module CredentialManager -Scope CurrentUser\nまたは cos auth login --insecure-file-store で代替ストアを使用してください。\n詳細: ${stderr.trim()}`,
+      )
+    }
     if (exitCode !== 0) return null
     return stdout.trim() || null
   }

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -1,0 +1,64 @@
+/**
+ * windows.ts — Windows の cmdkey コマンドを使った TokenStore 実装。
+ */
+
+import type { TokenStore } from "@/core/auth/store"
+
+const SERVICE = "coscli"
+
+/** WindowsKeychainStore は Windows の cmdkey コマンド経由で資格情報マネージャーにアクセスする。 */
+export class WindowsKeychainStore implements TokenStore {
+  async save(profile: string, sid: string): Promise<void> {
+    const proc = Bun.spawn(
+      ["cmdkey", `/generic:${SERVICE}:${profile}`, "/user:cos", `/pass:${sid}`],
+      { stdout: "pipe", stderr: "pipe" },
+    )
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      throw new Error(`cmdkey への保存に失敗しました: ${stderr}`)
+    }
+  }
+
+  async load(profile: string): Promise<string | null> {
+    // Windows の cmdkey は直接値を読み出せないため PowerShell を使う
+    const script = `
+      $cred = Get-StoredCredential -Target '${SERVICE}:${profile}'
+      if ($cred) { $cred.GetNetworkCredential().Password }
+    `
+    const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", script], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    if (exitCode !== 0) return null
+    return stdout.trim() || null
+  }
+
+  async delete(profile: string): Promise<void> {
+    const proc = Bun.spawn(["cmdkey", `/delete:${SERVICE}:${profile}`], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    await proc.exited
+  }
+
+  async list(): Promise<string[]> {
+    const proc = Bun.spawn(["cmdkey", "/list"], { stdout: "pipe", stderr: "pipe" })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    if (exitCode !== 0) return []
+
+    const prefix = `${SERVICE}:`
+    const profiles: string[] = []
+    for (const line of stdout.split("\n")) {
+      const match = line.match(/Target:\s*(.+)/)
+      if (match?.[1]) {
+        const target = match[1].trim()
+        if (target.startsWith(prefix)) {
+          profiles.push(target.slice(prefix.length))
+        }
+      }
+    }
+    return profiles
+  }
+}

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,0 +1,71 @@
+/**
+ * logger.ts — stderr への人間向けメッセージ出力。
+ *
+ * データは stdout、進捗・警告・ヒントは stderr に書く。
+ * --json / --plain / --quiet 時は人間向けメッセージを抑制する。
+ */
+
+import { color } from "@/infra/color"
+
+export type LogLevel = "debug" | "info" | "warn" | "error"
+
+export interface LoggerOptions {
+  quiet?: boolean
+  json?: boolean
+  plain?: boolean
+  verbose?: number
+}
+
+/** Logger は stderr への人間向けメッセージ出力を管理する。 */
+export class Logger {
+  constructor(private readonly opts: LoggerOptions = {}) {}
+
+  /** info は通常の進捗メッセージを stderr に出力する。 */
+  info(message: string): void {
+    if (this.isSilent()) return
+    process.stderr.write(`${message}\n`)
+  }
+
+  /** success は成功メッセージを stderr に出力する。 */
+  success(message: string): void {
+    if (this.isSilent()) return
+    process.stderr.write(`${color.green("✔")} ${message}\n`)
+  }
+
+  /** warn は警告メッセージを stderr に出力する。 */
+  warn(message: string): void {
+    if (this.opts.json || this.opts.plain) return
+    process.stderr.write(`${color.yellow("⚠")} ${message}\n`)
+  }
+
+  /** error はエラーメッセージを stderr に出力する。常に出力する。 */
+  error(message: string): void {
+    process.stderr.write(`${color.red("✗")} ${message}\n`)
+  }
+
+  /** debug はデバッグメッセージを stderr に出力する (-v フラグで有効)。 */
+  debug(message: string): void {
+    if ((this.opts.verbose ?? 0) >= 2) {
+      process.stderr.write(`${color.dim("[debug]")} ${color.dim(message)}\n`)
+    }
+  }
+
+  /** verbose はリクエスト情報等を stderr に出力する (-v で有効)。 */
+  verbose(message: string): void {
+    if ((this.opts.verbose ?? 0) >= 1) {
+      process.stderr.write(`${color.dim("[info]")} ${message}\n`)
+    }
+  }
+
+  private isSilent(): boolean {
+    return !!(this.opts.quiet || this.opts.json || this.opts.plain)
+  }
+}
+
+/** defaultLogger はデフォルト設定のロガーインスタンス。コマンド起動時に上書きされる。 */
+export let defaultLogger = new Logger()
+
+/** setDefaultLogger はデフォルトロガーを差し替える。 */
+export function setDefaultLogger(logger: Logger): void {
+  defaultLogger = logger
+}

--- a/src/presenter/json.ts
+++ b/src/presenter/json.ts
@@ -1,0 +1,121 @@
+/**
+ * json.ts — --json / --results-only / --select 出力フォーマット。
+ *
+ * すべての出力を envelope 形式 { data, meta } で包み、
+ * --results-only で data だけを、--select で特定のパスを抽出して出力する。
+ */
+
+import { randomUUID } from "node:crypto"
+
+/** ResponseEnvelope は CLI の標準出力 envelope 形式。 */
+export interface ResponseEnvelope<T> {
+  data: T
+  meta: {
+    command: string
+    durationMs: number
+    requestId: string
+    warnings: string[]
+  }
+}
+
+/** ErrorEnvelope はエラー時の出力形式。 */
+export interface ErrorEnvelope {
+  error: {
+    code: string
+    message: string
+    hint?: string
+  }
+}
+
+/** JsonOutputOptions は JSON 出力のオプション。 */
+export interface JsonOutputOptions {
+  /** 出力先 (デフォルト process.stdout) */
+  stream?: NodeJS.WritableStream
+  /** true の場合 meta を省いて data だけを出力する */
+  resultsOnly?: boolean
+  /** jq 風の軽量パスセレクタ (例: "pages[].title") */
+  select?: string
+}
+
+/** writeJson は envelope を JSON として stdout に書き出す。 */
+export function writeJson<T>(
+  data: T,
+  meta: { command: string; startTime: number; warnings?: string[] },
+  opts: JsonOutputOptions = {},
+): void {
+  const stream = opts.stream ?? process.stdout
+  const durationMs = Date.now() - meta.startTime
+
+  let output: unknown
+  if (opts.resultsOnly) {
+    output = applySelect(data, opts.select)
+  } else {
+    const envelope: ResponseEnvelope<T> = {
+      data,
+      meta: {
+        command: meta.command,
+        durationMs,
+        requestId: randomUUID(),
+        warnings: meta.warnings ?? [],
+      },
+    }
+    output = opts.select ? applySelect(envelope.data, opts.select) : envelope
+  }
+
+  stream.write(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+/** writeErrorJson はエラーを JSON として stdout に書き出す。 */
+export function writeErrorJson(
+  code: string,
+  message: string,
+  hint?: string,
+  stream?: NodeJS.WritableStream,
+): void {
+  const out = stream ?? process.stdout
+  const envelope: ErrorEnvelope = {
+    error: { code, message, ...(hint ? { hint } : {}) },
+  }
+  out.write(`${JSON.stringify(envelope, null, 2)}\n`)
+}
+
+/**
+ * applySelect は "a.b[].c" 形式の軽量パスセレクタを適用する。
+ *
+ * サポートする形式:
+ *   - "pages"      → data.pages
+ *   - "pages[]"    → data.pages の各要素
+ *   - "pages[].title" → data.pages の各要素の title
+ *   - "a.b.c"      → data.a.b.c
+ */
+export function applySelect(data: unknown, selector?: string): unknown {
+  if (!selector) return data
+
+  const parts = selector.split(".")
+  let current: unknown = data
+
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined
+
+    if (part.endsWith("[]")) {
+      const key = part.slice(0, -2)
+      const array = key ? (current as Record<string, unknown>)[key] : current
+      if (!Array.isArray(array)) return undefined
+      current = array
+      // 次の part があればそれを各要素に適用する (ここでは current が配列のまま次へ)
+    } else {
+      if (Array.isArray(current)) {
+        // 配列の各要素にキーを適用する
+        current = current.map((item) =>
+          item !== null && typeof item === "object"
+            ? (item as Record<string, unknown>)[part]
+            : undefined,
+        )
+      } else {
+        current = (current as Record<string, unknown>)[part]
+      }
+    }
+  }
+
+  return current
+}

--- a/src/presenter/plain.ts
+++ b/src/presenter/plain.ts
@@ -1,0 +1,62 @@
+/**
+ * plain.ts — --plain / TSV 出力フォーマット。
+ *
+ * cli-table3 でボーダー付きテーブルを描画するか、
+ * タブ区切り (TSV) で出力するかを選択できる。
+ * AI エージェントやスクリプトには TSV が扱いやすい。
+ */
+
+import Table from "cli-table3"
+
+/** PlainOutputOptions はテキスト出力のオプション。 */
+export interface PlainOutputOptions {
+  /** 出力先 (デフォルト process.stdout) */
+  stream?: NodeJS.WritableStream
+  /** true の場合ヘッダー行を出力しない */
+  noHeader?: boolean
+}
+
+/**
+ * writePlainTable は cli-table3 を使ってボーダー付きテーブルを出力する。
+ * TTY 環境での人間向け表示に適する。
+ */
+export function writePlainTable(
+  headers: string[],
+  rows: string[][],
+  opts: PlainOutputOptions = {},
+): void {
+  const stream = opts.stream ?? process.stdout
+  const table = new Table({ head: headers })
+  for (const row of rows) {
+    table.push(row)
+  }
+  stream.write(`${table.toString()}\n`)
+}
+
+/**
+ * writeTsv はタブ区切り (TSV) で出力する。
+ * スクリプト連携や awk/cut での処理に適する。
+ * セル値に含まれるタブは "\t" にエスケープする。
+ */
+export function writeTsv(headers: string[], rows: string[][], opts: PlainOutputOptions = {}): void {
+  const stream = opts.stream ?? process.stdout
+  const escapeCell = (s: string) => s.replace(/\t/g, "\\t").replace(/\n/g, "\\n")
+
+  if (!opts.noHeader) {
+    stream.write(`${headers.map(escapeCell).join("\t")}\n`)
+  }
+  for (const row of rows) {
+    stream.write(`${row.map(escapeCell).join("\t")}\n`)
+  }
+}
+
+/**
+ * writePlainList は文字列のリストを1行ずつ出力する。
+ * タイトル一覧などシンプルな値の列挙に使う。
+ */
+export function writePlainList(items: string[], opts: PlainOutputOptions = {}): void {
+  const stream = opts.stream ?? process.stdout
+  for (const item of items) {
+    stream.write(`${item}\n`)
+  }
+}

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -1,0 +1,115 @@
+/**
+ * page.ts — Cosense ページ関連の zod スキーマ定義。
+ *
+ * /api/pages/:project および /api/pages/:project/:title のレスポンスを検証する。
+ */
+
+import { z } from "zod"
+
+/** Line は Cosense ページの 1 行を表す。 */
+export const LineSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  userId: z.string(),
+  created: z.number(),
+  updated: z.number(),
+})
+export type Line = z.infer<typeof LineSchema>
+
+/** PageSummary はページ一覧に含まれる軽量なページ情報。 */
+export const PageSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  image: z.string().nullable().optional(),
+  descriptions: z.array(z.string()).optional(),
+  user: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      displayName: z.string(),
+    })
+    .optional(),
+  pin: z.number().optional(),
+  views: z.number().optional(),
+  linked: z.number().optional(),
+  commitId: z.string().optional(),
+  created: z.number(),
+  updated: z.number(),
+  accessed: z.number().optional(),
+  snapshotCreated: z.number().nullable().optional(),
+  pageRank: z.number().optional(),
+})
+export type PageSummary = z.infer<typeof PageSummarySchema>
+
+/** Page は個別ページの詳細情報。 */
+export const PageSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  image: z.string().nullable().optional(),
+  descriptions: z.array(z.string()).optional(),
+  user: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      displayName: z.string(),
+    })
+    .optional(),
+  pin: z.number().optional(),
+  views: z.number().optional(),
+  linked: z.number().optional(),
+  commitId: z.string(),
+  created: z.number(),
+  updated: z.number(),
+  accessed: z.number().optional(),
+  snapshotCreated: z.number().nullable().optional(),
+  persistent: z.boolean().optional(),
+  lines: z.array(LineSchema),
+  links: z.array(z.string()).optional(),
+  icons: z.array(z.string()).optional(),
+  files: z.array(z.string()).optional(),
+  relatedPages: z
+    .object({
+      links1hop: z.array(PageSummarySchema).optional(),
+      links2hop: z.array(PageSummarySchema).optional(),
+      hasBackLinks: z.boolean().optional(),
+    })
+    .optional(),
+})
+export type Page = z.infer<typeof PageSchema>
+
+/** PageListResponse は /api/pages/:project のレスポンス全体。 */
+export const PageListResponseSchema = z.object({
+  projectName: z.string(),
+  skip: z.number(),
+  limit: z.number(),
+  count: z.number(),
+  pages: z.array(PageSummarySchema),
+})
+export type PageListResponse = z.infer<typeof PageListResponseSchema>
+
+/** SearchResult は /api/pages/:project/search/query のレスポンス。 */
+export const SearchResultSchema = z.object({
+  query: z.string().optional(),
+  pages: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      image: z.string().nullable().optional(),
+      descriptions: z.array(z.string()).optional(),
+      words: z.array(z.string()).optional(),
+    }),
+  ),
+  existsSelectedProject: z.boolean().optional(),
+  projectName: z.string(),
+  searchQuery: z.string().optional(),
+})
+export type SearchResult = z.infer<typeof SearchResultSchema>
+
+/** TitleSearchResult は /api/pages/:project/search/titles のレスポンス要素。 */
+export const TitleSearchResultSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  updated: z.number(),
+  exists: z.boolean().optional(),
+})
+export type TitleSearchResult = z.infer<typeof TitleSearchResultSchema>

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -25,7 +25,7 @@ export const ProjectSchema = z.object({
   pageCount: z.number().optional(),
   memberCount: z.number().optional(),
   invitationRotateTime: z.number().nullable().optional(),
-  uploadImaages: z.number().optional(),
+  uploadImages: z.number().optional(),
   uploadFiles: z.number().optional(),
 })
 export type Project = z.infer<typeof ProjectSchema>

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -1,0 +1,37 @@
+/**
+ * project.ts — Cosense プロジェクト関連の zod スキーマ定義。
+ */
+
+import { z } from "zod"
+
+/** Project は /api/projects/:project のレスポンス。 */
+export const ProjectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  displayName: z.string(),
+  publicVisible: z.boolean(),
+  loginStrategies: z.array(z.string()).optional(),
+  plan: z.string().optional(),
+  gyazoTeamsName: z.string().nullable().optional(),
+  image: z.string().nullable().optional(),
+  theme: z.string().optional(),
+  created: z.number(),
+  updated: z.number(),
+  isMember: z.boolean().optional(),
+  isAdmin: z.boolean().optional(),
+  trialing: z.boolean().optional(),
+  trialMaxPages: z.number().optional(),
+  skipConfirmation: z.boolean().optional(),
+  pageCount: z.number().optional(),
+  memberCount: z.number().optional(),
+  invitationRotateTime: z.number().nullable().optional(),
+  uploadImaages: z.number().optional(),
+  uploadFiles: z.number().optional(),
+})
+export type Project = z.infer<typeof ProjectSchema>
+
+/** ProjectListResponse は /api/projects のレスポンス。 */
+export const ProjectListResponseSchema = z.object({
+  projects: z.array(ProjectSchema),
+})
+export type ProjectListResponse = z.infer<typeof ProjectListResponseSchema>

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -1,0 +1,24 @@
+/**
+ * user.ts — Cosense ユーザー関連の zod スキーマ定義。
+ */
+
+import { z } from "zod"
+
+/** Me は /api/users/me のレスポンス。 */
+export const MeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  displayName: z.string(),
+  email: z.string().optional(),
+  photo: z.string().optional(),
+  csrfToken: z.string(),
+  isPasswordUser: z.boolean().optional(),
+  isGitHubUser: z.boolean().optional(),
+  config: z
+    .object({
+      userScript: z.boolean().optional(),
+      theme: z.string().optional(),
+    })
+    .optional(),
+})
+export type Me = z.infer<typeof MeSchema>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * version.ts — CLI バージョン文字列。
+ *
+ * bun build --define 'VERSION="x.y.z"' でビルド時に注入される。
+ * このファイルは型宣言のみ。cli.ts から直接参照するため export は不要。
+ */
+export {}

--- a/tests/fixtures/me.json
+++ b/tests/fixtures/me.json
@@ -1,0 +1,10 @@
+{
+  "id": "user-id-me",
+  "name": "テストユーザー",
+  "displayName": "テストユーザー表示名",
+  "email": "test@example.com",
+  "photo": "https://example.com/photo.jpg",
+  "csrfToken": "test-csrf-token-12345",
+  "isPasswordUser": false,
+  "isGitHubUser": true
+}

--- a/tests/fixtures/page-detail.json
+++ b/tests/fixtures/page-detail.json
@@ -1,0 +1,46 @@
+{
+  "id": "page-id-hello",
+  "title": "Hello World",
+  "image": null,
+  "descriptions": ["最初の行", "2行目"],
+  "user": {
+    "id": "user-id-1",
+    "name": "テストユーザー",
+    "displayName": "テストユーザー表示名"
+  },
+  "pin": 0,
+  "views": 10,
+  "linked": 3,
+  "commitId": "commit-id-hello",
+  "created": 1700000000,
+  "updated": 1700100000,
+  "accessed": 1700200000,
+  "snapshotCreated": null,
+  "persistent": true,
+  "lines": [
+    {
+      "id": "line-id-title",
+      "text": "Hello World",
+      "userId": "user-id-1",
+      "created": 1700000000,
+      "updated": 1700000000
+    },
+    {
+      "id": "line-id-1",
+      "text": "最初の行",
+      "userId": "user-id-1",
+      "created": 1700000001,
+      "updated": 1700000001
+    },
+    {
+      "id": "line-id-2",
+      "text": "2行目",
+      "userId": "user-id-1",
+      "created": 1700000002,
+      "updated": 1700000002
+    }
+  ],
+  "links": ["関連ページ1", "関連ページ2"],
+  "icons": [],
+  "files": []
+}

--- a/tests/fixtures/page-list.json
+++ b/tests/fixtures/page-list.json
@@ -1,0 +1,46 @@
+{
+  "projectName": "テストプロジェクト",
+  "skip": 0,
+  "limit": 30,
+  "count": 2,
+  "pages": [
+    {
+      "id": "page-id-hello",
+      "title": "Hello World",
+      "image": null,
+      "descriptions": ["最初の行", "2行目"],
+      "user": {
+        "id": "user-id-1",
+        "name": "テストユーザー",
+        "displayName": "テストユーザー表示名"
+      },
+      "pin": 0,
+      "views": 10,
+      "linked": 3,
+      "commitId": "commit-id-hello",
+      "created": 1700000000,
+      "updated": 1700100000,
+      "accessed": 1700200000,
+      "snapshotCreated": null
+    },
+    {
+      "id": "page-id-japanese",
+      "title": "日本語タイトル",
+      "image": null,
+      "descriptions": ["日本語の説明文"],
+      "user": {
+        "id": "user-id-1",
+        "name": "テストユーザー",
+        "displayName": "テストユーザー表示名"
+      },
+      "pin": 0,
+      "views": 5,
+      "linked": 0,
+      "commitId": "commit-id-japanese",
+      "created": 1700050000,
+      "updated": 1700150000,
+      "accessed": 1700250000,
+      "snapshotCreated": null
+    }
+  ]
+}

--- a/tests/unit/core/api/encoder.test.ts
+++ b/tests/unit/core/api/encoder.test.ts
@@ -1,0 +1,81 @@
+/**
+ * encoder.test.ts — Cosense ページタイトルの URL スラッグ変換テスト。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { buildPageUrl, decodePageTitle, encodePageTitle } from "@/core/api/encoder"
+
+describe("encodePageTitle", () => {
+  it("半角スペースをアンダースコアに変換する", () => {
+    expect(encodePageTitle("Hello World")).toBe("Hello_World")
+  })
+
+  it("複数の連続スペースもそれぞれアンダースコアに変換する", () => {
+    expect(encodePageTitle("A  B")).toBe("A__B")
+  })
+
+  it("全角スペースはそのままパーセントエンコードする", () => {
+    expect(encodePageTitle("Hello　World")).toBe("Hello%E3%80%80World")
+  })
+
+  it("日本語タイトルをパーセントエンコードする", () => {
+    expect(encodePageTitle("日本語")).toBe("%E6%97%A5%E6%9C%AC%E8%AA%9E")
+  })
+
+  it("英数字のみの場合はそのまま返す", () => {
+    expect(encodePageTitle("Hello123")).toBe("Hello123")
+  })
+
+  it("記号を含むタイトルをエンコードする", () => {
+    expect(encodePageTitle("foo/bar")).toBe("foo%2Fbar")
+  })
+
+  it("アンダースコアそのものを含むタイトルもエンコードする", () => {
+    // アンダースコアは RFC 3986 で unreserved なためエンコードしない
+    expect(encodePageTitle("foo_bar")).toBe("foo_bar")
+  })
+
+  it("空文字列をそのまま返す", () => {
+    expect(encodePageTitle("")).toBe("")
+  })
+
+  it("タブ文字をパーセントエンコードする", () => {
+    expect(encodePageTitle("foo\tbar")).toBe("foo%09bar")
+  })
+})
+
+describe("decodePageTitle", () => {
+  it("アンダースコアをスペースに戻す", () => {
+    expect(decodePageTitle("Hello_World")).toBe("Hello World")
+  })
+
+  it("パーセントエンコードをデコードする", () => {
+    expect(decodePageTitle("%E6%97%A5%E6%9C%AC%E8%AA%9E")).toBe("日本語")
+  })
+
+  it("空文字列をそのまま返す", () => {
+    expect(decodePageTitle("")).toBe("")
+  })
+})
+
+describe("buildPageUrl", () => {
+  it("プロジェクト名とタイトルから URL を生成する", () => {
+    expect(buildPageUrl("myproject", "Hello World")).toBe(
+      "https://scrapbox.io/myproject/Hello_World",
+    )
+  })
+
+  it("日本語タイトルを含む URL を生成する", () => {
+    expect(buildPageUrl("myproject", "日本語")).toBe(
+      "https://scrapbox.io/myproject/%E6%97%A5%E6%9C%AC%E8%AA%9E",
+    )
+  })
+
+  it("プロジェクト名が空の場合はエラーをスローする", () => {
+    expect(() => buildPageUrl("", "Hello")).toThrow("プロジェクト名を指定してください")
+  })
+
+  it("タイトルが空の場合はエラーをスローする", () => {
+    expect(() => buildPageUrl("myproject", "")).toThrow("タイトルを指定してください")
+  })
+})

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -1,0 +1,162 @@
+/**
+ * rest.test.ts — Cosense REST API クライアントのテスト。
+ *
+ * msw でモックサーバーを立て、REST クライアントの動作を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { CosenseRestClient } from "@/core/api/rest"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import meFixture from "../../../fixtures/me.json"
+import pageDetailFixture from "../../../fixtures/page-detail.json"
+import pageListFixture from "../../../fixtures/page-list.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_SID = "s%3Atest-connect-sid"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/users/me`, ({ request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    return HttpResponse.json(meFixture)
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] === TEST_PROJECT) {
+      return HttpResponse.json(pageListFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (
+      params["project"] === TEST_PROJECT &&
+      decodeURIComponent(params["title"] as string) === "Hello_World"
+    ) {
+      return HttpResponse.json(pageDetailFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/:title/text`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return new HttpResponse("Unauthorized", { status: 401 })
+    }
+    if (
+      params["project"] === TEST_PROJECT &&
+      decodeURIComponent(params["title"] as string) === "Hello_World"
+    ) {
+      return new HttpResponse("Hello World\n最初の行\n2行目")
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/search/query`, ({ request, params }) => {
+    if (params["project"] === TEST_PROJECT) {
+      const url = new URL(request.url)
+      const query = url.searchParams.get("q")
+      return HttpResponse.json({
+        projectName: TEST_PROJECT,
+        pages:
+          query === "Hello"
+            ? [{ id: "page-id-hello", title: "Hello World", words: ["Hello"] }]
+            : [],
+      })
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("CosenseRestClient", () => {
+  describe("getMe", () => {
+    it("認証済みの場合はユーザー情報を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const me = await client.getMe()
+      expect(me.name).toBe("テストユーザー")
+      expect(me.csrfToken).toBe("test-csrf-token-12345")
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.getMe()).rejects.toThrow()
+    })
+  })
+
+  describe("listPages", () => {
+    it("ページ一覧を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.listPages(TEST_PROJECT)
+      expect(result.pages).toHaveLength(2)
+      expect(result.pages[0]?.title).toBe("Hello World")
+      expect(result.pages[1]?.title).toBe("日本語タイトル")
+    })
+
+    it("ページ数を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.listPages(TEST_PROJECT)
+      expect(result.count).toBe(2)
+    })
+
+    it("存在しないプロジェクトは NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(client.listPages("存在しないプロジェクト")).rejects.toThrow()
+    })
+  })
+
+  describe("getPage", () => {
+    it("ページ詳細を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const page = await client.getPage(TEST_PROJECT, "Hello World")
+      expect(page.title).toBe("Hello World")
+      expect(page.lines).toHaveLength(3)
+      expect(page.lines[0]?.text).toBe("Hello World")
+    })
+
+    it("存在しないページは NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(client.getPage(TEST_PROJECT, "存在しないページ")).rejects.toThrow()
+    })
+  })
+
+  describe("getPageText", () => {
+    it("ページのプレーンテキストを返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const text = await client.getPageText(TEST_PROJECT, "Hello World")
+      expect(text).toContain("Hello World")
+      expect(text).toContain("最初の行")
+    })
+  })
+
+  describe("searchPages", () => {
+    it("クエリにマッチするページを返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchPages(TEST_PROJECT, "Hello")
+      expect(result.pages).toHaveLength(1)
+      expect(result.pages[0]?.title).toBe("Hello World")
+    })
+
+    it("マッチしないクエリは空配列を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchPages(TEST_PROJECT, "存在しないキーワード")
+      expect(result.pages).toHaveLength(0)
+    })
+  })
+})

--- a/tests/unit/core/api/ws.test.ts
+++ b/tests/unit/core/api/ws.test.ts
@@ -1,0 +1,91 @@
+/**
+ * ws.test.ts — ScrapboxWriter interface と @cosense/std ラッパのテスト。
+ *
+ * @cosense/std の patch() を spy して、正しい引数で呼ばれるか検証する。
+ * 実際の WebSocket 接続は行わない。
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { CosenseWriter, DryRunWriter } from "@/core/api/ws"
+import type { Line } from "@/schemas/page"
+
+// @cosense/std のモック
+const mockPatch = mock(async () => ({
+  commitId: "mock-commit-id",
+  pageId: "mock-page-id",
+}))
+
+// CosenseWriter はコンストラクタで @cosense/std を受け取る (依存性注入)
+const mockStdClient = {
+  patch: mockPatch,
+}
+
+describe("CosenseWriter", () => {
+  beforeEach(() => {
+    mockPatch.mockClear()
+  })
+
+  it("patch を呼ぶと update 関数の戻り値でコミットする", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+    )
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[]) => ["行1", "行2"],
+    })
+    expect(mockPatch).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ commitId: "mock-commit-id" })
+  })
+
+  it("--dry-run モードでは patch を呼ばず DryRunResult を返す", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      {
+        dryRun: true,
+      },
+    )
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[]) => ["行1", "行2"],
+    })
+    expect(mockPatch).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ dryRun: true, project: "テストプロジェクト" })
+  })
+})
+
+describe("DryRunWriter", () => {
+  it("patch を呼んでも実際のコミットをしない", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[]) => ["行1", "行2"],
+    })
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "テストページ",
+    })
+  })
+
+  it("insertLines を呼んでも何もしない", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.insertLines({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      lines: ["新しい行"],
+    })
+    expect(result).toMatchObject({ dryRun: true })
+  })
+
+  it("deletePage を呼んでも何もしない", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.deletePage({
+      project: "テストプロジェクト",
+      title: "テストページ",
+    })
+    expect(result).toMatchObject({ dryRun: true })
+  })
+})

--- a/tests/unit/core/auth/session.test.ts
+++ b/tests/unit/core/auth/session.test.ts
@@ -1,0 +1,40 @@
+/**
+ * session.test.ts — core/auth/session の単体テスト。
+ *
+ * TokenStore をモックに差し替えてセッション取得フローを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { loadSession, saveSession } from "@/core/auth/session"
+import { InMemoryTokenStore } from "@/core/auth/store"
+
+describe("saveSession", () => {
+  it("TokenStore に connect.sid を保存する", async () => {
+    const store = new InMemoryTokenStore()
+    await saveSession(store, { profile: "default", sid: "my-session-id" })
+    const token = await store.load("default")
+    expect(token).toBe("my-session-id")
+  })
+})
+
+describe("loadSession", () => {
+  it("保存済みの connect.sid を取得する", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("work", "work-session-id")
+    const sid = await loadSession(store, { profile: "work" })
+    expect(sid).toBe("work-session-id")
+  })
+
+  it("セッションが存在しない場合は undefined を返す", async () => {
+    const store = new InMemoryTokenStore()
+    const sid = await loadSession(store, { profile: "存在しないプロファイル" })
+    expect(sid).toBeUndefined()
+  })
+
+  it("profile 未指定時は default プロファイルを使う", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("default", "default-session")
+    const sid = await loadSession(store, {})
+    expect(sid).toBe("default-session")
+  })
+})

--- a/tests/unit/core/auth/store.test.ts
+++ b/tests/unit/core/auth/store.test.ts
@@ -1,0 +1,54 @@
+/**
+ * store.test.ts — TokenStore interface とインメモリ実装のテスト。
+ *
+ * 実際の OS keychain を使わず、InMemoryTokenStore で動作検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { InMemoryTokenStore } from "@/core/auth/store"
+
+describe("InMemoryTokenStore", () => {
+  it("セッション ID を保存して取得できる", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("default", "my-connect-sid")
+    expect(await store.load("default")).toBe("my-connect-sid")
+  })
+
+  it("存在しないプロファイルは null を返す", async () => {
+    const store = new InMemoryTokenStore()
+    expect(await store.load("nonexistent")).toBeNull()
+  })
+
+  it("セッション ID を削除できる", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("default", "my-sid")
+    await store.delete("default")
+    expect(await store.load("default")).toBeNull()
+  })
+
+  it("複数プロファイルを独立して管理できる", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("personal", "sid-personal")
+    await store.save("work", "sid-work")
+    expect(await store.load("personal")).toBe("sid-personal")
+    expect(await store.load("work")).toBe("sid-work")
+  })
+
+  it("プロファイル一覧を取得できる", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("personal", "sid-personal")
+    await store.save("work", "sid-work")
+    const profiles = await store.list()
+    expect(profiles).toContain("personal")
+    expect(profiles).toContain("work")
+    expect(profiles).toHaveLength(2)
+  })
+
+  it("削除後はプロファイル一覧から消える", async () => {
+    const store = new InMemoryTokenStore()
+    await store.save("default", "sid")
+    await store.delete("default")
+    const profiles = await store.list()
+    expect(profiles).toHaveLength(0)
+  })
+})

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -1,0 +1,195 @@
+/**
+ * pages.test.ts — core/pages ユースケース層の単体テスト。
+ *
+ * CosenseRestClient をモックに差し替えてユースケース関数を検証する。
+ * 実際の HTTP 通信は行わない。
+ */
+
+import { describe, expect, it, mock } from "bun:test"
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import {
+  appendToPage,
+  createPage,
+  deletePage,
+  editPage,
+  getCodeBlock,
+  getPage,
+  getPageText,
+  listPages,
+} from "@/core/pages"
+
+/** REST クライアントのモック */
+function createMockRestClient(overrides: Partial<CosenseRestClient> = {}): CosenseRestClient {
+  return {
+    getMe: mock(async () => ({ id: "user1", name: "テストユーザー", csrfToken: "csrf-token" })),
+    listPages: mock(async () => ({
+      projectName: "テストプロジェクト",
+      skip: 0,
+      limit: 30,
+      count: 1,
+      pages: [
+        {
+          id: "page1",
+          title: "テストページ",
+          updated: 1700000000,
+          accessed: 1700000001,
+          views: 10,
+          linked: 2,
+          commitId: "abc",
+          snapshotCreated: null,
+          persistent: true,
+          image: null,
+          pin: 0,
+          pageRank: 0.1,
+          descriptions: ["概要行"],
+        },
+      ],
+    })),
+    getPage: mock(async () => ({
+      id: "page1",
+      title: "テストページ",
+      updated: 1700000000,
+      accessed: 1700000001,
+      views: 10,
+      linked: 2,
+      commitId: "abc",
+      snapshotCreated: null,
+      persistent: true,
+      image: null,
+      pin: 0,
+      pageRank: 0.1,
+      descriptions: ["概要行"],
+      lines: [{ id: "l1", text: "テストページ", userId: "u1", created: 0, updated: 0 }],
+      relatedPages: { links1hop: [], links2hop: [], hasBackLinksOrIcons: false },
+      collaborators: [],
+    })),
+    getPageText: mock(async () => "テストページ\n本文テキスト"),
+    getCodeBlock: mock(async () => 'console.log("hello")'),
+    searchPages: mock(async () => ({
+      projectName: "テストプロジェクト",
+      query: "テスト",
+      limit: 10,
+      count: 1,
+      existsExactTitleMatch: false,
+      pages: [],
+    })),
+    getProject: mock(async () => ({
+      id: "proj1",
+      name: "テストプロジェクト",
+      displayName: "テストプロジェクト",
+      publicVisible: true,
+      loginStrategies: [],
+      theme: "default",
+      gyazoTeamsName: null,
+      translation: false,
+      infobox: false,
+      created: 1700000000,
+      updated: 1700000000,
+      isMember: true,
+    })),
+    listProjects: mock(async () => ({ projects: [] })),
+    ...overrides,
+  } as unknown as CosenseRestClient
+}
+
+/** Writer のモック */
+function createMockWriter(overrides: Partial<ScrapboxWriter> = {}): ScrapboxWriter {
+  return {
+    patch: mock(async () => ({ commitId: "commit1", pageId: "page1" })),
+    insertLines: mock(async () => ({ commitId: "commit1" })),
+    deletePage: mock(async () => ({ title: "テストページ" })),
+    ...overrides,
+  } as unknown as ScrapboxWriter
+}
+
+describe("listPages", () => {
+  it("REST クライアントから pages リストを取得して返す", async () => {
+    const client = createMockRestClient()
+    const result = await listPages(client, { project: "テストプロジェクト" })
+    expect(client.listPages).toHaveBeenCalledWith("テストプロジェクト", {})
+    expect(result.pages[0]?.title).toBe("テストページ")
+  })
+
+  it("limit と sort オプションを REST クライアントに渡す", async () => {
+    const client = createMockRestClient()
+    await listPages(client, { project: "proj", limit: 5, sort: "updated" })
+    expect(client.listPages).toHaveBeenCalledWith("proj", { limit: 5, sort: "updated" })
+  })
+})
+
+describe("getPage", () => {
+  it("タイトルを指定してページを取得する", async () => {
+    const client = createMockRestClient()
+    const result = await getPage(client, { project: "proj", title: "テストページ" })
+    expect(client.getPage).toHaveBeenCalledWith("proj", "テストページ")
+    expect(result.title).toBe("テストページ")
+  })
+})
+
+describe("createPage", () => {
+  it("Writer の patch を呼んでページを作成する", async () => {
+    const writer = createMockWriter()
+    const result = await createPage(writer, {
+      project: "proj",
+      title: "新しいページ",
+      lines: ["行1", "行2"],
+    })
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ commitId: "commit1" })
+  })
+})
+
+describe("appendToPage", () => {
+  it("Writer の insertLines を呼んで行を追加する", async () => {
+    const writer = createMockWriter()
+    await appendToPage(writer, {
+      project: "proj",
+      title: "既存ページ",
+      lines: ["追加行"],
+    })
+    expect(writer.insertLines).toHaveBeenCalledWith({
+      project: "proj",
+      title: "既存ページ",
+      lines: ["追加行"],
+    })
+  })
+})
+
+describe("getPageText", () => {
+  it("ページのテキスト本文を取得する", async () => {
+    const client = createMockRestClient()
+    const result = await getPageText(client, { project: "proj", title: "テストページ" })
+    expect(client.getPageText).toHaveBeenCalledWith("proj", "テストページ")
+    expect(result).toContain("テストページ")
+  })
+})
+
+describe("getCodeBlock", () => {
+  it("コードブロックを取得する", async () => {
+    const client = createMockRestClient()
+    const result = await getCodeBlock(client, {
+      project: "proj",
+      title: "テストページ",
+      filename: "main.ts",
+    })
+    expect(client.getCodeBlock).toHaveBeenCalledWith("proj", "テストページ", "main.ts")
+    expect(result).toContain("hello")
+  })
+})
+
+describe("editPage", () => {
+  it("Writer の patch を呼んでページを全置換する", async () => {
+    const writer = createMockWriter()
+    await editPage(writer, { project: "proj", title: "既存ページ", lines: ["新しい内容"] })
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("deletePage", () => {
+  it("Writer の deletePage を呼んでページを削除する", async () => {
+    const writer = createMockWriter()
+    await deletePage(writer, { project: "proj", title: "削除ページ" })
+    expect(writer.deletePage).toHaveBeenCalledWith({ project: "proj", title: "削除ページ" })
+  })
+})

--- a/tests/unit/core/sandbox.test.ts
+++ b/tests/unit/core/sandbox.test.ts
@@ -1,0 +1,91 @@
+/**
+ * sandbox.test.ts — コマンド実行許可ポリシーのテスト。
+ *
+ * --enable-commands / --disable-commands の組み合わせ挙動を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { PolicyError, createPolicy } from "@/core/sandbox"
+
+describe("createPolicy / allow", () => {
+  it("設定なしの場合は全コマンドを許可する", () => {
+    const policy = createPolicy({})
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeUndefined()
+    expect(policy.allow("project.export")).toBeUndefined()
+  })
+
+  it("enable リストに含まれるコマンドを許可する", () => {
+    const policy = createPolicy({ enable: ["page.list", "page.get"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.get")).toBeUndefined()
+  })
+
+  it("enable リストに含まれないコマンドを拒否する", () => {
+    const policy = createPolicy({ enable: ["page.list", "page.get"] })
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("project.export")).toBeInstanceOf(PolicyError)
+  })
+
+  it("disable リストに含まれるコマンドを拒否する", () => {
+    const policy = createPolicy({ disable: ["page.delete"] })
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+
+  it("disable リストに含まれないコマンドは通す", () => {
+    const policy = createPolicy({ disable: ["page.delete"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("project.info")).toBeUndefined()
+  })
+
+  it("enable で絞った後 disable でさらに削る", () => {
+    const policy = createPolicy({
+      enable: ["page.list", "page.get", "page.delete"],
+      disable: ["page.delete"],
+    })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.get")).toBeUndefined()
+    // enable リスト内でも disable で除外される
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    // enable に含まれない他のコマンドも拒否
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+
+  it("ワイルドカード 'page' は page.* 全体を許可する", () => {
+    const policy = createPolicy({ enable: ["page"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeUndefined()
+    // project 系は拒否
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+
+  it("ワイルドカード 'page' を enable し 'page.delete' を disable する", () => {
+    const policy = createPolicy({ enable: ["page"], disable: ["page.delete"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+})
+
+describe("PolicyError", () => {
+  it("コマンド名を含むメッセージを持つ", () => {
+    const policy = createPolicy({ disable: ["page.delete"] })
+    const err = policy.allow("page.delete")
+    expect(err).toBeInstanceOf(PolicyError)
+    expect((err as PolicyError).command).toBe("page.delete")
+    expect((err as PolicyError).message).toContain("page.delete")
+  })
+})
+
+describe("PolicyOptions のパース", () => {
+  it("カンマ区切り文字列をリストに変換する", () => {
+    const policy = createPolicy({ enableStr: "page.list,page.get", disableStr: "page.delete" })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+
+  it("空文字列は設定なし扱いにする", () => {
+    const policy = createPolicy({ enableStr: "", disableStr: "" })
+    expect(policy.allow("page.delete")).toBeUndefined()
+  })
+})

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -1,0 +1,140 @@
+/**
+ * config.test.ts — infra/config の単体テスト。
+ *
+ * ファイルシステムへの副作用は tmp ディレクトリに限定し、
+ * テスト終了後にクリーンアップする。
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  defaultConfigPath,
+  getConfigValue,
+  loadConfig,
+  saveConfig,
+  setConfigValue,
+} from "@/infra/config"
+
+/** テスト用の一時ファイルパスを生成する */
+function tmpConfigPath(): string {
+  return join(tmpdir(), `coscli-config-test-${Date.now()}.json5`)
+}
+
+describe("defaultConfigPath", () => {
+  it("XDG_CONFIG_HOME が設定されている場合はそのパスを使う", () => {
+    const original = process.env["XDG_CONFIG_HOME"]
+    process.env["XDG_CONFIG_HOME"] = "/カスタム設定ディレクトリ"
+    const result = defaultConfigPath()
+    expect(result).toBe("/カスタム設定ディレクトリ/coscli/config.json5")
+    process.env["XDG_CONFIG_HOME"] = original
+  })
+})
+
+describe("loadConfig", () => {
+  it("設定ファイルが存在しない場合は空オブジェクトを返す", () => {
+    const result = loadConfig("/存在しないパス/config.json5")
+    expect(result).toEqual({})
+  })
+
+  it("正しいJSON5ファイルを読み込んで設定を返す", () => {
+    const path = tmpConfigPath()
+    saveConfig({ defaultProject: "テストプロジェクト" }, path)
+    const result = loadConfig(path)
+    expect(result.defaultProject).toBe("テストプロジェクト")
+    unlinkSync(path)
+  })
+
+  it("不正なJSON5ファイルの場合はエラーをスローする", () => {
+    const path = tmpConfigPath()
+    Bun.write(path, "{ 不正なJSON5 :")
+    expect(() => loadConfig(path)).toThrow("設定ファイルの読み込みに失敗しました")
+    unlinkSync(path)
+  })
+})
+
+describe("saveConfig", () => {
+  let path: string
+
+  beforeEach(() => {
+    path = tmpConfigPath()
+  })
+
+  afterEach(() => {
+    if (existsSync(path)) unlinkSync(path)
+  })
+
+  it("設定をファイルに保存して読み込めること", () => {
+    saveConfig({ defaultProject: "マイプロジェクト", defaultProfile: "work" }, path)
+    const loaded = loadConfig(path)
+    expect(loaded.defaultProject).toBe("マイプロジェクト")
+    expect(loaded.defaultProfile).toBe("work")
+  })
+
+  it("ディレクトリが存在しない場合は自動作成する", () => {
+    const nestedPath = join(tmpdir(), `coscli-nested-${Date.now()}`, "config.json5")
+    saveConfig({ defaultProject: "ネストテスト" }, nestedPath)
+    const loaded = loadConfig(nestedPath)
+    expect(loaded.defaultProject).toBe("ネストテスト")
+    unlinkSync(nestedPath)
+  })
+})
+
+describe("getConfigValue", () => {
+  const config = {
+    defaultProject: "テストプロジェクト",
+    output: { color: "always" as const },
+    projects: {
+      myproject: { defaultSort: "updated" },
+    },
+  }
+
+  it("トップレベルのキーを取得できる", () => {
+    expect(getConfigValue(config, "defaultProject")).toBe("テストプロジェクト")
+  })
+
+  it("ネストしたキーをドット区切りで取得できる", () => {
+    expect(getConfigValue(config, "output.color")).toBe("always")
+  })
+
+  it("存在しないキーは undefined を返す", () => {
+    expect(getConfigValue(config, "存在しないキー")).toBeUndefined()
+  })
+
+  it("ネストしたキーが存在しない場合は undefined を返す", () => {
+    expect(getConfigValue(config, "output.存在しない")).toBeUndefined()
+  })
+})
+
+describe("setConfigValue", () => {
+  it("トップレベルのキーを設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "defaultProject", "新プロジェクト")
+    expect(updated.defaultProject).toBe("新プロジェクト")
+  })
+
+  it("ネストしたキーをドット区切りで設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "output.color", "never")
+    expect(updated.output?.color).toBe("never")
+  })
+
+  it("既存の設定を上書きできる", () => {
+    const config = { defaultProject: "古いプロジェクト" }
+    const updated = setConfigValue(config, "defaultProject", "新プロジェクト")
+    expect(updated.defaultProject).toBe("新プロジェクト")
+  })
+
+  it("元のオブジェクトを変更しない（イミュータブル）", () => {
+    const config = { defaultProject: "元のプロジェクト" }
+    setConfigValue(config, "defaultProject", "新プロジェクト")
+    expect(config.defaultProject).toBe("元のプロジェクト")
+  })
+
+  it("スキーマに合わない値はエラーをスローする", () => {
+    const config = {}
+    // output.color は "auto"|"always"|"never" のみ許可
+    expect(() => setConfigValue(config, "output.color", "invalid")).toThrow()
+  })
+})

--- a/tests/unit/infra/keychain-file.test.ts
+++ b/tests/unit/infra/keychain-file.test.ts
@@ -1,0 +1,58 @@
+/**
+ * keychain-file.test.ts — ファイルベース TokenStore のテスト。
+ */
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { FileTokenStore } from "@/infra/keychain/file"
+
+const tmpFile = join(tmpdir(), `coscli-test-secrets-${Date.now()}.json`)
+
+describe("FileTokenStore", () => {
+  afterEach(() => {
+    if (existsSync(tmpFile)) unlinkSync(tmpFile)
+  })
+
+  it("セッション ID を保存して取得できる", async () => {
+    const store = new FileTokenStore(tmpFile)
+    await store.save("default", "test-sid-12345")
+    expect(await store.load("default")).toBe("test-sid-12345")
+  })
+
+  it("存在しないプロファイルは null を返す", async () => {
+    const store = new FileTokenStore(tmpFile)
+    expect(await store.load("nonexistent")).toBeNull()
+  })
+
+  it("削除後は null を返す", async () => {
+    const store = new FileTokenStore(tmpFile)
+    await store.save("default", "test-sid")
+    await store.delete("default")
+    expect(await store.load("default")).toBeNull()
+  })
+
+  it("複数プロファイルを独立して管理できる", async () => {
+    const store = new FileTokenStore(tmpFile)
+    await store.save("個人アカウント", "sid-personal")
+    await store.save("仕事アカウント", "sid-work")
+    expect(await store.load("個人アカウント")).toBe("sid-personal")
+    expect(await store.load("仕事アカウント")).toBe("sid-work")
+  })
+
+  it("プロファイル一覧を取得できる", async () => {
+    const store = new FileTokenStore(tmpFile)
+    await store.save("個人アカウント", "sid-personal")
+    await store.save("仕事アカウント", "sid-work")
+    const profiles = await store.list()
+    expect(profiles).toContain("個人アカウント")
+    expect(profiles).toContain("仕事アカウント")
+  })
+
+  it("ファイルが存在しない場合は空リストを返す", async () => {
+    const store = new FileTokenStore(tmpFile)
+    const profiles = await store.list()
+    expect(profiles).toHaveLength(0)
+  })
+})

--- a/tests/unit/presenter/json.test.ts
+++ b/tests/unit/presenter/json.test.ts
@@ -1,0 +1,165 @@
+/**
+ * json.test.ts — presenter/json の単体テスト。
+ *
+ * writeJson / writeErrorJson は出力先 stream を差し替えて検証する。
+ * applySelect は純粋関数なので直接テストする。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { applySelect, writeErrorJson, writeJson } from "@/presenter/json"
+
+/** WritableStream の代わりに文字列を収集するモックストリーム */
+function createMockStream() {
+  let buffer = ""
+  return {
+    write(chunk: string) {
+      buffer += chunk
+    },
+    get output(): string {
+      return buffer
+    },
+  }
+}
+
+describe("writeJson", () => {
+  it("data と meta を含む envelope を出力する", () => {
+    const stream = createMockStream()
+    writeJson(
+      { name: "テストユーザー" },
+      { command: "auth.whoami", startTime: Date.now() },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.data).toEqual({ name: "テストユーザー" })
+    expect(parsed.meta.command).toBe("auth.whoami")
+    expect(typeof parsed.meta.durationMs).toBe("number")
+    expect(typeof parsed.meta.requestId).toBe("string")
+    expect(parsed.meta.warnings).toEqual([])
+  })
+
+  it("warnings が指定されている場合は meta.warnings に含める", () => {
+    const stream = createMockStream()
+    writeJson(
+      {},
+      { command: "page.list", startTime: Date.now(), warnings: ["ページ数が多いです"] },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.meta.warnings).toEqual(["ページ数が多いです"])
+  })
+
+  it("resultsOnly=true の場合は data だけを出力する", () => {
+    const stream = createMockStream()
+    writeJson(
+      [{ title: "ページ1" }, { title: "ページ2" }],
+      { command: "page.list", startTime: Date.now() },
+      { stream: stream as unknown as NodeJS.WritableStream, resultsOnly: true },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed[0].title).toBe("ページ1")
+  })
+
+  it("select を指定するとデータを絞り込んで出力する", () => {
+    const stream = createMockStream()
+    writeJson(
+      { pages: [{ title: "タイトルA" }, { title: "タイトルB" }] },
+      { command: "page.list", startTime: Date.now() },
+      { stream: stream as unknown as NodeJS.WritableStream, select: "pages[].title" },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed).toEqual(["タイトルA", "タイトルB"])
+  })
+
+  it("resultsOnly + select を組み合わせると data に select を適用する", () => {
+    const stream = createMockStream()
+    writeJson(
+      { pages: [{ title: "タイトルC" }], total: 1 },
+      { command: "page.list", startTime: Date.now() },
+      {
+        stream: stream as unknown as NodeJS.WritableStream,
+        resultsOnly: true,
+        select: "pages[].title",
+      },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed).toEqual(["タイトルC"])
+  })
+})
+
+describe("writeErrorJson", () => {
+  it("error フィールドを含む JSON を出力する", () => {
+    const stream = createMockStream()
+    writeErrorJson(
+      "NOT_FOUND",
+      "ページが見つかりません",
+      undefined,
+      stream as unknown as NodeJS.WritableStream,
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.error.code).toBe("NOT_FOUND")
+    expect(parsed.error.message).toBe("ページが見つかりません")
+    expect(parsed.error.hint).toBeUndefined()
+  })
+
+  it("hint が指定されている場合は error.hint を含める", () => {
+    const stream = createMockStream()
+    writeErrorJson(
+      "AUTH_FAILED",
+      "認証に失敗しました",
+      "`cos auth login` を実行してください",
+      stream as unknown as NodeJS.WritableStream,
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.error.hint).toBe("`cos auth login` を実行してください")
+  })
+})
+
+describe("applySelect", () => {
+  const data = {
+    pages: [
+      { title: "ページA", author: "山田太郎" },
+      { title: "ページB", author: "鈴木花子" },
+    ],
+    total: 2,
+  }
+
+  it("selector が undefined の場合はデータをそのまま返す", () => {
+    expect(applySelect(data, undefined)).toBe(data)
+  })
+
+  it("トップレベルのキーを取得できる", () => {
+    expect(applySelect(data, "total")).toBe(2)
+  })
+
+  it("ネストしたキーをドット区切りで取得できる", () => {
+    const nested = { a: { b: { c: "深い値" } } }
+    expect(applySelect(nested, "a.b.c")).toBe("深い値")
+  })
+
+  it("pages[] で配列を取得できる", () => {
+    const result = applySelect(data, "pages[]")
+    expect(Array.isArray(result)).toBe(true)
+    expect((result as unknown[]).length).toBe(2)
+  })
+
+  it("pages[].title で配列の各要素のプロパティを取得できる", () => {
+    expect(applySelect(data, "pages[].title")).toEqual(["ページA", "ページB"])
+  })
+
+  it("pages[].author で配列の各要素の別プロパティを取得できる", () => {
+    expect(applySelect(data, "pages[].author")).toEqual(["山田太郎", "鈴木花子"])
+  })
+
+  it("存在しないキーは undefined を返す", () => {
+    expect(applySelect(data, "存在しないキー")).toBeUndefined()
+  })
+
+  it("配列でない値に [] を適用すると undefined を返す", () => {
+    expect(applySelect(data, "total[]")).toBeUndefined()
+  })
+
+  it("null データに対してはundefined を返す", () => {
+    expect(applySelect(null, "pages")).toBeUndefined()
+  })
+})

--- a/tests/unit/presenter/plain.test.ts
+++ b/tests/unit/presenter/plain.test.ts
@@ -1,0 +1,103 @@
+/**
+ * plain.test.ts — presenter/plain の単体テスト。
+ *
+ * cli-table3 を使ったテーブル出力と TSV 出力を検証する。
+ * 出力先 stream を差し替えて副作用なしにテストする。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { writePlainList, writePlainTable, writeTsv } from "@/presenter/plain"
+
+/** WritableStream の代わりに文字列を収集するモックストリーム */
+function createMockStream() {
+  let buffer = ""
+  return {
+    write(chunk: string) {
+      buffer += chunk
+    },
+    get output(): string {
+      return buffer
+    },
+  }
+}
+
+describe("writePlainTable", () => {
+  it("ヘッダーと行データをテーブル形式で出力する", () => {
+    const stream = createMockStream()
+    writePlainTable(
+      ["タイトル", "更新日時"],
+      [
+        ["ページA", "2024-01-01"],
+        ["ページB", "2024-06-15"],
+      ],
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    expect(stream.output).toContain("タイトル")
+    expect(stream.output).toContain("更新日時")
+    expect(stream.output).toContain("ページA")
+    expect(stream.output).toContain("ページB")
+  })
+
+  it("空のデータでも出力が崩れない", () => {
+    const stream = createMockStream()
+    writePlainTable(["タイトル", "件数"], [], {
+      stream: stream as unknown as NodeJS.WritableStream,
+    })
+    expect(stream.output).toContain("タイトル")
+  })
+})
+
+describe("writeTsv", () => {
+  it("ヘッダー付きの TSV を出力する", () => {
+    const stream = createMockStream()
+    writeTsv(
+      ["プロジェクト", "ページ数"],
+      [
+        ["マイプロジェクト", "42"],
+        ["別プロジェクト", "10"],
+      ],
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const lines = stream.output.split("\n").filter((l) => l.length > 0)
+    expect(lines[0]).toBe("プロジェクト\tページ数")
+    expect(lines[1]).toBe("マイプロジェクト\t42")
+    expect(lines[2]).toBe("別プロジェクト\t10")
+  })
+
+  it("noHeader=true の場合はヘッダー行を出力しない", () => {
+    const stream = createMockStream()
+    writeTsv(["タイトル"], [["ページX"]], {
+      stream: stream as unknown as NodeJS.WritableStream,
+      noHeader: true,
+    })
+    const lines = stream.output.split("\n").filter((l) => l.length > 0)
+    expect(lines.length).toBe(1)
+    expect(lines[0]).toBe("ページX")
+  })
+
+  it("タブを含むセル値はエスケープされる", () => {
+    const stream = createMockStream()
+    writeTsv(["タイトル"], [["タブ\t含む"]], {
+      stream: stream as unknown as NodeJS.WritableStream,
+      noHeader: true,
+    })
+    expect(stream.output).toContain("タブ\\t含む")
+  })
+})
+
+describe("writePlainList", () => {
+  it("各要素を1行ずつ出力する", () => {
+    const stream = createMockStream()
+    writePlainList(["ページA", "ページB", "ページC"], {
+      stream: stream as unknown as NodeJS.WritableStream,
+    })
+    const lines = stream.output.split("\n").filter((l) => l.length > 0)
+    expect(lines).toEqual(["ページA", "ページB", "ページC"])
+  })
+
+  it("空配列の場合は何も出力しない", () => {
+    const stream = createMockStream()
+    writePlainList([], { stream: stream as unknown as NodeJS.WritableStream })
+    expect(stream.output).toBe("")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI `cos` の v0.1 MVP 実装
- TypeScript + Bun ランタイム、`bun build --compile` で単一バイナリ配布対応
- TDD (RED→GREEN→REFACTOR) で全実装済み (テスト 105件)

## 実装内容

### コマンド
- **page**: list / get / text / code / url / new / edit / append / delete
- **project**: list / info
- **search**: キーワード検索
- **auth**: login / logout / whoami
- **config**: get / set / path

### AI エージェント向け機能
- `--enable-commands` / `--disable-commands` による sandbox ポリシー制御 (exit 7)
- JSON 出力: `{data, meta}` envelope形式 + `--results-only` + `--select` セレクタ
- `--dry-run`: 書き込み系コマンドで変更プレビューのみ
- 構造化エラー: `{error: {code, message, hint}}` + 終了コード体系

### インフラ
- OS keychain 認証 (macOS/Linux/Windows) + file fallback
- `~/.config/coscli/config.json5` による JSON5 設定ファイル
- picocolors によるカラー出力 (auto/always/never)

## Test plan
- [x] `bun test` — 105件パス
- [x] `bunx biome ci` — Lint エラー 0
- [x] `bun run typecheck` — 型エラー 0
- [x] `bun build --compile` — dist/cos バイナリ動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)