### PR TITLE
feat: v0.2 追加ページコマンド (rename / prepend / insert / pin / unpin / icon)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,10 +17,16 @@ import { pageCodeCommand } from "@/commands/page/code"
 import { pageDeleteCommand } from "@/commands/page/delete"
 import { pageEditCommand } from "@/commands/page/edit"
 import { pageGetCommand } from "@/commands/page/get"
+import { pageIconCommand } from "@/commands/page/icon"
+import { pageInsertCommand } from "@/commands/page/insert"
 // ページコマンド
 import { pageListCommand } from "@/commands/page/list"
 import { pageNewCommand } from "@/commands/page/new"
+import { pagePinCommand } from "@/commands/page/pin"
+import { pagePrependCommand } from "@/commands/page/prepend"
+import { pageRenameCommand } from "@/commands/page/rename"
 import { pageTextCommand } from "@/commands/page/text"
+import { pageUnpinCommand } from "@/commands/page/unpin"
 import { pageUrlCommand } from "@/commands/page/url"
 
 import { projectInfoCommand } from "@/commands/project/info"
@@ -55,6 +61,13 @@ const pageCommand = defineCommand({
     edit: pageEditCommand,
     ed: pageEditCommand,
     append: pageAppendCommand,
+    prepend: pagePrependCommand,
+    insert: pageInsertCommand,
+    rename: pageRenameCommand,
+    mv: pageRenameCommand,
+    pin: pagePinCommand,
+    unpin: pageUnpinCommand,
+    icon: pageIconCommand,
     delete: pageDeleteCommand,
     rm: pageDeleteCommand,
   },

--- a/src/commands/page/icon.ts
+++ b/src/commands/page/icon.ts
@@ -1,0 +1,48 @@
+/**
+ * page/icon.ts — `cos page icon <title>` コマンド。
+ *
+ * ページアイコン取得 URL をローカルで算出して stdout に出力する。
+ * API 呼び出しは行わない。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { buildIconUrl } from "@/core/api/encoder"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageIconCommand = defineCommand({
+  meta: { description: "ページアイコン取得 URL を生成する (API 呼び出しなし)" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    checkSandbox("page.icon", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.verbose(`アイコン URL を生成: ${a.title}`)
+
+    const url = buildIconUrl(project, a.title)
+
+    if (a.json) {
+      writeJson({ url }, { command: "page.icon", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${url}\n`)
+  },
+})

--- a/src/commands/page/icon.ts
+++ b/src/commands/page/icon.ts
@@ -39,7 +39,7 @@ export const pageIconCommand = defineCommand({
     const url = buildIconUrl(project, a.title)
 
     if (a.json) {
-      writeJson({ url }, { command: "page.icon", startTime }, buildJsonOpts(a))
+      writeJson({ icon: url }, { command: "page.icon", startTime }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -1,0 +1,110 @@
+/**
+ * page/insert.ts — `cos page insert <title> --after <n>` コマンド。
+ *
+ * 指定行 (1-indexed) の後ろに行を挿入する。
+ * --line で直接テキスト指定、- で stdin から読み込む。
+ * --after 0 以下または lines 数超の値は VALIDATION_ERROR (exit 5) で終了する。
+ */
+
+import { readFileSync } from "node:fs"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { insertIntoPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageInsertCommand = defineCommand({
+  meta: { description: "指定行 (1-indexed) の後ろに行を挿入する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    after: {
+      type: "string",
+      description: "挿入位置 (1-indexed の行番号、タイトル行=1)",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "挿入する行テキスト (複数行は \\n で区切る)",
+    },
+    "from-file": {
+      type: "string",
+      description: "挿入行のファイルパス (- で stdin)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title: string
+      after: string
+      line?: string
+      "from-file"?: string
+    }
+    checkSandbox("page.insert", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --after バリデーション (1-indexed、1以上の整数のみ許可)
+    const afterN = Number.parseInt(a.after, 10)
+    if (Number.isNaN(afterN) || afterN < 1) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--after の値が無効です: "${a.after}"`,
+        "1 以上の整数を指定してください (タイトル行=1)",
+      )
+      process.exit(5)
+    }
+
+    let lines: string[] = []
+    if (a.line) {
+      lines = a.line.split("\\n")
+    } else if (a["from-file"] === "-") {
+      const content = readFileSync(0, "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    } else if (a["from-file"]) {
+      const content = readFileSync(a["from-file"], "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    }
+
+    if (lines.length === 0) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "挿入する行が指定されていません",
+        "--line または --from-file でコンテンツを指定してください",
+      )
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" の ${afterN} 行目の後ろに挿入中...`)
+
+    const writer = await buildWriter(a)
+    let result: Awaited<ReturnType<typeof insertIntoPage>> | undefined
+    try {
+      result = await insertIntoPage(writer, { project, title: a.title, after: afterN, lines })
+    } catch (err) {
+      // insertIntoPage 内部の範囲外エラーをキャッチして VALIDATION_ERROR として報告
+      const message = err instanceof Error ? err.message : String(err)
+      writeErrorJson("VALIDATION_ERROR", message)
+      process.exit(5)
+      return
+    }
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.insert", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" の ${afterN} 行目の後ろに挿入しました`)
+  },
+})

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -55,26 +55,35 @@ export const pageInsertCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // --after バリデーション (1-indexed、1以上の整数のみ許可)
-    const afterN = Number.parseInt(a.after, 10)
-    if (Number.isNaN(afterN) || afterN < 1) {
+    // --after バリデーション (1-indexed、正の整数のみ許可。"1abc" や "1.5" は弾く)
+    if (!/^[1-9]\d*$/.test(a.after)) {
       writeErrorJson(
         "VALIDATION_ERROR",
         `--after の値が無効です: "${a.after}"`,
         "1 以上の整数を指定してください (タイトル行=1)",
       )
       process.exit(5)
+      return
     }
+    const afterN = Number.parseInt(a.after, 10)
 
     let lines: string[] = []
-    if (a.line) {
+    if (a.line !== undefined) {
       lines = a.line.split("\\n")
-    } else if (a["from-file"] === "-") {
-      const content = readFileSync(0, "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
     } else if (a["from-file"]) {
-      const content = readFileSync(a["from-file"], "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      try {
+        const content =
+          a["from-file"] === "-" ? readFileSync(0, "utf-8") : readFileSync(a["from-file"], "utf-8")
+        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      } catch {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
+          "ファイルパスが正しいか確認してください",
+        )
+        process.exit(5)
+        return
+      }
     }
 
     if (lines.length === 0) {
@@ -93,11 +102,13 @@ export const pageInsertCommand = defineCommand({
     try {
       result = await insertIntoPage(writer, { project, title: a.title, after: afterN, lines })
     } catch (err) {
-      // insertIntoPage 内部の範囲外エラーをキャッチして VALIDATION_ERROR として報告
-      const message = err instanceof Error ? err.message : String(err)
-      writeErrorJson("VALIDATION_ERROR", message)
-      process.exit(5)
-      return
+      // insertIntoPage 内部の範囲外エラーのみ VALIDATION_ERROR として報告し、それ以外は再スロー
+      if (err instanceof Error && err.message.startsWith("--after の値が範囲外です")) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
     }
 
     if (a.json || a["dry-run"]) {

--- a/src/commands/page/pin.ts
+++ b/src/commands/page/pin.ts
@@ -1,0 +1,75 @@
+/**
+ * page/pin.ts — `cos page pin <title>` コマンド。
+ *
+ * ページをピン留めする。WebSocket commit で PinChange を送信する。
+ * --create 未指定時は事前に存在確認を行い、404 の場合は NOT_FOUND (exit 4) で終了する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { pinPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pagePinCommand = defineCommand({
+  meta: { description: "ページをピン留めする" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    create: {
+      type: "boolean",
+      description: "ページが未作成の場合に空ページを作成してピン留めする",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; create: boolean }
+    checkSandbox("page.pin", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --create 未指定時は対象ページの存在確認
+    if (!a.create && !a["dry-run"]) {
+      const client = await buildRestClient(a)
+      try {
+        await client.getPage(project, a.title)
+      } catch (err) {
+        const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
+        if (isNotFound) {
+          writeErrorJson(
+            "NOT_FOUND",
+            `ページ "${a.title}" が見つかりません`,
+            "ページを作成してからピン留めするか、--create フラグを使用してください",
+          )
+          process.exit(4)
+        }
+        throw err
+      }
+    }
+
+    logger.info(`"${a.title}" をピン留め中...`)
+
+    const writer = await buildWriter(a)
+    const result = await pinPage(writer, { project, title: a.title, create: a.create })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.pin", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" をピン留めしました`)
+  },
+})

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -45,14 +45,22 @@ export const pagePrependCommand = defineCommand({
     const startTime = Date.now()
 
     let lines: string[] = []
-    if (a.line) {
+    if (a.line !== undefined) {
       lines = a.line.split("\\n")
-    } else if (a["from-file"] === "-") {
-      const content = readFileSync(0, "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
     } else if (a["from-file"]) {
-      const content = readFileSync(a["from-file"], "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      try {
+        const content =
+          a["from-file"] === "-" ? readFileSync(0, "utf-8") : readFileSync(a["from-file"], "utf-8")
+        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      } catch {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
+          "ファイルパスが正しいか確認してください",
+        )
+        process.exit(5)
+        return
+      }
     }
 
     if (lines.length === 0) {
@@ -62,6 +70,7 @@ export const pagePrependCommand = defineCommand({
         "--line または --from-file でコンテンツを指定してください",
       )
       process.exit(5)
+      return
     }
 
     logger.info(`"${a.title}" の先頭に行を挿入中...`)

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -1,0 +1,79 @@
+/**
+ * page/prepend.ts — `cos page prepend <title>` コマンド。
+ *
+ * ページのタイトル行直後に行を挿入する。
+ * --line で直接テキスト指定、- で stdin から読み込む。
+ */
+
+import { readFileSync } from "node:fs"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { prependToPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pagePrependCommand = defineCommand({
+  meta: { description: "ページ先頭 (タイトル直後) に行を挿入する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "挿入する行テキスト (複数行は \\n で区切る)",
+    },
+    "from-file": {
+      type: "string",
+      description: "挿入行のファイルパス (- で stdin)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; line?: string; "from-file"?: string }
+    checkSandbox("page.prepend", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    let lines: string[] = []
+    if (a.line) {
+      lines = a.line.split("\\n")
+    } else if (a["from-file"] === "-") {
+      const content = readFileSync(0, "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    } else if (a["from-file"]) {
+      const content = readFileSync(a["from-file"], "utf-8")
+      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    }
+
+    if (lines.length === 0) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "挿入する行が指定されていません",
+        "--line または --from-file でコンテンツを指定してください",
+      )
+      process.exit(5)
+    }
+
+    logger.info(`"${a.title}" の先頭に行を挿入中...`)
+
+    const writer = await buildWriter(a)
+    const result = await prependToPage(writer, { project, title: a.title, lines })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.prepend", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" の先頭に挿入しました`)
+  },
+})

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -53,8 +53,8 @@ export const pageRenameCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // dry-run 以外では重複チェックを行う
-    if (!a["dry-run"] && !a["force-fallback"]) {
+    // dry-run 以外かつ同名でない場合は重複チェックを行う (同名は no-op なのでスキップ)
+    if (!a["dry-run"] && !a["force-fallback"] && a["new-title"] !== a.title) {
       const client = await buildRestClient(a)
       try {
         await client.getPage(project, a["new-title"])

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -1,0 +1,91 @@
+/**
+ * page/rename.ts — `cos page rename <title> <new-title>` コマンド。
+ *
+ * ページタイトルを変更する。WebSocket commit で lines[0] を書き換えることで
+ * @cosense/std が TitleChange を自動 emit する。
+ *
+ * --force-fallback なし時は変更前に新タイトルの重複チェックを行い、
+ * 重複する場合は DUPLICATE_TITLE エラー (exit 5) で終了する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { renamePage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageRenameCommand = defineCommand({
+  meta: { description: "ページタイトルを変更する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "変更前のページタイトル",
+      required: true,
+    },
+    "new-title": {
+      type: "positional",
+      description: "変更後のページタイトル",
+      required: true,
+    },
+    "force-fallback": {
+      type: "boolean",
+      description: "重複タイトル時に @cosense/std の suggestUnDupTitle による自動補正を許可する",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title: string
+      "new-title": string
+      "force-fallback": boolean
+    }
+    checkSandbox("page.rename", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // dry-run 以外では重複チェックを行う
+    if (!a["dry-run"] && !a["force-fallback"]) {
+      const client = await buildRestClient(a)
+      try {
+        await client.getPage(project, a["new-title"])
+        // 例外が発生しなければ同名ページが存在する
+        writeErrorJson(
+          "DUPLICATE_TITLE",
+          `"${a["new-title"]}" は既に存在します`,
+          "別のタイトルを指定するか、--force-fallback を使用してください",
+        )
+        process.exit(5)
+      } catch (err) {
+        // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー
+        const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
+        if (!isNotFound) throw err
+      }
+    }
+
+    logger.info(`"${a.title}" を "${a["new-title"]}" に変更中...`)
+
+    const writer = await buildWriter(a)
+    const result = await renamePage(writer, {
+      project,
+      title: a.title,
+      newTitle: a["new-title"],
+    })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.rename", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" を "${a["new-title"]}" に変更しました`)
+  },
+})

--- a/src/commands/page/unpin.ts
+++ b/src/commands/page/unpin.ts
@@ -1,0 +1,49 @@
+/**
+ * page/unpin.ts — `cos page unpin <title>` コマンド。
+ *
+ * ページのピン留めを解除する。WebSocket commit で PinChange(pin: 0) を送信する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { unpinPage } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageUnpinCommand = defineCommand({
+  meta: { description: "ページのピン留めを解除する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    checkSandbox("page.unpin", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" のピン留めを解除中...`)
+
+    const writer = await buildWriter(a)
+    const result = await unpinPage(writer, { project, title: a.title })
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.unpin", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" のピン留めを解除しました`)
+  },
+})

--- a/src/core/api/encoder.ts
+++ b/src/core/api/encoder.ts
@@ -25,3 +25,10 @@ export function buildPageUrl(project: string, title: string): string {
   if (!title) throw new Error("タイトルを指定してください")
   return `${BASE_URL}/${encodeURIComponent(project)}/${encodePageTitle(title)}`
 }
+
+/** buildIconUrl はページアイコン取得 URL を生成する (API 呼び出しなし)。 */
+export function buildIconUrl(project: string, title: string): string {
+  if (!project) throw new Error("プロジェクト名を指定してください")
+  if (!title) throw new Error("タイトルを指定してください")
+  return `${BASE_URL}/api/pages/${encodeURIComponent(project)}/${encodePageTitle(title)}/icon`
+}

--- a/src/core/api/ws.ts
+++ b/src/core/api/ws.ts
@@ -18,6 +18,14 @@ export interface ScrapboxWriterStdClient {
     update: (lines: Line[]) => Promise<string[]>,
     options?: { sid?: string; maxRetry?: number },
   ): Promise<{ commitId: string; pageId: string } | unknown>
+
+  pin(
+    project: string,
+    title: string,
+    options?: { sid?: string; create?: boolean },
+  ): Promise<unknown>
+
+  unpin(project: string, title: string, options?: { sid?: string }): Promise<unknown>
 }
 
 /** DryRunResult は --dry-run 時に実際のコミットをしないで返す結果型。 */
@@ -50,6 +58,19 @@ export interface DeletePageOptions {
   title: string
 }
 
+/** PinPageOptions は pinPage() に渡すオプション。 */
+export interface PinPageOptions {
+  project: string
+  title: string
+  create?: boolean
+}
+
+/** UnpinPageOptions は unpinPage() に渡すオプション。 */
+export interface UnpinPageOptions {
+  project: string
+  title: string
+}
+
 /** ScrapboxWriter は Cosense への書き込み操作を抽象化する interface。 */
 export interface ScrapboxWriter {
   patch(opts: PatchOptions): Promise<{ commitId: string; pageId: string } | DryRunResult>
@@ -57,6 +78,10 @@ export interface ScrapboxWriter {
   insertLines(opts: InsertLinesOptions): Promise<{ commitId: string } | DryRunResult>
 
   deletePage(opts: DeletePageOptions): Promise<{ title: string } | DryRunResult>
+
+  pinPage(opts: PinPageOptions): Promise<{ title: string } | DryRunResult>
+
+  unpinPage(opts: UnpinPageOptions): Promise<{ title: string } | DryRunResult>
 }
 
 /** CosenseWriterOptions は CosenseWriter のオプション。 */
@@ -133,6 +158,29 @@ export class CosenseWriter implements ScrapboxWriter {
     })
     return { title: opts.title }
   }
+
+  async pinPage(opts: PinPageOptions): Promise<{ title: string } | DryRunResult> {
+    if (this.opts.dryRun) {
+      return { dryRun: true, project: opts.project, title: opts.title }
+    }
+
+    const pinOpts: { sid?: string; create?: boolean } = {}
+    if (this.opts.sid !== undefined) pinOpts.sid = this.opts.sid
+    if (opts.create !== undefined) pinOpts.create = opts.create
+    await this.stdClient.pin(opts.project, opts.title, pinOpts)
+    return { title: opts.title }
+  }
+
+  async unpinPage(opts: UnpinPageOptions): Promise<{ title: string } | DryRunResult> {
+    if (this.opts.dryRun) {
+      return { dryRun: true, project: opts.project, title: opts.title }
+    }
+
+    const unpinOpts: { sid?: string } = {}
+    if (this.opts.sid !== undefined) unpinOpts.sid = this.opts.sid
+    await this.stdClient.unpin(opts.project, opts.title, unpinOpts)
+    return { title: opts.title }
+  }
 }
 
 /**
@@ -153,6 +201,14 @@ export class DryRunWriter implements ScrapboxWriter {
   async deletePage(opts: DeletePageOptions): Promise<DryRunResult> {
     return { dryRun: true, project: opts.project, title: opts.title }
   }
+
+  async pinPage(opts: PinPageOptions): Promise<DryRunResult> {
+    return { dryRun: true, project: opts.project, title: opts.title }
+  }
+
+  async unpinPage(opts: UnpinPageOptions): Promise<DryRunResult> {
+    return { dryRun: true, project: opts.project, title: opts.title }
+  }
 }
 
 /**
@@ -169,7 +225,7 @@ export async function createScrapboxWriter(opts: {
   if (opts.dryRun) return new DryRunWriter()
 
   // @cosense/std は動的 import で読み込み (バイナリサイズ最適化)
-  const { patch } = await import("@cosense/std/websocket")
+  const { patch, pin, unpin } = await import("@cosense/std/websocket")
 
   const stdClient: ScrapboxWriterStdClient = {
     patch: (project, title, update, options) =>
@@ -182,6 +238,9 @@ export async function createScrapboxWriter(opts: {
           retry: options?.maxRetry,
         } as Parameters<typeof patch>[3],
       ),
+    pin: (project, title, options) => pin(project, title, options as Parameters<typeof pin>[2]),
+    unpin: (project, title, options) =>
+      unpin(project, title, options as Parameters<typeof unpin>[2]),
   }
 
   const writerOpts: CosenseWriterOptions = { sid: opts.sid }

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -78,3 +78,65 @@ export async function editPage(
 export async function deletePage(writer: ScrapboxWriter, opts: { project: string; title: string }) {
   return writer.deletePage({ project: opts.project, title: opts.title })
 }
+
+/** renamePage はページタイトルを変更する (WebSocket commit)。lines[0] を書き換えると TitleChange が自動 emit される。 */
+export async function renamePage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; newTitle: string },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: (lines) => [opts.newTitle, ...lines.slice(1).map((l) => l.text)],
+  })
+}
+
+/** prependToPage はタイトル直後に行を挿入する (WebSocket commit)。 */
+export async function prependToPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; lines: string[] },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: (existing) => [
+      existing[0]?.text ?? opts.title,
+      ...opts.lines,
+      ...existing.slice(1).map((l) => l.text),
+    ],
+  })
+}
+
+/**
+ * insertIntoPage は指定行 (1-indexed) の後ろに行を挿入する (WebSocket commit)。
+ * after が範囲外の場合は update 関数内で Error を throw する。
+ */
+export async function insertIntoPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; after: number; lines: string[] },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: (existing) => {
+      if (opts.after < 1 || opts.after > existing.length) {
+        throw new Error(`--after の値が範囲外です (1〜${existing.length} の整数を指定してください)`)
+      }
+      const txt = existing.map((l) => l.text)
+      return [...txt.slice(0, opts.after), ...opts.lines, ...txt.slice(opts.after)]
+    },
+  })
+}
+
+/** pinPage はページをピン留めする (WebSocket commit)。 */
+export async function pinPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; create: boolean },
+) {
+  return writer.pinPage({ project: opts.project, title: opts.title, create: opts.create })
+}
+
+/** unpinPage はピン留めを解除する (WebSocket commit)。 */
+export async function unpinPage(writer: ScrapboxWriter, opts: { project: string; title: string }) {
+  return writer.unpinPage({ project: opts.project, title: opts.title })
+}

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -119,7 +119,7 @@ export async function insertIntoPage(
     project: opts.project,
     title: opts.title,
     update: (existing) => {
-      if (opts.after < 1 || opts.after > existing.length) {
+      if (!Number.isInteger(opts.after) || opts.after < 1 || opts.after > existing.length) {
         throw new Error(`--after の値が範囲外です (1〜${existing.length} の整数を指定してください)`)
       }
       const txt = existing.map((l) => l.text)

--- a/tests/unit/commands/page/icon.test.ts
+++ b/tests/unit/commands/page/icon.test.ts
@@ -2,7 +2,7 @@
  * page/icon.test.ts — `cos page icon <title>` コマンドのテスト。
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { pageIconCommand } from "@/commands/page/icon"
 
 // process.exit をモック化してテスト終了を防ぐ
@@ -52,11 +52,9 @@ describe("pageIconCommand", () => {
     )
   })
 
-  it("--json フラグ指定時は JSON に url フィールドを含む", async () => {
-    const writeJsonSpy = mock(() => {})
+  it("--json フラグ指定時は JSON の data に icon フィールドを含む", async () => {
     process.env["COS_PROJECT"] = "myproject"
 
-    const consoleSpy = spyOn(process.stdout, "write").mockImplementation(() => true)
     await runIcon({
       title: "MyPage",
       project: "myproject",
@@ -66,10 +64,10 @@ describe("pageIconCommand", () => {
       "dry-run": false,
       quiet: false,
     })
-    // JSON 出力は stdout に書かれる
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("icon"))
-    writeJsonSpy.mockRestore()
-    consoleSpy.mockRestore()
+    // stdoutMock に書かれた JSON を解析して icon フィールドを検証する
+    const rawOutput = stdoutMock.mock.calls[0]?.[0] as string
+    expect(rawOutput).toBeDefined()
+    expect(JSON.parse(rawOutput).data).toMatchObject({ icon: expect.any(String) })
   })
 
   it("プロジェクト未指定の場合は exit 5 で終了する", async () => {

--- a/tests/unit/commands/page/icon.test.ts
+++ b/tests/unit/commands/page/icon.test.ts
@@ -1,0 +1,92 @@
+/**
+ * page/icon.test.ts — `cos page icon <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { pageIconCommand } from "@/commands/page/icon"
+
+// process.exit をモック化してテスト終了を防ぐ
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runIcon(args: Record<string, unknown>) {
+  await (
+    pageIconCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pageIconCommand", () => {
+  it("アイコン URL を stdout に出力する", async () => {
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+
+    await runIcon({
+      title: "テストページ",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+
+    expect(stdoutMock).toHaveBeenCalledWith(
+      "https://scrapbox.io/api/pages/%E3%83%86%E3%82%B9%E3%83%88%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88/%E3%83%86%E3%82%B9%E3%83%88%E3%83%9A%E3%83%BC%E3%82%B8/icon\n",
+    )
+  })
+
+  it("--json フラグ指定時は JSON に url フィールドを含む", async () => {
+    const writeJsonSpy = mock(() => {})
+    process.env["COS_PROJECT"] = "myproject"
+
+    const consoleSpy = spyOn(process.stdout, "write").mockImplementation(() => true)
+    await runIcon({
+      title: "MyPage",
+      project: "myproject",
+      json: true,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // JSON 出力は stdout に書かれる
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("icon"))
+    writeJsonSpy.mockRestore()
+    consoleSpy.mockRestore()
+  })
+
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    // process.exit がモックされているため実行が継続し buildIconUrl で throw される場合がある
+    try {
+      await runIcon({
+        title: "テストページ",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後に継続するため throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -1,0 +1,117 @@
+/**
+ * page/insert.test.ts — `cos page insert <title> --after <n>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageInsertCommand } from "@/commands/page/insert"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runInsert(args: Record<string, unknown>) {
+  await (
+    pageInsertCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pageInsertCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runInsert({
+        title: "テストページ",
+        after: "2",
+        line: "挿入行",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--after に数値以外を指定した場合は VALIDATION_ERROR で exit 5", async () => {
+    try {
+      await runInsert({
+        title: "テストページ",
+        after: "abc",
+        line: "挿入行",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+  })
+
+  it("--after に 0 を指定した場合は VALIDATION_ERROR で exit 5", async () => {
+    try {
+      await runInsert({
+        title: "テストページ",
+        after: "0",
+        line: "挿入行",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+  })
+
+  it("--line も --from-file も指定しない場合は CONTENT_REQUIRED で exit 5", async () => {
+    try {
+      await runInsert({
+        title: "テストページ",
+        after: "1",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
+  })
+})

--- a/tests/unit/commands/page/pin.test.ts
+++ b/tests/unit/commands/page/pin.test.ts
@@ -1,0 +1,53 @@
+/**
+ * page/pin.test.ts — `cos page pin <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pagePinCommand } from "@/commands/page/pin"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runPin(args: Record<string, unknown>) {
+  await (
+    pagePinCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pagePinCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPin({
+        title: "ピンページ",
+        project: undefined,
+        create: false,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})

--- a/tests/unit/commands/page/prepend.test.ts
+++ b/tests/unit/commands/page/prepend.test.ts
@@ -1,0 +1,75 @@
+/**
+ * page/prepend.test.ts — `cos page prepend <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pagePrependCommand } from "@/commands/page/prepend"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runPrepend(args: Record<string, unknown>) {
+  await (
+    pagePrependCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pagePrependCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPrepend({
+        title: "テストページ",
+        line: "追加行",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line も --from-file も指定しない場合は CONTENT_REQUIRED で exit 5", async () => {
+    try {
+      await runPrepend({
+        title: "テストページ",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
+  })
+})

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -1,0 +1,58 @@
+/**
+ * page/rename.test.ts — `cos page rename <title> <new-title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageRenameCommand } from "@/commands/page/rename"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runRename(args: Record<string, unknown>) {
+  await (
+    pageRenameCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pageRenameCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runRename({
+        title: "旧タイトル",
+        "new-title": "新タイトル",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})

--- a/tests/unit/commands/page/unpin.test.ts
+++ b/tests/unit/commands/page/unpin.test.ts
@@ -1,0 +1,52 @@
+/**
+ * page/unpin.test.ts — `cos page unpin <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageUnpinCommand } from "@/commands/page/unpin"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runUnpin(args: Record<string, unknown>) {
+  await (
+    pageUnpinCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("pageUnpinCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runUnpin({
+        title: "ピン解除ページ",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})

--- a/tests/unit/core/api/encoder.test.ts
+++ b/tests/unit/core/api/encoder.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { buildPageUrl, decodePageTitle, encodePageTitle } from "@/core/api/encoder"
+import { buildIconUrl, buildPageUrl, decodePageTitle, encodePageTitle } from "@/core/api/encoder"
 
 describe("encodePageTitle", () => {
   it("半角スペースをアンダースコアに変換する", () => {
@@ -77,5 +77,33 @@ describe("buildPageUrl", () => {
 
   it("タイトルが空の場合はエラーをスローする", () => {
     expect(() => buildPageUrl("myproject", "")).toThrow("タイトルを指定してください")
+  })
+})
+
+describe("buildIconUrl", () => {
+  it("プロジェクト名とタイトルからアイコン URL を生成する", () => {
+    expect(buildIconUrl("myproject", "Hello World")).toBe(
+      "https://scrapbox.io/api/pages/myproject/Hello_World/icon",
+    )
+  })
+
+  it("日本語タイトルを含むアイコン URL を生成する", () => {
+    expect(buildIconUrl("テストプロジェクト", "日本語ページ")).toBe(
+      "https://scrapbox.io/api/pages/%E3%83%86%E3%82%B9%E3%83%88%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88/%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%83%9A%E3%83%BC%E3%82%B8/icon",
+    )
+  })
+
+  it("半角スペースをアンダースコアに変換してアイコン URL を生成する", () => {
+    expect(buildIconUrl("my project", "my page")).toBe(
+      "https://scrapbox.io/api/pages/my%20project/my_page/icon",
+    )
+  })
+
+  it("プロジェクト名が空の場合はエラーをスローする", () => {
+    expect(() => buildIconUrl("", "ページタイトル")).toThrow("プロジェクト名を指定してください")
+  })
+
+  it("タイトルが空の場合はエラーをスローする", () => {
+    expect(() => buildIconUrl("myproject", "")).toThrow("タイトルを指定してください")
   })
 })

--- a/tests/unit/core/api/ws.test.ts
+++ b/tests/unit/core/api/ws.test.ts
@@ -14,15 +14,21 @@ const mockPatch = mock(async () => ({
   commitId: "mock-commit-id",
   pageId: "mock-page-id",
 }))
+const mockPin = mock(async () => "ピン留めページ")
+const mockUnpin = mock(async () => "ピン解除ページ")
 
 // CosenseWriter はコンストラクタで @cosense/std を受け取る (依存性注入)
 const mockStdClient = {
   patch: mockPatch,
+  pin: mockPin,
+  unpin: mockUnpin,
 }
 
 describe("CosenseWriter", () => {
   beforeEach(() => {
     mockPatch.mockClear()
+    mockPin.mockClear()
+    mockUnpin.mockClear()
   })
 
   it("patch を呼ぶと update 関数の戻り値でコミットする", async () => {
@@ -52,6 +58,64 @@ describe("CosenseWriter", () => {
     })
     expect(mockPatch).not.toHaveBeenCalled()
     expect(result).toMatchObject({ dryRun: true, project: "テストプロジェクト" })
+  })
+
+  it("pinPage を呼ぶと stdClient.pin を正しい引数で呼ぶ", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      { sid: "テスト-sid" },
+    )
+    await writer.pinPage({ project: "テストプロジェクト", title: "ピンページ", create: true })
+    expect(mockPin).toHaveBeenCalledWith("テストプロジェクト", "ピンページ", {
+      sid: "テスト-sid",
+      create: true,
+    })
+  })
+
+  it("pinPage の dry-run モードでは stdClient.pin を呼ばず DryRunResult を返す", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      { dryRun: true },
+    )
+    const result = await writer.pinPage({
+      project: "テストプロジェクト",
+      title: "ピンページ",
+      create: false,
+    })
+    expect(mockPin).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "ピンページ",
+    })
+  })
+
+  it("unpinPage を呼ぶと stdClient.unpin を正しい引数で呼ぶ", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      { sid: "テスト-sid" },
+    )
+    await writer.unpinPage({ project: "テストプロジェクト", title: "ピン解除ページ" })
+    expect(mockUnpin).toHaveBeenCalledWith("テストプロジェクト", "ピン解除ページ", {
+      sid: "テスト-sid",
+    })
+  })
+
+  it("unpinPage の dry-run モードでは stdClient.unpin を呼ばず DryRunResult を返す", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      { dryRun: true },
+    )
+    const result = await writer.unpinPage({
+      project: "テストプロジェクト",
+      title: "ピン解除ページ",
+    })
+    expect(mockUnpin).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "ピン解除ページ",
+    })
   })
 })
 
@@ -87,5 +151,32 @@ describe("DryRunWriter", () => {
       title: "テストページ",
     })
     expect(result).toMatchObject({ dryRun: true })
+  })
+
+  it("pinPage を呼んでも DryRunResult を返す", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.pinPage({
+      project: "テストプロジェクト",
+      title: "ピンページ",
+      create: false,
+    })
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "ピンページ",
+    })
+  })
+
+  it("unpinPage を呼んでも DryRunResult を返す", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.unpinPage({
+      project: "テストプロジェクト",
+      title: "ピン解除ページ",
+    })
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "ピン解除ページ",
+    })
   })
 })

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -16,7 +16,12 @@ import {
   getCodeBlock,
   getPage,
   getPageText,
+  insertIntoPage,
   listPages,
+  pinPage,
+  prependToPage,
+  renamePage,
+  unpinPage,
 } from "@/core/pages"
 
 /** REST クライアントのモック */
@@ -99,6 +104,8 @@ function createMockWriter(overrides: Partial<ScrapboxWriter> = {}): ScrapboxWrit
     patch: mock(async () => ({ commitId: "commit1", pageId: "page1" })),
     insertLines: mock(async () => ({ commitId: "commit1" })),
     deletePage: mock(async () => ({ title: "テストページ" })),
+    pinPage: mock(async () => ({ title: "ピン留めページ" })),
+    unpinPage: mock(async () => ({ title: "ピン解除ページ" })),
     ...overrides,
   } as unknown as ScrapboxWriter
 }
@@ -191,5 +198,175 @@ describe("deletePage", () => {
     const writer = createMockWriter()
     await deletePage(writer, { project: "proj", title: "削除ページ" })
     expect(writer.deletePage).toHaveBeenCalledWith({ project: "proj", title: "削除ページ" })
+  })
+})
+
+describe("renamePage", () => {
+  it("patch の update 関数が新タイトルを先頭にした配列を返す", async () => {
+    // update 関数の戻り値をキャプチャするためにモックを差し替える
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "rename-commit", pageId: "page1" }
+      }),
+    })
+    await renamePage(writer, { project: "proj", title: "旧タイトル", newTitle: "新タイトル" })
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+
+    // update 関数を実際に呼んで戻り値を検証する
+    const existingLines = [
+      { id: "l1", text: "旧タイトル", userId: "u1", created: 0, updated: 0 },
+      { id: "l2", text: "本文1行目", userId: "u1", created: 0, updated: 0 },
+      { id: "l3", text: "本文2行目", userId: "u1", created: 0, updated: 0 },
+    ]
+    const result = await capturedUpdate?.(existingLines)
+    expect(result).toEqual(["新タイトル", "本文1行目", "本文2行目"])
+  })
+})
+
+describe("prependToPage", () => {
+  it("patch の update 関数がタイトル直後に新行を挿入した配列を返す", async () => {
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "prepend-commit", pageId: "page1" }
+      }),
+    })
+    await prependToPage(writer, {
+      project: "proj",
+      title: "既存ページ",
+      lines: ["先頭追加行1", "先頭追加行2"],
+    })
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+
+    const existingLines = [
+      { id: "l1", text: "既存ページ", userId: "u1", created: 0, updated: 0 },
+      { id: "l2", text: "既存本文", userId: "u1", created: 0, updated: 0 },
+    ]
+    const result = await capturedUpdate?.(existingLines)
+    expect(result).toEqual(["既存ページ", "先頭追加行1", "先頭追加行2", "既存本文"])
+  })
+
+  it("本文が空ページでもタイトル直後に行を挿入できる", async () => {
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "prepend-commit", pageId: "page1" }
+      }),
+    })
+    await prependToPage(writer, { project: "proj", title: "空ページ", lines: ["新しい行"] })
+
+    // タイトル行のみのページ
+    const existingLines = [{ id: "l1", text: "空ページ", userId: "u1", created: 0, updated: 0 }]
+    const result = await capturedUpdate?.(existingLines)
+    expect(result).toEqual(["空ページ", "新しい行"])
+  })
+})
+
+describe("insertIntoPage", () => {
+  it("--after 2 で 2 行目の後ろに行を挿入する (1-indexed)", async () => {
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "insert-commit", pageId: "page1" }
+      }),
+    })
+    await insertIntoPage(writer, {
+      project: "proj",
+      title: "挿入ページ",
+      after: 2,
+      lines: ["挿入行"],
+    })
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+
+    const existingLines = [
+      { id: "l1", text: "挿入ページ", userId: "u1", created: 0, updated: 0 },
+      { id: "l2", text: "本文1行目", userId: "u1", created: 0, updated: 0 },
+      { id: "l3", text: "本文2行目", userId: "u1", created: 0, updated: 0 },
+    ]
+    const result = await capturedUpdate?.(existingLines)
+    expect(result).toEqual(["挿入ページ", "本文1行目", "挿入行", "本文2行目"])
+  })
+
+  it("--after 0 (範囲外) の場合は update 関数が例外をスローする", async () => {
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "insert-commit", pageId: "page1" }
+      }),
+    })
+    await insertIntoPage(writer, { project: "proj", title: "ページ", after: 0, lines: ["行"] })
+
+    const existingLines = [{ id: "l1", text: "ページ", userId: "u1", created: 0, updated: 0 }]
+    expect(() => capturedUpdate?.(existingLines)).toThrow("範囲外")
+  })
+
+  it("lines 数を超える --after (範囲外) の場合は update 関数が例外をスローする", async () => {
+    let capturedUpdate:
+      | ((
+          lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+        ) => string[] | Promise<string[]>)
+      | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedUpdate = opts.update
+        return { commitId: "insert-commit", pageId: "page1" }
+      }),
+    })
+    await insertIntoPage(writer, { project: "proj", title: "ページ", after: 99, lines: ["行"] })
+
+    const existingLines = [
+      { id: "l1", text: "ページ", userId: "u1", created: 0, updated: 0 },
+      { id: "l2", text: "本文", userId: "u1", created: 0, updated: 0 },
+    ]
+    expect(() => capturedUpdate?.(existingLines)).toThrow("範囲外")
+  })
+})
+
+describe("pinPage", () => {
+  it("Writer の pinPage を正しい引数で呼ぶ", async () => {
+    const writer = createMockWriter()
+    await pinPage(writer, { project: "proj", title: "ピンページ", create: true })
+    expect(writer.pinPage).toHaveBeenCalledWith({
+      project: "proj",
+      title: "ピンページ",
+      create: true,
+    })
+  })
+})
+
+describe("unpinPage", () => {
+  it("Writer の unpinPage を正しい引数で呼ぶ", async () => {
+    const writer = createMockWriter()
+    await unpinPage(writer, { project: "proj", title: "ピン解除ページ" })
+    expect(writer.unpinPage).toHaveBeenCalledWith({
+      project: "proj",
+      title: "ピン解除ページ",
+    })
   })
 })


