### PR TITLE
v0.2 Phase B: CI マトリクス整備とインテグレーションテスト追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.13"
 
       - name: 依存パッケージのインストール
         run: bun install --frozen-lockfile
@@ -34,13 +34,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.13"
 
       - name: 依存パッケージのインストール
         run: bun install --frozen-lockfile
 
+      # 統合テストが混入しないようにテストパスを明示指定する
       - name: ユニットテスト実行 (カバレッジあり)
-        run: bun test --coverage
+        run: bun test tests/unit/ src/ --coverage
 
   integration-test:
     name: インテグレーションテスト (${{ matrix.os }})
@@ -54,19 +55,21 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.13"
 
       - name: 依存パッケージのインストール
         run: bun install --frozen-lockfile
 
-      # Linux: libsecret + gnome-keyring のセットアップ
-      - name: gnome-keyring セットアップ (Linux)
+      # Linux: libsecret + gnome-keyring のセットアップとインテグレーションテストを同一ステップで実行。
+      # gnome-keyring-daemon はステップ終了で停止するため、テストも同一シェルセッション内で実行する必要がある。
+      - name: インテグレーションテスト実行 (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
-          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+          bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール
       - name: CredentialManager セットアップ (Windows)
@@ -76,5 +79,6 @@ jobs:
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module CredentialManager -Scope CurrentUser -Force
 
-      - name: インテグレーションテスト実行
+      - name: インテグレーションテスト実行 (macOS / Windows)
+        if: matrix.os != 'ubuntu-latest'
         run: bun test tests/integration/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
           sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
           eval $(echo "" | gnome-keyring-daemon --unlock --components=secrets)
+          echo "=== secret-tool search 動作確認 ==="
+          echo "test-sid" | secret-tool store --label=debug service coscli account debug-test && echo "store OK" || echo "store FAILED"
+          echo "--- search --all 出力 ---"
+          secret-tool search --all service coscli; echo "search exit: $?"
+          echo "--- search (--all なし) 出力 ---"
+          secret-tool search service coscli account debug-test; echo "search-single exit: $?"
+          echo "=================================="
           bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,18 +62,16 @@ jobs:
 
       # Linux: libsecret + gnome-keyring のセットアップとインテグレーションテストを同一ステップで実行。
       # gnome-keyring-daemon はステップ終了で停止するため、テストも同一シェルセッション内で実行する必要がある。
-      # --start: デーモンプロセスを起動して GNOME_KEYRING_CONTROL 等の環境変数を出力する。
-      #          ただし "login" コレクションは作成しないため、単独では secret-tool store が失敗する。
-      # --unlock: stdin から空パスワードを読み込み "login" コレクションを作成・アンロックする。
-      #           CI 環境では既存コレクションが存在しないため --start の後に必ず実行する。
+      # --unlock: stdin から空パスワードを読み込み "login" コレクションを作成・アンロックし、
+      #           GNOME_KEYRING_CONTROL 等の環境変数を stdout に出力する。eval $() で取り込む必要がある。
+      #           --start は "login" コレクションを作成しないため使用しない。
       - name: インテグレーションテスト実行 (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
-          eval $(gnome-keyring-daemon --start --components=secrets)
-          echo -n "" | gnome-keyring-daemon --unlock
+          eval $(echo "" | gnome-keyring-daemon --unlock --components=secrets)
           bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  ci:
-    name: Lint / Type Check / Test
+  lint-typecheck:
+    name: Lint / 型チェック
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,5 +26,55 @@ jobs:
       - name: 型チェック
         run: bun run typecheck
 
-      - name: テスト実行
+  unit-test:
+    name: ユニットテスト
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 依存パッケージのインストール
+        run: bun install --frozen-lockfile
+
+      - name: ユニットテスト実行 (カバレッジあり)
         run: bun test --coverage
+
+  integration-test:
+    name: インテグレーションテスト (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 依存パッケージのインストール
+        run: bun install --frozen-lockfile
+
+      # Linux: libsecret + gnome-keyring のセットアップ
+      - name: gnome-keyring セットアップ (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools
+          eval $(dbus-launch --sh-syntax)
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+
+      # Windows: CredentialManager PowerShell モジュールのインストール
+      - name: CredentialManager セットアップ (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module CredentialManager -Scope CurrentUser -Force
+
+      - name: インテグレーションテスト実行
+        run: bun test tests/integration/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,10 @@ jobs:
           eval $(echo "" | gnome-keyring-daemon --unlock --components=secrets)
           echo "=== secret-tool search 動作確認 ==="
           echo "test-sid" | secret-tool store --label=debug service coscli account debug-test && echo "store OK" || echo "store FAILED"
-          echo "--- search --all 出力 ---"
-          secret-tool search --all service coscli; echo "search exit: $?"
-          echo "--- search (--all なし) 出力 ---"
-          secret-tool search service coscli account debug-test; echo "search-single exit: $?"
+          echo "--- stdout のみ ---"
+          secret-tool search --all service coscli 2>/dev/null; echo "stdout exit: $?"
+          echo "--- stderr のみ ---"
+          secret-tool search --all service coscli 2>&1 1>/dev/null; echo "stderr exit: $?"
           echo "=================================="
           bun test tests/integration/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
 
       # Linux: libsecret + gnome-keyring のセットアップとインテグレーションテストを同一ステップで実行。
       # gnome-keyring-daemon はステップ終了で停止するため、テストも同一シェルセッション内で実行する必要がある。
-      # --start: デーモンを起動して login コレクションが存在しない場合は新規作成する。
-      # --unlock では既存コレクションを前提とするため CI 環境では --start を使用する。
+      # --start: デーモンプロセスを起動して GNOME_KEYRING_CONTROL 等の環境変数を出力する。
+      #          ただし "login" コレクションは作成しないため、単独では secret-tool store が失敗する。
+      # --unlock: stdin から空パスワードを読み込み "login" コレクションを作成・アンロックする。
+      #           CI 環境では既存コレクションが存在しないため --start の後に必ず実行する。
       - name: インテグレーションテスト実行 (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -71,6 +73,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
           eval $(gnome-keyring-daemon --start --components=secrets)
+          echo -n "" | gnome-keyring-daemon --unlock
           bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,15 @@ jobs:
 
       # Linux: libsecret + gnome-keyring のセットアップとインテグレーションテストを同一ステップで実行。
       # gnome-keyring-daemon はステップ終了で停止するため、テストも同一シェルセッション内で実行する必要がある。
+      # --start: デーモンを起動して login コレクションが存在しない場合は新規作成する。
+      # --unlock では既存コレクションを前提とするため CI 環境では --start を使用する。
       - name: インテグレーションテスト実行 (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
-          echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+          eval $(gnome-keyring-daemon --start --components=secrets)
           bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
           eval $(dbus-launch --sh-syntax)
           eval $(echo "" | gnome-keyring-daemon --unlock --components=secrets)
-          echo "=== secret-tool search 動作確認 ==="
-          echo "test-sid" | secret-tool store --label=debug service coscli account debug-test && echo "store OK" || echo "store FAILED"
-          echo "--- stdout のみ ---"
-          secret-tool search --all service coscli 2>/dev/null; echo "stdout exit: $?"
-          echo "--- stderr のみ ---"
-          secret-tool search --all service coscli 2>&1 1>/dev/null; echo "stderr exit: $?"
-          echo "=================================="
           bun test tests/integration/
 
       # Windows: CredentialManager PowerShell モジュールのインストール

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,5 +2,5 @@
 # カバレッジ設定
 coverage = true
 coverageThreshold = { line = 80, function = 80 }
-# テストファイルのパターン
-include = ["tests/**/*.test.ts", "src/**/*.test.ts"]
+# デフォルトはユニットテストのみ実行。インテグレーションテストは bun test tests/integration/ で個別実行
+include = ["tests/unit/**/*.test.ts", "src/**/*.test.ts"]

--- a/src/infra/keychain/linux.ts
+++ b/src/infra/keychain/linux.ts
@@ -97,11 +97,17 @@ export class LinuxKeychainStore implements TokenStore {
       if (isENOENT(e)) throw new Error(SECRET_TOOL_NOT_FOUND_MESSAGE)
       throw e
     }
-    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    // libsecret 0.21+ (Ubuntu 24.04) では attribute.* 行が stderr に出力される。
+    // 0.20 以前は stdout に出力されるため、後方互換性のため両方を検索する。
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
     if (exitCode !== 0) return []
 
     const profiles: string[] = []
-    for (const line of stdout.split("\n")) {
+    for (const line of `${stdout}\n${stderr}`.split("\n")) {
       const match = line.match(/attribute\.account\s*=\s*(.+)/)
       if (match?.[1]) profiles.push(match[1].trim())
     }

--- a/src/infra/keychain/macos.ts
+++ b/src/infra/keychain/macos.ts
@@ -63,6 +63,8 @@ export class MacOSKeychainStore implements TokenStore {
     // 各ブロック内で "acct" は "svce" より前に出力されるためブロック単位でパースする。
     const profiles: string[] = []
     const blocks = result.stdout.split(/^keychain:/m)
+    // TextDecoder はループ外で 1 度だけ生成して使い回す
+    const decoder = new TextDecoder()
 
     for (const block of blocks) {
       if (!block.includes(`"svce"<blob>="${SERVICE}"`)) continue
@@ -77,10 +79,13 @@ export class MacOSKeychainStore implements TokenStore {
       // 16進数形式: "acct"<blob>=0xHEX (非 ASCII 文字列の UTF-8 バイト列表現)
       const hexMatch = block.match(/"acct"<blob>=0x([0-9A-Fa-f]+)/)
       if (hexMatch?.[1]) {
-        const pairs = hexMatch[1].match(/.{2}/g)
+        const hex = hexMatch[1]
+        // 奇数長の場合は不正な hex としてスキップ
+        if (hex.length % 2 !== 0) continue
+        const pairs = hex.match(/.{2}/g)
         if (pairs) {
           const bytes = pairs.map((h) => Number.parseInt(h, 16))
-          profiles.push(new TextDecoder().decode(new Uint8Array(bytes)))
+          profiles.push(decoder.decode(new Uint8Array(bytes)))
         }
       }
     }

--- a/src/infra/keychain/macos.ts
+++ b/src/infra/keychain/macos.ts
@@ -56,23 +56,31 @@ export class MacOSKeychainStore implements TokenStore {
   }
 
   async list(): Promise<string[]> {
-    // security コマンドでサービス名を指定して全アカウント名を取得する
     const result = await this.run(["security", "dump-keychain"])
     if (!result.success) return []
 
-    const lines = result.stdout.split("\n")
+    // dump-keychain の出力は "keychain:" 行でエントリが区切られる。
+    // 各ブロック内で "acct" は "svce" より前に出力されるためブロック単位でパースする。
     const profiles: string[] = []
-    let inCosenseEntry = false
+    const blocks = result.stdout.split(/^keychain:/m)
 
-    for (const line of lines) {
-      if (line.includes(`"svce"<blob>="${SERVICE}"`)) {
-        inCosenseEntry = true
+    for (const block of blocks) {
+      if (!block.includes(`"svce"<blob>="${SERVICE}"`)) continue
+
+      // ASCII 形式: "acct"<blob>="account-name"
+      const quotedMatch = block.match(/"acct"<blob>="([^"]+)"/)
+      if (quotedMatch?.[1]) {
+        profiles.push(quotedMatch[1])
+        continue
       }
-      if (inCosenseEntry && line.includes('"acct"<blob>=')) {
-        const match = line.match(/"acct"<blob>="([^"]+)"/)
-        if (match?.[1]) {
-          profiles.push(match[1])
-          inCosenseEntry = false
+
+      // 16進数形式: "acct"<blob>=0xHEX (非 ASCII 文字列の UTF-8 バイト列表現)
+      const hexMatch = block.match(/"acct"<blob>=0x([0-9A-Fa-f]+)/)
+      if (hexMatch?.[1]) {
+        const pairs = hexMatch[1].match(/.{2}/g)
+        if (pairs) {
+          const bytes = pairs.map((h) => Number.parseInt(h, 16))
+          profiles.push(new TextDecoder().decode(new Uint8Array(bytes)))
         }
       }
     }

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -129,7 +129,8 @@ export class WindowsKeychainStore implements TokenStore {
     const prefix = `${SERVICE}:`
     const profiles: string[] = []
     for (const line of stdout.split("\n")) {
-      const match = line.match(/Target:\s*(.+)/)
+      // Windows Server 2022 等では "LegacyGeneric:target=<actual>" 形式で出力される場合がある
+      const match = line.match(/Target:\s*(?:LegacyGeneric:target=)?(.+)/)
       if (match?.[1]) {
         const target = match[1].trim()
         if (target.startsWith(prefix)) {

--- a/tests/integration/keychain-cmdkey.test.ts
+++ b/tests/integration/keychain-cmdkey.test.ts
@@ -1,0 +1,87 @@
+/**
+ * keychain-cmdkey.test.ts — Windows cmdkey + CredentialManager を使った実インテグレーションテスト。
+ *
+ * このテストは Windows 環境でのみ実行されます。他の OS では自動的にスキップします。
+ * 実行前提:
+ *   - cmdkey コマンドが利用可能 (Windows 7 以降で標準提供)
+ *   - CredentialManager PowerShell モジュールがインストール済み
+ *     (Install-Module CredentialManager -Scope CurrentUser)
+ *
+ * CI セットアップ例:
+ *   Install-Module CredentialManager -Scope CurrentUser -Force
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import { WindowsKeychainStore } from "@/infra/keychain/windows"
+
+// Windows 以外ではスキップ
+const describeSuite = process.platform === "win32" ? describe : describe.skip
+
+describeSuite(
+  "WindowsKeychainStore インテグレーションテスト (cmdkey + CredentialManager 使用)",
+  () => {
+    // 他の Credential Manager エントリと衝突しない一意なプロファイル名を使用
+    const TEST_PROFILE = "cos-integration-test-山田太郎"
+    const TEST_SID = "test-session-id-abcdef123456"
+    const store = new WindowsKeychainStore()
+
+    beforeAll(async () => {
+      // テスト前にエントリが残っていれば削除してクリーンな状態にする
+      await store.delete(TEST_PROFILE)
+    })
+
+    afterAll(async () => {
+      // テスト後のクリーンアップ
+      await store.delete(TEST_PROFILE)
+    })
+
+    it("save してから load で同じ SID を取得できる", async () => {
+      // 前提: プロファイルが存在しない
+      await store.save(TEST_PROFILE, TEST_SID)
+      const loaded = await store.load(TEST_PROFILE)
+      // 検証: 保存した SID が正確に復元される
+      expect(loaded).toBe(TEST_SID)
+    })
+
+    it("save を 2 回呼んでも上書きされる（update 動作）", async () => {
+      const newSid = "test-session-id-updated-999"
+      // 前提: 既存エントリがある
+      await store.save(TEST_PROFILE, TEST_SID)
+
+      await store.save(TEST_PROFILE, newSid)
+      const loaded = await store.load(TEST_PROFILE)
+      // 検証: 最新の SID に更新されている
+      expect(loaded).toBe(newSid)
+    })
+
+    it("list で保存したプロファイルが含まれる", async () => {
+      // 前提: プロファイルが保存済み
+      await store.save(TEST_PROFILE, TEST_SID)
+      const profiles = await store.list()
+      // 検証: list にテストプロファイルが含まれる
+      expect(profiles).toContain(TEST_PROFILE)
+    })
+
+    it("delete 後に load すると null を返す", async () => {
+      // 前提: プロファイルが存在する
+      await store.save(TEST_PROFILE, TEST_SID)
+
+      await store.delete(TEST_PROFILE)
+      const loaded = await store.load(TEST_PROFILE)
+      // 検証: 削除後は null
+      expect(loaded).toBeNull()
+    })
+
+    it("存在しないプロファイルの load は null を返す", async () => {
+      // 前提: 存在しないプロファイル名を使用
+      const loaded = await store.load("cos-integration-test-存在しないユーザー")
+      // 検証: null を返す（エラーにならない）
+      expect(loaded).toBeNull()
+    })
+
+    it("存在しないプロファイルの delete はエラーにならない", async () => {
+      // 検証: delete は存在しなくても例外を投げない
+      await expect(store.delete("cos-integration-test-存在しないユーザー")).resolves.toBeUndefined()
+    })
+  },
+)

--- a/tests/integration/keychain-cmdkey.test.ts
+++ b/tests/integration/keychain-cmdkey.test.ts
@@ -23,9 +23,11 @@ describeSuite(
     // 他の Credential Manager エントリと衝突しない一意なプロファイル名を使用
     const TEST_PROFILE = "cos-integration-test-山田太郎"
     const TEST_SID = "test-session-id-abcdef123456"
-    const store = new WindowsKeychainStore()
+    // describe.skip でも callback は評価されるため、store の生成は beforeAll に移動する
+    let store: WindowsKeychainStore
 
     beforeAll(async () => {
+      store = new WindowsKeychainStore()
       // テスト前にエントリが残っていれば削除してクリーンな状態にする
       await store.delete(TEST_PROFILE)
     })

--- a/tests/integration/keychain-secret-tool.test.ts
+++ b/tests/integration/keychain-secret-tool.test.ts
@@ -1,0 +1,85 @@
+/**
+ * keychain-secret-tool.test.ts — Linux secret-tool (libsecret) を使った実インテグレーションテスト。
+ *
+ * このテストは Linux 環境でのみ実行されます。他の OS では自動的にスキップします。
+ * 実行前提:
+ *   - secret-tool コマンドがインストール済み (apt: libsecret-tools)
+ *   - GNOME Keyring デーモンが起動済み (DBUS_SESSION_BUS_ADDRESS が設定されている)
+ *
+ * CI セットアップ例:
+ *   sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools
+ *   eval $(dbus-launch --sh-syntax)
+ *   echo -n "" | gnome-keyring-daemon --unlock --components=secrets
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import { LinuxKeychainStore } from "@/infra/keychain/linux"
+
+// Linux 以外ではスキップ
+const describeSuite = process.platform === "linux" ? describe : describe.skip
+
+describeSuite("LinuxKeychainStore インテグレーションテスト (secret-tool 使用)", () => {
+  // 他の Secret Service エントリと衝突しない一意なプロファイル名を使用
+  const TEST_PROFILE = "cos-integration-test-山田太郎"
+  const TEST_SID = "test-session-id-abcdef123456"
+  const store = new LinuxKeychainStore()
+
+  beforeAll(async () => {
+    // テスト前にエントリが残っていれば削除してクリーンな状態にする
+    await store.delete(TEST_PROFILE)
+  })
+
+  afterAll(async () => {
+    // テスト後のクリーンアップ
+    await store.delete(TEST_PROFILE)
+  })
+
+  it("save してから load で同じ SID を取得できる", async () => {
+    // 前提: プロファイルが存在しない
+    await store.save(TEST_PROFILE, TEST_SID)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 保存した SID が正確に復元される
+    expect(loaded).toBe(TEST_SID)
+  })
+
+  it("save を 2 回呼んでも上書きされる（update 動作）", async () => {
+    const newSid = "test-session-id-updated-999"
+    // 前提: 既存エントリがある
+    await store.save(TEST_PROFILE, TEST_SID)
+
+    await store.save(TEST_PROFILE, newSid)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 最新の SID に更新されている
+    expect(loaded).toBe(newSid)
+  })
+
+  it("list で保存したプロファイルが含まれる", async () => {
+    // 前提: プロファイルが保存済み
+    await store.save(TEST_PROFILE, TEST_SID)
+    const profiles = await store.list()
+    // 検証: list にテストプロファイルが含まれる
+    expect(profiles).toContain(TEST_PROFILE)
+  })
+
+  it("delete 後に load すると null を返す", async () => {
+    // 前提: プロファイルが存在する
+    await store.save(TEST_PROFILE, TEST_SID)
+
+    await store.delete(TEST_PROFILE)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 削除後は null
+    expect(loaded).toBeNull()
+  })
+
+  it("存在しないプロファイルの load は null を返す", async () => {
+    // 前提: 存在しないプロファイル名を使用
+    const loaded = await store.load("cos-integration-test-存在しないユーザー")
+    // 検証: null を返す（エラーにならない）
+    expect(loaded).toBeNull()
+  })
+
+  it("存在しないプロファイルの delete はエラーにならない", async () => {
+    // 検証: delete は存在しなくても例外を投げない
+    await expect(store.delete("cos-integration-test-存在しないユーザー")).resolves.toBeUndefined()
+  })
+})

--- a/tests/integration/keychain-secret-tool.test.ts
+++ b/tests/integration/keychain-secret-tool.test.ts
@@ -7,7 +7,7 @@
  *   - GNOME Keyring デーモンが起動済み (DBUS_SESSION_BUS_ADDRESS が設定されている)
  *
  * CI セットアップ例:
- *   sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools
+ *   sudo apt-get install -y --no-install-recommends gnome-keyring dbus-x11 libsecret-tools
  *   eval $(dbus-launch --sh-syntax)
  *   echo -n "" | gnome-keyring-daemon --unlock --components=secrets
  */
@@ -22,9 +22,11 @@ describeSuite("LinuxKeychainStore インテグレーションテスト (secret-t
   // 他の Secret Service エントリと衝突しない一意なプロファイル名を使用
   const TEST_PROFILE = "cos-integration-test-山田太郎"
   const TEST_SID = "test-session-id-abcdef123456"
-  const store = new LinuxKeychainStore()
+  // describe.skip でも callback は評価されるため、store の生成は beforeAll に移動する
+  let store: LinuxKeychainStore
 
   beforeAll(async () => {
+    store = new LinuxKeychainStore()
     // テスト前にエントリが残っていれば削除してクリーンな状態にする
     await store.delete(TEST_PROFILE)
   })

--- a/tests/integration/keychain-security.test.ts
+++ b/tests/integration/keychain-security.test.ts
@@ -1,0 +1,79 @@
+/**
+ * keychain-security.test.ts — macOS security コマンドを使った実インテグレーションテスト。
+ *
+ * このテストは macOS 環境でのみ実行されます。他の OS では自動的にスキップします。
+ * 実際の Keychain に対して save / load / delete / list 操作を行い、
+ * 往復動作（round-trip）を検証します。
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import { MacOSKeychainStore } from "@/infra/keychain/macos"
+
+// macOS 以外ではスキップ
+const describeSuite = process.platform === "darwin" ? describe : describe.skip
+
+describeSuite("MacOSKeychainStore インテグレーションテスト (security コマンド使用)", () => {
+  // 他の Keychain エントリと衝突しない一意なプロファイル名を使用
+  const TEST_PROFILE = "cos-integration-test-山田太郎"
+  const TEST_SID = "test-session-id-abcdef123456"
+  const store = new MacOSKeychainStore()
+
+  beforeAll(async () => {
+    // テスト前にエントリが残っていれば削除してクリーンな状態にする
+    await store.delete(TEST_PROFILE)
+  })
+
+  afterAll(async () => {
+    // テスト後のクリーンアップ
+    await store.delete(TEST_PROFILE)
+  })
+
+  it("save してから load で同じ SID を取得できる", async () => {
+    // 前提: プロファイルが存在しない
+    await store.save(TEST_PROFILE, TEST_SID)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 保存した SID が正確に復元される
+    expect(loaded).toBe(TEST_SID)
+  })
+
+  it("save を 2 回呼んでも上書きされる（update 動作）", async () => {
+    const newSid = "test-session-id-updated-999"
+    // 前提: 既存エントリがある
+    await store.save(TEST_PROFILE, TEST_SID)
+
+    await store.save(TEST_PROFILE, newSid)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 最新の SID に更新されている
+    expect(loaded).toBe(newSid)
+  })
+
+  it("list で保存したプロファイルが含まれる", async () => {
+    // 前提: プロファイルが保存済み
+    await store.save(TEST_PROFILE, TEST_SID)
+    const profiles = await store.list()
+    // 検証: list にテストプロファイルが含まれる
+    expect(profiles).toContain(TEST_PROFILE)
+  })
+
+  it("delete 後に load すると null を返す", async () => {
+    // 前提: プロファイルが存在する
+    await store.save(TEST_PROFILE, TEST_SID)
+
+    await store.delete(TEST_PROFILE)
+    const loaded = await store.load(TEST_PROFILE)
+    // 検証: 削除後は null
+    expect(loaded).toBeNull()
+  })
+
+  it("存在しないプロファイルの load は null を返す", async () => {
+    // 前提: 存在しないプロファイル名を使用
+    const loaded = await store.load("cos-integration-test-存在しないユーザー")
+    // 検証: null を返す（エラーにならない）
+    expect(loaded).toBeNull()
+  })
+
+  it("存在しないプロファイルの delete はエラーにならない", async () => {
+    // 検証: delete は存在しなくても例外を投げない
+    await expect(store.delete("cos-integration-test-存在しないユーザー")).resolves.toBeUndefined()
+  })
+})

--- a/tests/integration/keychain-security.test.ts
+++ b/tests/integration/keychain-security.test.ts
@@ -16,9 +16,11 @@ describeSuite("MacOSKeychainStore インテグレーションテスト (security
   // 他の Keychain エントリと衝突しない一意なプロファイル名を使用
   const TEST_PROFILE = "cos-integration-test-山田太郎"
   const TEST_SID = "test-session-id-abcdef123456"
-  const store = new MacOSKeychainStore()
+  // describe.skip でも callback は評価されるため、store の生成は beforeAll に移動する
+  let store: MacOSKeychainStore
 
   beforeAll(async () => {
+    store = new MacOSKeychainStore()
     // テスト前にエントリが残っていれば削除してクリーンな状態にする
     await store.delete(TEST_PROFILE)
   })

--- a/tests/unit/infra/keychain-linux.test.ts
+++ b/tests/unit/infra/keychain-linux.test.ts
@@ -104,7 +104,40 @@ describe("LinuxKeychainStore", () => {
   })
 
   describe("list", () => {
-    it("secret-tool search --all の出力をパースしてプロファイル一覧を返す", async () => {
+    it("libsecret 0.21+ (Ubuntu 24.04): attribute.* が stderr に出力されるフォーマットをパースする", async () => {
+      // libsecret 0.21+ では attribute.* 行は stderr、その他は stdout に出力される
+      const stdoutOutput = [
+        "[/1]",
+        "label = coscli",
+        "secret = ",
+        "",
+        "created = 2024-01-01 00:00:00",
+        "modified = 2024-01-01 00:00:00",
+        "",
+        "[/2]",
+        "label = coscli",
+        "secret = ",
+        "",
+        "created = 2024-01-01 00:00:00",
+        "modified = 2024-01-01 00:00:00",
+      ].join("\n")
+      const stderrOutput = [
+        "attribute.service = coscli",
+        "attribute.account = 個人アカウント",
+        "attribute.service = coscli",
+        "attribute.account = 仕事アカウント",
+      ].join("\n")
+
+      const { spawner } = captureSpawner(stdoutOutput, stderrOutput, 0)
+      const store = new LinuxKeychainStore(spawner)
+      const profiles = await store.list()
+
+      expect(profiles).toContain("個人アカウント")
+      expect(profiles).toContain("仕事アカウント")
+    })
+
+    it("libsecret 0.20 以前: attribute.* が stdout に出力されるフォーマットもパースする", async () => {
+      // libsecret 0.20 以前 (Ubuntu 22.04 等) では attribute.* 行は stdout に出力される
       const searchOutput = [
         "[/org/freedesktop/secrets/collection/login/1]",
         "label = coscli",

--- a/tests/unit/infra/keychain-macos.test.ts
+++ b/tests/unit/infra/keychain-macos.test.ts
@@ -95,14 +95,29 @@ describe("MacOSKeychainStore", () => {
 
   describe("list", () => {
     it("security dump-keychain の出力をパースして coscli のプロファイル一覧を返す", async () => {
+      // 実際の dump-keychain フォーマット: "acct" は "svce" より前に出力され、keychain: 行でエントリが区切られる
       const dumpOutput = [
         'keychain: "/Users/ユーザー/Library/Keychains/login.keychain"',
-        '    "svce"<blob>="coscli"',
+        "version: 512",
+        'class: "genp"',
+        "attributes:",
         '    "acct"<blob>="個人アカウント"',
         '    "svce"<blob>="coscli"',
+        '    "type"<uint32>=<NULL>',
+        'keychain: "/Users/ユーザー/Library/Keychains/login.keychain"',
+        "version: 512",
+        'class: "genp"',
+        "attributes:",
         '    "acct"<blob>="仕事アカウント"',
-        '    "svce"<blob>="other-app"',
+        '    "svce"<blob>="coscli"',
+        '    "type"<uint32>=<NULL>',
+        'keychain: "/Users/ユーザー/Library/Keychains/login.keychain"',
+        "version: 512",
+        'class: "genp"',
+        "attributes:",
         '    "acct"<blob>="他のアプリ"',
+        '    "svce"<blob>="other-app"',
+        '    "type"<uint32>=<NULL>',
       ].join("\n")
 
       const { spawner } = captureSpawner(dumpOutput, "", 0)
@@ -112,6 +127,27 @@ describe("MacOSKeychainStore", () => {
       expect(profiles).toContain("個人アカウント")
       expect(profiles).toContain("仕事アカウント")
       expect(profiles).not.toContain("他のアプリ")
+    })
+
+    it("非 ASCII プロファイル名が 0x 形式でエンコードされていても正しくデコードする", async () => {
+      // "山田太郎" の UTF-8 バイト列の 16 進数表現
+      const YAMADA_TARO_HEX = "E5B1B1E794B0E5A4AAE9838E"
+      const dumpOutput = [
+        'keychain: "/Users/ユーザー/Library/Keychains/login.keychain"',
+        "version: 512",
+        'class: "genp"',
+        "attributes:",
+        `    "acct"<blob>=0x${YAMADA_TARO_HEX}`,
+        '    "svce"<blob>="coscli"',
+        '    "type"<uint32>=<NULL>',
+      ].join("\n")
+
+      const { spawner } = captureSpawner(dumpOutput, "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      const profiles = await store.list()
+
+      // 検証: hex デコードされたプロファイル名が返る
+      expect(profiles).toContain("山田太郎")
     })
 
     it("exit code 非 0 のとき空配列を返す", async () => {

--- a/tests/unit/infra/keychain-windows.test.ts
+++ b/tests/unit/infra/keychain-windows.test.ts
@@ -133,6 +133,34 @@ describe("WindowsKeychainStore", () => {
       expect(profiles).not.toContain("other")
     })
 
+    it("LegacyGeneric:target= プレフィックス付きフォーマット (Windows Server 2022 等) でも正しくパースできる", async () => {
+      // Windows 環境では cmdkey /list が "LegacyGeneric:target=<actual-target>" 形式で出力することがある
+      const listOutput = [
+        "Currently stored credentials:",
+        "",
+        "    Target: LegacyGeneric:target=coscli:個人アカウント",
+        "    Type: Generic",
+        "    User: cos",
+        "    Local machine persistence",
+        "",
+        "    Target: LegacyGeneric:target=coscli:仕事アカウント",
+        "    Type: Generic",
+        "    User: cos",
+        "",
+        "    Target: LegacyGeneric:target=other-app:other",
+        "    Type: Generic",
+      ].join("\n")
+
+      const { spawner } = captureSpawner(listOutput, "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      const profiles = await store.list()
+
+      // 検証: LegacyGeneric プレフィックスが除去され正しいプロファイル名が返る
+      expect(profiles).toContain("個人アカウント")
+      expect(profiles).toContain("仕事アカウント")
+      expect(profiles).not.toContain("other")
+    })
+
     it("exit code 非 0 のとき空配列を返す", async () => {
       const { spawner } = captureSpawner("", "エラー", 1)
       const store = new WindowsKeychainStore(spawner)


### PR DESCRIPTION
## Summary

- CI ワークフローを 3 ジョブ構成（lint/型チェック・ユニットテスト・インテグレーションテスト）に再編し、ubuntu / macos / windows の 3 OS マトリクスでインテグレーションテストを実行するよう設定
- macOS (security コマンド) / Linux (secret-tool + gnome-keyring) / Windows (cmdkey + CredentialManager モジュール) 向けの実インテグレーションテストを追加
- `bunfig.toml` のデフォルト include をユニットテスト限定にして `bun test tests/integration/` での分離実行を整備
- インテグレーションテスト実行により `MacOSKeychainStore.list()` の実装バグを発見・修正: `security dump-keychain` の実際のフォーマット (`"acct"` が `"svce"` より前に出力、非 ASCII は `0x` 形式) に対応できていなかった

## Test plan

- [ ] ローカル macOS で `bun test tests/integration/` が全件 pass
- [ ] CI ubuntu ジョブで gnome-keyring セットアップ後に Linux integration tests が pass
- [ ] CI macos ジョブで macOS integration tests が pass
- [ ] CI windows ジョブで CredentialManager インストール後に Windows integration tests が pass
- [ ] ユニットテスト 179 件全件 pass (ubuntu ジョブ)
- [ ] Biome lint / 型チェックがクリーン

Refs #2 — Phase B スコープのみ。smoke test (Phase C) / docs (Phase D) は後続 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * macOSキーチェーン出力の解析を改良し、hexエンコードのacctや多様な出力ブロックに対応。
  * Windowsのキー管理出力の変種（LegacyGeneric:target=...）を正しく処理。

* **Tests**
  * Windows、Linux、macOS 向けの統合テストを追加。
  * macOS/Linux/Windows 用のユニットテストを拡充し非ASCIIやレガシーフォーマットを検証。

* **Chores**
  * CIを分割しテスト実行を分離、実行環境とツールバージョンを固定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->