### PR TITLE
v0.2 Phase C: release.yml にスモークテスト追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,23 @@ jobs:
           - target: bun-darwin-arm64
             os: macos-latest
             output: cos-darwin-arm64
+            smoke_test: true
           - target: bun-darwin-x64
             os: macos-latest
             output: cos-darwin-x64
+            smoke_test: false
           - target: bun-linux-x64
             os: ubuntu-latest
             output: cos-linux-x64
+            smoke_test: true
           - target: bun-linux-arm64
             os: ubuntu-latest
             output: cos-linux-arm64
+            smoke_test: false
           - target: bun-windows-x64
             os: windows-latest
             output: cos-windows-x64.exe
+            smoke_test: true
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +45,14 @@ jobs:
 
       - name: バイナリのビルド
         run: bun build src/cli.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.output }} --define 'VERSION="${{ github.ref_name }}"'
+
+      # ネイティブ実行可能ターゲット (darwin-arm64 / linux-x64 / windows-x64) のみ実行する。
+      # darwin-x64 は macos-latest (ARM) で実行不可のためスキップ。linux-arm64 は ubuntu-latest (x64) で実行不可のためスキップ。
+      - name: スモークテスト (--version 出力確認)
+        if: matrix.smoke_test
+        shell: bash
+        run: |
+          ./dist/${{ matrix.output }} --version
 
       - name: アーティファクトのアップロード
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

ビルド後のバイナリが正常起動することを確認するスモークテストを追加します。

## 変更内容

- `.github/workflows/release.yml` — matrix に `smoke_test` フラグを追加し、ネイティブ実行可能な 3 ターゲットでビルド直後に `--version` を実行して動作確認

## スモークテスト対象

| ターゲット | OS | smoke_test |
|---|---|---|
| bun-darwin-arm64 | macos-latest (ARM) | ✅ 実行 |
| bun-darwin-x64 | macos-latest (ARM) | ❌ スキップ (クロスアーキテクチャ) |
| bun-linux-x64 | ubuntu-latest (x64) | ✅ 実行 |
| bun-linux-arm64 | ubuntu-latest (x64) | ❌ スキップ (クロスアーキテクチャ) |
| bun-windows-x64 | windows-latest (x64) | ✅ 実行 |

## テスト計画

- [ ] v タグ付き push でリリースワークフローが起動し、全 5 ターゲットのビルドが通ること
- [ ] smoke_test: true の 3 ターゲットで `--version` が正常終了すること
- [ ] smoke_test: false の 2 ターゲットはスモークテストステップがスキップされること

Refs #2 — Phase C スコープ。Phase D (ドキュメント + Homebrew tap 調査) は後続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースビルドプロセスの検証手順を改善しました。特定のプラットフォーム向けビルドに対して自動検証を追加し、品質保証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->