### PR DESCRIPTION
## Summary

- `cos page rename <title> <new-title>` / `cos page mv` (alias): タイトル変更。重複時はデフォルト DUPLICATE_TITLE (exit 5)、`--force-fallback` で @cosense/std の自動補正を許可
- `cos page prepend <title>`: タイトル直後に行を挿入 (`--line` / `--from-file`)
- `cos page insert <title> --after <N>`: 1-indexed 指定行の後ろに挿入。範囲外は VALIDATION_ERROR (exit 5)
- `cos page pin <title>`: ピン留め。`--create` で未作成ページも空ページとして作成
- `cos page unpin <title>`: ピン留め解除
- `cos page icon <title>`: アイコン取得 URL を出力 (API 呼び出しなし)

## 変更ファイル

- `src/commands/page/{rename,prepend,insert,pin,unpin,icon}.ts` — 6 コマンド実装
- `src/core/api/encoder.ts` — `buildIconUrl` 追加
- `src/core/api/ws.ts` — `ScrapboxWriter` に `pinPage` / `unpinPage` メソッド追加
- `src/core/pages.ts` — `renamePage`, `prependToPage`, `insertIntoPage`, `pinPage`, `unpinPage` 追加
- `src/cli.ts` — 6 コマンドと `mv` alias を `pageCommand.subCommands` に登録
- `tests/unit/commands/page/{rename,prepend,insert,pin,unpin,icon}.test.ts` — 6 テストファイル新規
- 既存テスト (`encoder.test.ts`, `ws.test.ts`, `pages.test.ts`) に describe 追加

## Test plan

- [ ] `bun test` 全 212 件 PASS
- [ ] `bunx biome check src tests` エラー 0
- [ ] `bun run typecheck` エラー 0
- [ ] `--dry-run --json` での各コマンド動作確認
- [ ] `--after 0` / `--after -1` で VALIDATION_ERROR (exit 5) 確認
- [ ] プロジェクト未指定で PROJECT_REQUIRED (exit 5) 確認
- [ ] sandbox `--disable-commands page.rename` で POLICY_DENIED (exit 7) 確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ページのアイコンURLを取得するコマンドを追加
  * ページの特定位置に行を挿入するコマンドを追加
  * ページの先頭に行を追加するコマンドを追加
  * ページ名を変更するコマンドを追加
  * ページをピン留めおよびピン留め解除するコマンドを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->