### PR TITLE
feat: v0.2 cos sync pull/push/diff — ローカルファイルと Cosense の同期

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,11 @@ import { configGetCommand } from "@/commands/config/get"
 import { configPathCommand } from "@/commands/config/path"
 import { configSetCommand } from "@/commands/config/set"
 
+// 同期コマンド
+import { syncDiffCommand } from "@/commands/sync/diff"
+import { syncPullCommand } from "@/commands/sync/pull"
+import { syncPushCommand } from "@/commands/sync/push"
+
 /** page サブコマンドグループ */
 const pageCommand = defineCommand({
   meta: { description: "ページ操作コマンド" },
@@ -104,6 +109,16 @@ const configCommand = defineCommand({
   },
 })
 
+/** sync サブコマンドグループ */
+const syncCommand = defineCommand({
+  meta: { description: "ローカルファイルと Cosense の同期コマンド" },
+  subCommands: {
+    pull: syncPullCommand,
+    push: syncPushCommand,
+    diff: syncDiffCommand,
+  },
+})
+
 /** ルートコマンド */
 const main = defineCommand({
   meta: {
@@ -149,6 +164,7 @@ const main = defineCommand({
     login: authLoginCommand,
     me: authWhoamiCommand,
     config: configCommand,
+    sync: syncCommand,
   },
 })
 

--- a/src/commands/sync/diff.ts
+++ b/src/commands/sync/diff.ts
@@ -1,0 +1,164 @@
+/**
+ * sync/diff.ts — `cos sync diff [<title>]` コマンド。
+ *
+ * ローカルファイルと Cosense ページの差分を表示する。
+ * --plain 時は GNU unified diff 風のテキスト出力。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { syncDiff } from "@/core/sync/engine"
+import { FilenameInvalidError } from "@/core/sync/fsname"
+import { loadConfig } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const syncDiffCommand = defineCommand({
+  meta: { description: "ローカルと Cosense の差分を表示する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル (省略時は --all 必須)",
+      required: false,
+    },
+    all: {
+      type: "boolean",
+      description: "プロジェクト全ページの差分を表示する",
+      default: false,
+    },
+    dir: {
+      type: "string",
+      description: "同期ディレクトリ (未指定時は設定ファイルの sync.dir を使う)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title?: string
+      all: boolean
+      dir?: string
+    }
+
+    checkSandbox("sync.diff", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --dir または設定ファイルの sync.dir を使う
+    const config = loadConfig()
+    const syncDir = a.dir ?? config.sync?.dir
+    if (!syncDir) {
+      writeErrorJson(
+        "DIR_REQUIRED",
+        "同期ディレクトリが指定されていません",
+        "--dir フラグか `cos config set sync.dir <path>` で同期ディレクトリを指定してください",
+      )
+      process.exit(5)
+    }
+
+    // <title> も --all も未指定の場合はエラー
+    if (!a.title && !a.all) {
+      writeErrorJson(
+        "TARGET_REQUIRED",
+        "ページタイトルまたは --all を指定してください",
+        "`cos sync diff <title>` または `cos sync diff --all` で対象を指定してください",
+      )
+      process.exit(5)
+    }
+
+    const client = await buildRestClient(a)
+
+    if (a.title) {
+      // 単一ページの diff
+      try {
+        const result = await syncDiff(client, syncDir, project, a.title)
+
+        if (a.json || !a.plain) {
+          writeJson(result, { command: "sync.diff", startTime }, buildJsonOpts(a))
+        } else {
+          writeDiffPlain(a.title, result.status, result.diff)
+        }
+      } catch (err) {
+        if (err instanceof FilenameInvalidError) {
+          writeErrorJson("FILENAME_INVALID", err.message, "タイトルに禁則文字が含まれています")
+          process.exit(5)
+        }
+        throw err
+      }
+    } else {
+      // --all: プロジェクト全ページの diff
+      logger.info(`${project} の全ページの差分を確認中...`)
+      const pageList = await client.listPages(project, { limit: 1000 })
+      const results = []
+      const warnings: string[] = []
+
+      for (const summary of pageList.pages) {
+        try {
+          const result = await syncDiff(client, syncDir, project, summary.title)
+          results.push(result)
+        } catch (err) {
+          if (err instanceof FilenameInvalidError) {
+            warnings.push(`スキップ: "${summary.title}" — ${err.reason}`)
+          } else {
+            throw err
+          }
+        }
+      }
+
+      if (a.json || !a.plain) {
+        writeJson(
+          { total: results.length, results },
+          { command: "sync.diff", startTime, warnings },
+          buildJsonOpts(a),
+        )
+      } else {
+        for (const r of results) {
+          writeDiffPlain(r.title, r.status, r.diff)
+        }
+      }
+    }
+  },
+})
+
+/** writeDiffPlain は差分をプレーンテキスト (unified diff 風) で stdout に書き出す。 */
+function writeDiffPlain(
+  title: string,
+  status: string,
+  diff: {
+    added: string[]
+    removed: string[]
+    modified: Array<{ line: number; before: string; after: string }>
+  },
+): void {
+  if (status === "in-sync") {
+    process.stdout.write(`${title}: 差分なし\n`)
+    return
+  }
+
+  process.stdout.write(`--- a/${title}\n`)
+  process.stdout.write(`+++ b/${title}\n`)
+
+  for (const line of diff.removed) {
+    process.stdout.write(`- ${line}\n`)
+  }
+  for (const m of diff.modified) {
+    process.stdout.write(`- ${m.before}\n`)
+    process.stdout.write(`+ ${m.after}\n`)
+  }
+  for (const line of diff.added) {
+    process.stdout.write(`+ ${line}\n`)
+  }
+
+  if (status === "remote-only") {
+    process.stdout.write("(リモートのみ: ローカルにファイルがありません)\n")
+  } else if (status === "local-only") {
+    process.stdout.write("(ローカルのみ: リモートにページがありません)\n")
+  }
+}

--- a/src/commands/sync/diff.ts
+++ b/src/commands/sync/diff.ts
@@ -93,13 +93,21 @@ export const syncDiffCommand = defineCommand({
         throw err
       }
     } else {
-      // --all: プロジェクト全ページの diff
+      // --all: プロジェクト全ページの diff (ページネーションで全件取得)
       logger.info(`${project} の全ページの差分を確認中...`)
-      const pageList = await client.listPages(project, { limit: 1000 })
+      const allPages = []
+      let skip = 0
+      const pageLimit = 100
+      while (true) {
+        const pageList = await client.listPages(project, { limit: pageLimit, skip })
+        allPages.push(...pageList.pages)
+        if (allPages.length >= pageList.count) break
+        skip += pageLimit
+      }
       const results = []
       const warnings: string[] = []
 
-      for (const summary of pageList.pages) {
+      for (const summary of allPages) {
         try {
           const result = await syncDiff(client, syncDir, project, summary.title)
           results.push(result)

--- a/src/commands/sync/diff.ts
+++ b/src/commands/sync/diff.ts
@@ -101,6 +101,7 @@ export const syncDiffCommand = defineCommand({
       while (true) {
         const pageList = await client.listPages(project, { limit: pageLimit, skip })
         allPages.push(...pageList.pages)
+        if (pageList.pages.length === 0) break
         if (allPages.length >= pageList.count) break
         skip += pageLimit
       }

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -43,11 +43,6 @@ export const syncPullCommand = defineCommand({
       description: "ファイル形式 (txt のみ対応。md は v0.3 で対応予定)",
       default: "txt",
     },
-    retries: {
-      type: "string",
-      description: "楽観ロック競合時の最大リトライ回数 (デフォルト: 0)",
-      default: "0",
-    },
   },
   async run({ args }) {
     const a = args as CommonArgs & {
@@ -55,7 +50,6 @@ export const syncPullCommand = defineCommand({
       all: boolean
       dir?: string
       format: string
-      retries: string
     }
 
     checkSandbox("sync.pull", a)
@@ -122,13 +116,21 @@ export const syncPullCommand = defineCommand({
         throw err
       }
     } else {
-      // --all: プロジェクト全ページを一括 pull
+      // --all: プロジェクト全ページを一括 pull (ページネーションで全件取得)
       logger.info(`${project} の全ページを pull 中...`)
-      const pageList = await client.listPages(project, { limit: 1000 })
+      const allPages = []
+      let skip = 0
+      const pageLimit = 100
+      while (true) {
+        const pageList = await client.listPages(project, { limit: pageLimit, skip })
+        allPages.push(...pageList.pages)
+        if (allPages.length >= pageList.count) break
+        skip += pageLimit
+      }
       const results = []
       const warnings: string[] = []
 
-      for (const summary of pageList.pages) {
+      for (const summary of allPages) {
         try {
           const result = await syncPull(client, syncDir, project, summary.title, { dryRun })
           results.push(result)

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -124,6 +124,7 @@ export const syncPullCommand = defineCommand({
       while (true) {
         const pageList = await client.listPages(project, { limit: pageLimit, skip })
         allPages.push(...pageList.pages)
+        if (pageList.pages.length === 0) break
         if (allPages.length >= pageList.count) break
         skip += pageLimit
       }

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -1,0 +1,163 @@
+/**
+ * sync/pull.ts — `cos sync pull [<title>]` コマンド。
+ *
+ * Cosense のページをローカルファイルとして取得する。
+ * --all 指定でプロジェクト全ページを一括取得する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { syncPull } from "@/core/sync/engine"
+import { FilenameInvalidError } from "@/core/sync/fsname"
+import { loadConfig } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const syncPullCommand = defineCommand({
+  meta: { description: "Cosense → ローカルへ pull する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル (省略時は --all 必須)",
+      required: false,
+    },
+    all: {
+      type: "boolean",
+      description: "プロジェクト全ページを一括取得する",
+      default: false,
+    },
+    dir: {
+      type: "string",
+      description: "同期先ディレクトリ (未指定時は設定ファイルの sync.dir を使う)",
+    },
+    format: {
+      type: "string",
+      description: "ファイル形式 (txt のみ対応。md は v0.3 で対応予定)",
+      default: "txt",
+    },
+    retries: {
+      type: "string",
+      description: "楽観ロック競合時の最大リトライ回数 (デフォルト: 0)",
+      default: "0",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title?: string
+      all: boolean
+      dir?: string
+      format: string
+      retries: string
+    }
+
+    checkSandbox("sync.pull", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --format=md は v0.3 対応予定
+    if (a.format !== "txt") {
+      writeErrorJson(
+        "FORMAT_NOT_SUPPORTED",
+        `--format=${a.format} はサポートされていません`,
+        "Markdown 変換は v0.3 で対応予定です。現在は --format=txt のみ使用できます",
+      )
+      process.exit(5)
+    }
+
+    // --dir または設定ファイルの sync.dir を使う
+    const config = loadConfig()
+    const syncDir = a.dir ?? config.sync?.dir
+    if (!syncDir) {
+      writeErrorJson(
+        "DIR_REQUIRED",
+        "同期先ディレクトリが指定されていません",
+        "--dir フラグか `cos config set sync.dir <path>` で同期先ディレクトリを指定してください",
+      )
+      process.exit(5)
+    }
+
+    // <title> も --all も未指定の場合はエラー
+    if (!a.title && !a.all) {
+      writeErrorJson(
+        "TARGET_REQUIRED",
+        "ページタイトルまたは --all を指定してください",
+        "`cos sync pull <title>` または `cos sync pull --all` で対象を指定してください",
+      )
+      process.exit(5)
+    }
+
+    const client = await buildRestClient(a)
+    const dryRun = a["dry-run"]
+
+    if (a.title) {
+      // 単一ページの pull
+      logger.info(`"${a.title}" を pull 中...`)
+      try {
+        const result = await syncPull(client, syncDir, project, a.title, { dryRun })
+        if (a.json || !a.plain) {
+          writeJson(result, { command: "sync.pull", startTime }, buildJsonOpts(a))
+        } else {
+          if (dryRun) {
+            process.stdout.write(`[dry-run] ${result.title}: ${result.lines.length} 行\n`)
+          } else {
+            process.stdout.write(
+              `${result.title} を pull しました (commitId: ${result.commitId})\n`,
+            )
+          }
+        }
+      } catch (err) {
+        if (err instanceof FilenameInvalidError) {
+          writeErrorJson("FILENAME_INVALID", err.message, "タイトルに禁則文字が含まれています")
+          process.exit(5)
+        }
+        throw err
+      }
+    } else {
+      // --all: プロジェクト全ページを一括 pull
+      logger.info(`${project} の全ページを pull 中...`)
+      const pageList = await client.listPages(project, { limit: 1000 })
+      const results = []
+      const warnings: string[] = []
+
+      for (const summary of pageList.pages) {
+        try {
+          const result = await syncPull(client, syncDir, project, summary.title, { dryRun })
+          results.push(result)
+          logger.verbose(`  ✓ ${summary.title}`)
+        } catch (err) {
+          if (err instanceof FilenameInvalidError) {
+            warnings.push(`スキップ: "${summary.title}" — ${err.reason}`)
+            logger.warn(`  ✗ ${summary.title}: ${err.reason}`)
+          } else {
+            throw err
+          }
+        }
+      }
+
+      if (a.json || !a.plain) {
+        writeJson(
+          { pulled: results.length, skipped: warnings.length, results },
+          { command: "sync.pull", startTime, warnings },
+          buildJsonOpts(a),
+        )
+      } else {
+        process.stdout.write(`${results.length} ページを pull しました`)
+        if (warnings.length > 0) {
+          process.stdout.write(` (${warnings.length} ページをスキップ)\n`)
+          for (const w of warnings) process.stdout.write(`  ${w}\n`)
+        } else {
+          process.stdout.write("\n")
+        }
+      }
+    }
+  },
+})

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -201,7 +201,13 @@ export const syncPushCommand = defineCommand({
 
       if (a.json || !a.plain) {
         writeJson(
-          { pushed: results.filter((r) => r.committed).length, conflicts: conflictCount, results },
+          {
+            pushed: results.filter((r) => r.committed).length,
+            conflicts: conflictCount,
+            errors: errors.length,
+            results,
+            errorDetails: errors,
+          },
           { command: "sync.push", startTime },
           buildJsonOpts(a),
         )
@@ -209,9 +215,11 @@ export const syncPushCommand = defineCommand({
         const pushed = results.filter((r) => r.committed).length
         process.stdout.write(`${pushed} ページを push しました`)
         if (conflictCount > 0) process.stdout.write(` (${conflictCount} 件の競合)`)
+        if (errors.length > 0) process.stdout.write(` (${errors.length} 件のエラー)`)
         process.stdout.write("\n")
       }
 
+      if (errors.length > 0 && conflictCount === 0) process.exit(1)
       if (conflictCount > 0) process.exit(6)
     }
   },

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -1,0 +1,218 @@
+/**
+ * sync/push.ts — `cos sync push [<title>]` コマンド。
+ *
+ * ローカルファイルの内容を Cosense ページに push する。
+ * commitId の一致チェックで楽観ロック競合を検出する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { syncPush } from "@/core/sync/engine"
+import { FilenameInvalidError } from "@/core/sync/fsname"
+import { loadConfig } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const syncPushCommand = defineCommand({
+  meta: { description: "ローカル → Cosense へ push する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル (省略時は --all 必須)",
+      required: false,
+    },
+    all: {
+      type: "boolean",
+      description: "ローカルにある全ファイルを一括 push する",
+      default: false,
+    },
+    dir: {
+      type: "string",
+      description: "同期元ディレクトリ (未指定時は設定ファイルの sync.dir を使う)",
+    },
+    format: {
+      type: "string",
+      description: "ファイル形式 (txt のみ対応)",
+      default: "txt",
+    },
+    retries: {
+      type: "string",
+      description: "楽観ロック競合時の最大リトライ回数 (デフォルト: 0)",
+      default: "0",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title?: string
+      all: boolean
+      dir?: string
+      format: string
+      retries: string
+    }
+
+    checkSandbox("sync.push", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --dir または設定ファイルの sync.dir を使う
+    const config = loadConfig()
+    const syncDir = a.dir ?? config.sync?.dir
+    if (!syncDir) {
+      writeErrorJson(
+        "DIR_REQUIRED",
+        "同期元ディレクトリが指定されていません",
+        "--dir フラグか `cos config set sync.dir <path>` で同期元ディレクトリを指定してください",
+      )
+      process.exit(5)
+    }
+
+    // <title> も --all も未指定の場合はエラー
+    if (!a.title && !a.all) {
+      writeErrorJson(
+        "TARGET_REQUIRED",
+        "ページタイトルまたは --all を指定してください",
+        "`cos sync push <title>` または `cos sync push --all` で対象を指定してください",
+      )
+      process.exit(5)
+    }
+
+    const retries = Number.parseInt(a.retries, 10)
+    const client = await buildRestClient(a)
+    const writer = await buildWriter(a)
+    const dryRun = a["dry-run"]
+
+    if (a.title) {
+      // 単一ページの push
+      logger.info(`"${a.title}" を push 中...`)
+      try {
+        const result = await syncPush(client, writer, syncDir, project, a.title, {
+          dryRun,
+          retries,
+        })
+
+        if (result.errorCode === "META_REQUIRED") {
+          writeErrorJson(
+            "META_REQUIRED",
+            `"${a.title}" のメタファイルが見つかりません`,
+            "先に `cos sync pull` を実行して同期状態を初期化してください",
+          )
+          process.exit(5)
+        }
+
+        if (result.errorCode === "LOCAL_NOT_FOUND") {
+          writeErrorJson(
+            "LOCAL_NOT_FOUND",
+            `ローカルファイル "${a.title}.txt" が見つかりません`,
+            "ファイルが存在するか確認してください",
+          )
+          process.exit(5)
+        }
+
+        if (result.errorCode === "CONFLICT") {
+          writeErrorJson(
+            "CONFLICT",
+            `"${a.title}" の楽観ロック競合が発生しました`,
+            "cos sync pull で最新を取得してから再度 push してください",
+          )
+          // CONFLICT 付加情報を JSON に含める
+          if (a.json || !a.plain) {
+            process.stdout.write(
+              `${JSON.stringify({ data: { localCommitId: result.localCommitId, serverCommitId: result.serverCommitId } }, null, 2)}\n`,
+            )
+          }
+          process.exit(6)
+        }
+
+        if (a.json || !a.plain) {
+          writeJson(result, { command: "sync.push", startTime }, buildJsonOpts(a))
+        } else {
+          if (dryRun || result.dryRun) {
+            process.stdout.write(`[dry-run] ${a.title}: push をシミュレートしました\n`)
+          } else if (result.status === "in-sync") {
+            process.stdout.write(`${a.title}: すでに同期済みです\n`)
+          } else {
+            process.stdout.write(
+              `${a.title} を push しました (commitId: ${result.newCommitId ?? "unknown"})\n`,
+            )
+          }
+        }
+      } catch (err) {
+        if (err instanceof FilenameInvalidError) {
+          writeErrorJson("FILENAME_INVALID", err.message, "タイトルに禁則文字が含まれています")
+          process.exit(5)
+        }
+        throw err
+      }
+    } else {
+      // --all: 同期ディレクトリのメタファイルから全ページを push
+      logger.info(`${project} の全ページを push 中...`)
+
+      const { readdirSync } = await import("node:fs")
+      const { join } = await import("node:path")
+      const metaDir = join(syncDir, ".coscli", project)
+
+      // メタディレクトリが存在しない = 一度も pull していない
+      const { existsSync } = await import("node:fs")
+      if (!existsSync(metaDir)) {
+        writeErrorJson(
+          "NO_META_FOUND",
+          `${project} のメタデータが見つかりません`,
+          "先に `cos sync pull --all` を実行してください",
+        )
+        process.exit(5)
+      }
+
+      const metaFiles = readdirSync(metaDir).filter((f) => f.endsWith(".json"))
+      const results = []
+      const errors = []
+      let conflictCount = 0
+
+      for (const metaFile of metaFiles) {
+        const title = metaFile.replace(/\.json$/, "")
+        try {
+          const result = await syncPush(client, writer, syncDir, project, title, {
+            dryRun,
+            retries,
+          })
+          results.push({ title, ...result })
+          if (result.errorCode === "CONFLICT") {
+            conflictCount++
+            logger.warn(`  ✗ 競合: ${title}`)
+          } else if (result.committed) {
+            logger.verbose(`  ✓ push: ${title}`)
+          } else {
+            logger.verbose(`  - スキップ: ${title} (同期済み)`)
+          }
+        } catch (err) {
+          errors.push({ title, error: err instanceof Error ? err.message : String(err) })
+          logger.warn(`  ✗ エラー: ${title}`)
+        }
+      }
+
+      if (a.json || !a.plain) {
+        writeJson(
+          { pushed: results.filter((r) => r.committed).length, conflicts: conflictCount, results },
+          { command: "sync.push", startTime },
+          buildJsonOpts(a),
+        )
+      } else {
+        const pushed = results.filter((r) => r.committed).length
+        process.stdout.write(`${pushed} ページを push しました`)
+        if (conflictCount > 0) process.stdout.write(` (${conflictCount} 件の競合)`)
+        process.stdout.write("\n")
+      }
+
+      if (conflictCount > 0) process.exit(6)
+    }
+  },
+})

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -123,13 +123,8 @@ export const syncPushCommand = defineCommand({
             "CONFLICT",
             `"${a.title}" の楽観ロック競合が発生しました`,
             "cos sync pull で最新を取得してから再度 push してください",
+            { localCommitId: result.localCommitId, serverCommitId: result.serverCommitId },
           )
-          // CONFLICT 付加情報を JSON に含める
-          if (a.json || !a.plain) {
-            process.stdout.write(
-              `${JSON.stringify({ data: { localCommitId: result.localCommitId, serverCommitId: result.serverCommitId } }, null, 2)}\n`,
-            )
-          }
           process.exit(6)
         }
 

--- a/src/core/sync/diff.ts
+++ b/src/core/sync/diff.ts
@@ -1,0 +1,135 @@
+/**
+ * diff.ts — ローカルとリモートの行差分を計算する LCS ベースのユーティリティ。
+ *
+ * Cosense ページは数百行スケールなので O(n*m) LCS で十分。
+ * 外部依存を追加せずに実装する。
+ */
+
+/** DiffStatus は2つのテキスト間の同期状態を示す。 */
+export type DiffStatus = "in-sync" | "modified"
+
+/** LineDiff は変更された行の詳細。 */
+export interface LineDiff {
+  /** 1-indexed のリモート上の行番号 */
+  line: number
+  /** 変更前 (リモート) の本文 */
+  before: string
+  /** 変更後 (ローカル) の本文 */
+  after: string
+}
+
+/** DiffResult は computeDiff の結果。 */
+export interface DiffResult {
+  status: DiffStatus
+  /** ローカルに追加された行 (リモートに無い行) */
+  added: string[]
+  /** ローカルから削除された行 (リモートにあるがローカルに無い行) */
+  removed: string[]
+  /** 内容が変わった行 */
+  modified: LineDiff[]
+}
+
+/**
+ * computeDiff はローカル行配列とリモート行配列の差分を計算する。
+ *
+ * @param localLines ローカルファイルの行配列
+ * @param remoteLines リモート (Cosense) の行配列
+ */
+export function computeDiff(localLines: string[], remoteLines: string[]): DiffResult {
+  const lcs = computeLcs(localLines, remoteLines)
+
+  const added: string[] = []
+  const removed: string[] = []
+  const modified: LineDiff[] = []
+
+  let li = 0 // localLines のポインタ
+  let ri = 0 // remoteLines のポインタ
+  let lcsIdx = 0 // lcs のポインタ
+
+  while (li < localLines.length || ri < remoteLines.length) {
+    const localLine = localLines[li]
+    const remoteLine = remoteLines[ri]
+    const lcsLine = lcs[lcsIdx]
+
+    if (
+      localLine !== undefined &&
+      remoteLine !== undefined &&
+      localLine === lcsLine &&
+      remoteLine === lcsLine
+    ) {
+      // 両側が LCS と一致 → 変更なし
+      li++
+      ri++
+      lcsIdx++
+    } else if (remoteLine !== undefined && remoteLine === lcsLine) {
+      // リモートが LCS と一致しているがローカルが不一致 → ローカルに追加
+      added.push(localLine as string)
+      li++
+    } else if (localLine !== undefined && localLine === lcsLine) {
+      // ローカルが LCS と一致しているがリモートが不一致 → リモートが削除されている (ローカル視点では削除)
+      removed.push(remoteLine as string)
+      ri++
+    } else if (localLine !== undefined && remoteLine !== undefined) {
+      // 両側とも LCS と不一致 → 変更
+      modified.push({ line: ri + 1, before: remoteLine, after: localLine })
+      li++
+      ri++
+    } else if (localLine !== undefined) {
+      // リモートが終わったがローカルはまだある → ローカルに追加
+      added.push(localLine)
+      li++
+    } else {
+      // ローカルが終わったがリモートはまだある → ローカルから削除
+      removed.push(remoteLine as string)
+      ri++
+    }
+  }
+
+  const status: DiffStatus =
+    added.length === 0 && removed.length === 0 && modified.length === 0 ? "in-sync" : "modified"
+
+  return { status, added, removed, modified }
+}
+
+/**
+ * computeLcs は2つの文字列配列の最長共通部分列 (LCS) を返す。
+ * O(n*m) の動的計画法で実装する。
+ */
+function computeLcs(a: string[], b: string[]): string[] {
+  const m = a.length
+  const n = b.length
+
+  // dp[i][j] = a[0..i-1] と b[0..j-1] の LCS 長
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const dpI = dp[i]
+      const dpI1 = dp[i - 1]
+      if (dpI === undefined || dpI1 === undefined) continue
+      if (a[i - 1] === b[j - 1]) {
+        dpI[j] = (dpI1[j - 1] ?? 0) + 1
+      } else {
+        dpI[j] = Math.max(dpI1[j] ?? 0, dpI[j - 1] ?? 0)
+      }
+    }
+  }
+
+  // バックトラックで LCS を復元
+  const lcs: string[] = []
+  let i = m
+  let j = n
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      lcs.unshift(a[i - 1] as string)
+      i--
+      j--
+    } else if ((dp[i - 1]?.[j] ?? 0) > (dp[i]?.[j - 1] ?? 0)) {
+      i--
+    } else {
+      j--
+    }
+  }
+
+  return lcs
+}

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -1,0 +1,272 @@
+/**
+ * engine.ts — sync pull/push/diff の純粋なドメインロジック。
+ *
+ * REST クライアントと ScrapboxWriter を DI で受け取ることで、
+ * テスト時にモックを注入できる。ファイルシステムへの依存は local.ts に委譲する。
+ */
+
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { computeDiff } from "@/core/sync/diff"
+import type { DiffResult } from "@/core/sync/diff"
+import { safeFsName } from "@/core/sync/fsname"
+import { contentToString, readLocalContent, sha256, writeLocalContent } from "@/core/sync/local"
+import { readMeta, writeMeta } from "@/core/sync/meta"
+import type { SyncMeta } from "@/core/sync/meta"
+
+/** SyncPullOptions は syncPull のオプション。 */
+export interface SyncPullOptions {
+  dryRun?: boolean
+  format?: "txt"
+}
+
+/** SyncPullResult は syncPull の結果。 */
+export interface SyncPullResult {
+  title: string
+  commitId: string
+  /** タイトル行を除いた本文行配列 */
+  lines: string[]
+  dryRun?: boolean
+}
+
+/**
+ * syncPull は Cosense からページを取得してローカルに保存する。
+ *
+ * lines[0] はタイトル行なので除外する。
+ * メタファイルに commitId と contentSha256 を記録する。
+ */
+export async function syncPull(
+  client: CosenseRestClient,
+  syncDir: string,
+  project: string,
+  title: string,
+  opts: SyncPullOptions = {},
+): Promise<SyncPullResult> {
+  const format = opts.format ?? "txt"
+  // タイトルのファイル名バリデーション (NG なら FilenameInvalidError を throw)
+  safeFsName(title)
+
+  const page = await client.getPage(project, title)
+  // lines[0] はタイトル行なので除外して本文だけ取り出す
+  const bodyLines = page.lines.slice(1).map((l) => l.text)
+
+  if (opts.dryRun) {
+    return { title, commitId: page.commitId, lines: bodyLines, dryRun: true }
+  }
+
+  writeLocalContent(syncDir, title, format, bodyLines)
+
+  const contentStr = contentToString(bodyLines)
+  const meta: SyncMeta = {
+    schemaVersion: 1,
+    project,
+    title,
+    pageId: page.id,
+    commitId: page.commitId,
+    lastPulledAt: Date.now(),
+    format,
+    contentSha256: sha256(contentStr),
+  }
+  writeMeta(syncDir, meta)
+
+  return { title, commitId: page.commitId, lines: bodyLines }
+}
+
+/** SyncPushOptions は syncPush のオプション。 */
+export interface SyncPushOptions {
+  dryRun?: boolean
+  retries?: number
+}
+
+/** SyncPushResult は syncPush の結果。 */
+export interface SyncPushResult {
+  committed: boolean
+  status?: "in-sync"
+  newCommitId?: string
+  dryRun?: boolean
+  errorCode?: "META_REQUIRED" | "LOCAL_NOT_FOUND" | "CONFLICT"
+  localCommitId?: string
+  serverCommitId?: string
+}
+
+/**
+ * syncPush はローカルファイルの内容を Cosense に push する。
+ *
+ * commitId の一致チェックで楽観ロック競合を検出する。
+ * --retries N 指定時、ローカル未編集であれば自動 pull → push を試みる。
+ */
+export async function syncPush(
+  client: CosenseRestClient,
+  writer: ScrapboxWriter,
+  syncDir: string,
+  project: string,
+  title: string,
+  opts: SyncPushOptions = {},
+): Promise<SyncPushResult> {
+  const format = "txt" as const
+  safeFsName(title)
+
+  const meta = readMeta(syncDir, project, title)
+  if (meta === null) {
+    return { committed: false, errorCode: "META_REQUIRED" }
+  }
+
+  const localLines = readLocalContent(syncDir, title, format)
+  if (localLines === null) {
+    return { committed: false, errorCode: "LOCAL_NOT_FOUND" }
+  }
+
+  const maxRetries = opts.retries ?? 0
+  let remainingRetries = maxRetries
+
+  while (true) {
+    const serverPage = await client.getPage(project, title)
+
+    if (meta.commitId !== serverPage.commitId) {
+      // commitId 不一致 = 競合
+      const localContentStr = contentToString(localLines)
+      const localUnchanged = sha256(localContentStr) === meta.contentSha256
+
+      if (localUnchanged && remainingRetries > 0) {
+        // ローカル未編集かつリトライ残あり → 自動 re-pull してから push
+        remainingRetries--
+        await syncPull(client, syncDir, project, title)
+        // pull 後メタが更新されたので再取得してループ継続
+        const updatedMeta = readMeta(syncDir, project, title)
+        if (updatedMeta) {
+          // コミット ID を更新してから続きに進む
+          // meta は const なので新しいメタで上書きして in-sync チェックへ
+          const rePushResult = await syncPush(client, writer, syncDir, project, title, {
+            ...opts,
+            retries: remainingRetries,
+          })
+          return rePushResult
+        }
+      }
+
+      return {
+        committed: false,
+        errorCode: "CONFLICT",
+        localCommitId: meta.commitId,
+        serverCommitId: serverPage.commitId,
+      }
+    }
+
+    // in-sync チェック: ローカルと最新 pull 後が同じなら push 不要
+    const serverBodyLines = serverPage.lines.slice(1).map((l) => l.text)
+    const diffResult = computeDiff(localLines, serverBodyLines)
+    if (diffResult.status === "in-sync") {
+      return { committed: false, status: "in-sync" }
+    }
+
+    if (opts.dryRun) {
+      return { committed: false, dryRun: true }
+    }
+
+    // push 実行
+    const patchResult = await writer.patch({
+      project,
+      title,
+      update: () => [title, ...localLines],
+    })
+
+    if ("dryRun" in patchResult) {
+      return { committed: false, dryRun: true }
+    }
+
+    const newCommitId = patchResult.commitId
+
+    // メタを更新
+    const localContentStr = contentToString(localLines)
+    const updatedMeta: SyncMeta = {
+      ...meta,
+      commitId: newCommitId,
+      lastPulledAt: Date.now(),
+      contentSha256: sha256(localContentStr),
+    }
+    writeMeta(syncDir, updatedMeta)
+
+    return { committed: true, newCommitId }
+  }
+}
+
+/** SyncDiffStatus は syncDiff で返す同期状態。 */
+export type SyncDiffStatus = "in-sync" | "modified" | "remote-only" | "local-only"
+
+/** SyncDiffResult は syncDiff の結果。 */
+export interface SyncDiffResult {
+  project: string
+  title: string
+  status: SyncDiffStatus
+  local: { commitId?: string; sha256: string; lineCount: number } | null
+  remote: { commitId: string; lineCount: number } | null
+  diff: DiffResult
+}
+
+/**
+ * syncDiff はローカルファイルとリモートページの差分を計算する。
+ */
+export async function syncDiff(
+  client: CosenseRestClient,
+  syncDir: string,
+  project: string,
+  title: string,
+): Promise<SyncDiffResult> {
+  const format = "txt" as const
+  safeFsName(title)
+
+  const serverPage = await client.getPage(project, title)
+  const serverBodyLines = serverPage.lines.slice(1).map((l) => l.text)
+
+  const localLines = readLocalContent(syncDir, title, format)
+  const meta = readMeta(syncDir, project, title)
+
+  if (localLines === null) {
+    // ローカルファイルが存在しない = リモートのみ
+    return {
+      project,
+      title,
+      status: "remote-only",
+      local: null,
+      remote: { commitId: serverPage.commitId, lineCount: serverBodyLines.length },
+      diff: computeDiff([], serverBodyLines),
+    }
+  }
+
+  if (serverBodyLines.length === 0 && localLines.length > 0) {
+    // リモートが空でローカルにある = ローカルのみ
+    const localContentStr = contentToString(localLines)
+    const localInfo: { commitId?: string; sha256: string; lineCount: number } = {
+      sha256: sha256(localContentStr),
+      lineCount: localLines.length,
+    }
+    if (meta?.commitId !== undefined) localInfo.commitId = meta.commitId
+    return {
+      project,
+      title,
+      status: "local-only",
+      local: localInfo,
+      remote: { commitId: serverPage.commitId, lineCount: 0 },
+      diff: computeDiff(localLines, []),
+    }
+  }
+
+  const diffResult = computeDiff(localLines, serverBodyLines)
+  const localContentStr = contentToString(localLines)
+  const status: SyncDiffStatus = diffResult.status === "in-sync" ? "in-sync" : "modified"
+
+  const localInfo: { commitId?: string; sha256: string; lineCount: number } = {
+    sha256: sha256(localContentStr),
+    lineCount: localLines.length,
+  }
+  if (meta?.commitId !== undefined) localInfo.commitId = meta.commitId
+
+  return {
+    project,
+    title,
+    status,
+    local: localInfo,
+    remote: { commitId: serverPage.commitId, lineCount: serverBodyLines.length },
+    diff: diffResult,
+  }
+}

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -163,11 +163,12 @@ export async function syncPush(
       return { committed: false, dryRun: true }
     }
 
-    // push 実行
+    // push 実行: maxRetry: 0 で @cosense/std の内部リトライを抑制し、上位の commitId チェックに委ねる
     const patchResult = await writer.patch({
       project,
       title,
       update: () => [title, ...localLines],
+      maxRetry: 0,
     })
 
     if ("dryRun" in patchResult) {

--- a/src/core/sync/fsname.ts
+++ b/src/core/sync/fsname.ts
@@ -1,0 +1,51 @@
+/**
+ * fsname.ts — タイトルがファイル名として安全かバリデートするユーティリティ。
+ *
+ * Cosense タイトルをローカルファイル名として使う前にチェックする。
+ * Windows (FAT/NTFS)・macOS・Linux の共通制約を適用する。
+ * 自動置換はせず、NG の場合は FilenameInvalidError を throw する。
+ */
+
+/** OS 禁則文字パターン: / \ : * ? " < > | */
+const FORBIDDEN_PATTERN = /[/\\:*?"<>|]/
+
+/** 予約名: . と .. はディレクトリトラバーサルの危険がある */
+const RESERVED_NAMES = new Set([".", ".."])
+
+/** FilenameInvalidError はファイル名として使用できないタイトルのエラー。 */
+export class FilenameInvalidError extends Error {
+  constructor(
+    public readonly title: string,
+    public readonly reason: string,
+  ) {
+    super(`タイトル "${title}" はファイル名として使用できません: ${reason}`)
+    this.name = "FilenameInvalidError"
+  }
+}
+
+/**
+ * safeFsName はタイトルをバリデートして安全なファイル名として返す。
+ * NG の場合は FilenameInvalidError を throw する。
+ */
+export function safeFsName(title: string): string {
+  if (title.length === 0) {
+    throw new FilenameInvalidError(title, "タイトルが空です")
+  }
+  if (RESERVED_NAMES.has(title)) {
+    throw new FilenameInvalidError(title, `"${title}" は予約名です`)
+  }
+  const match = FORBIDDEN_PATTERN.exec(title)
+  if (match !== null) {
+    const char = match[0] as string
+    throw new FilenameInvalidError(title, `禁則文字 "${char}" が含まれています`)
+  }
+  // 制御文字 (U+0000–U+001F) のチェック: charCodeAt でループして検出する
+  for (let i = 0; i < title.length; i++) {
+    const code = title.charCodeAt(i)
+    if (code < 0x20) {
+      const display = `U+${code.toString(16).padStart(4, "0").toUpperCase()}`
+      throw new FilenameInvalidError(title, `禁則文字 ${display} が含まれています`)
+    }
+  }
+  return title
+}

--- a/src/core/sync/local.ts
+++ b/src/core/sync/local.ts
@@ -1,0 +1,56 @@
+/**
+ * local.ts — ローカルファイルの本文 IO と sha256 計算ユーティリティ。
+ *
+ * sync pull/push でローカルの .txt ファイルを読み書きする。
+ * 行末の空行は trim してから読み込む (Cosense との往復で末尾改行が増殖しないように)。
+ */
+
+import { createHash } from "node:crypto"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+/** localFilePath はローカルファイルのパスを返す。 */
+function localFilePath(syncDir: string, title: string, format: "txt"): string {
+  return join(syncDir, `${title}.${format}`)
+}
+
+/**
+ * writeLocalContent は行配列をローカルファイルに書き込む。
+ * 各行は改行で区切り、末尾に改行を付加する。
+ */
+export function writeLocalContent(
+  syncDir: string,
+  title: string,
+  format: "txt",
+  lines: string[],
+): void {
+  const filePath = localFilePath(syncDir, title, format)
+  const content = lines.length === 0 ? "" : `${lines.join("\n")}\n`
+  writeFileSync(filePath, content, "utf-8")
+}
+
+/**
+ * readLocalContent はローカルファイルから行配列を読み込む。
+ * ファイルが存在しない場合は null を返す。
+ * 末尾の空行は除去する。
+ */
+export function readLocalContent(syncDir: string, title: string, format: "txt"): string[] | null {
+  const filePath = localFilePath(syncDir, title, format)
+  if (!existsSync(filePath)) return null
+  const content = readFileSync(filePath, "utf-8")
+  // 末尾の空行を除去してから split
+  const lines = content.replace(/\n+$/, "").split("\n")
+  // 空ファイルは [""] になるので空配列に変換
+  if (lines.length === 1 && lines[0] === "") return []
+  return lines
+}
+
+/** sha256 は文字列の SHA-256 ハッシュ (hex) を返す。 */
+export function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf-8").digest("hex")
+}
+
+/** contentToString は行配列をファイル書き込み用文字列に変換する。 */
+export function contentToString(lines: string[]): string {
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`
+}

--- a/src/core/sync/meta.ts
+++ b/src/core/sync/meta.ts
@@ -1,0 +1,48 @@
+/**
+ * meta.ts — 同期メタデータのスキーマ定義と読み書きユーティリティ。
+ *
+ * pull 時に commitId・contentSha256 等を <dir>/.coscli/<project>/<title>.json に保存し、
+ * push/diff 時の競合検出とローカル変更有無の判定に使う。
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { z } from "zod"
+
+/** SyncMetaSchema は同期メタデータの zod スキーマ。 */
+export const SyncMetaSchema = z.object({
+  schemaVersion: z.literal(1),
+  project: z.string(),
+  /** title は生のページタイトル (ファイル名と一致するが、メタ側を正として扱う) */
+  title: z.string(),
+  pageId: z.string(),
+  /** commitId は pull 時点のサーバ最新コミット ID (楽観ロック判定用) */
+  commitId: z.string(),
+  lastPulledAt: z.number(),
+  format: z.enum(["txt"]),
+  /** contentSha256 は pull 直後のローカル本文ハッシュ (push 時にローカル変更検出に使う) */
+  contentSha256: z.string(),
+})
+
+export type SyncMeta = z.infer<typeof SyncMetaSchema>
+
+/** metaFilePath はメタファイルのパスを返す。 */
+function metaFilePath(syncDir: string, project: string, title: string): string {
+  return join(syncDir, ".coscli", project, `${title}.json`)
+}
+
+/** writeMeta はメタデータをファイルに書き込む。中間ディレクトリは自動作成する。 */
+export function writeMeta(syncDir: string, meta: SyncMeta): void {
+  const filePath = metaFilePath(syncDir, meta.project, meta.title)
+  const dir = join(syncDir, ".coscli", meta.project)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(filePath, JSON.stringify(meta, null, 2))
+}
+
+/** readMeta はメタデータをファイルから読み込む。ファイルが存在しない場合は null を返す。 */
+export function readMeta(syncDir: string, project: string, title: string): SyncMeta | null {
+  const filePath = metaFilePath(syncDir, project, title)
+  if (!existsSync(filePath)) return null
+  const raw = readFileSync(filePath, "utf-8")
+  return SyncMetaSchema.parse(JSON.parse(raw) as unknown)
+}

--- a/src/core/sync/meta.ts
+++ b/src/core/sync/meta.ts
@@ -39,10 +39,16 @@ export function writeMeta(syncDir: string, meta: SyncMeta): void {
   writeFileSync(filePath, JSON.stringify(meta, null, 2))
 }
 
-/** readMeta はメタデータをファイルから読み込む。ファイルが存在しない場合は null を返す。 */
+/** readMeta はメタデータをファイルから読み込む。ファイルが存在しない場合は null を返す。破損時は Error を throw する。 */
 export function readMeta(syncDir: string, project: string, title: string): SyncMeta | null {
   const filePath = metaFilePath(syncDir, project, title)
   if (!existsSync(filePath)) return null
-  const raw = readFileSync(filePath, "utf-8")
-  return SyncMetaSchema.parse(JSON.parse(raw) as unknown)
+  try {
+    const raw = readFileSync(filePath, "utf-8")
+    return SyncMetaSchema.parse(JSON.parse(raw) as unknown)
+  } catch (err) {
+    throw new Error(
+      `メタデータファイルの読み込みに失敗しました: ${filePath}\n${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
 }

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -23,6 +23,13 @@ const AgentConfigSchema = z.object({
   maxChangesPerCommit: z.number().optional(),
 })
 
+/** SyncConfig はローカル同期に関する設定。 */
+const SyncConfigSchema = z.object({
+  dir: z.string().optional(),
+  format: z.enum(["txt"]).optional(),
+  retries: z.number().int().min(0).optional(),
+})
+
 /** CoscliConfig は設定ファイル全体のスキーマ。 */
 export const CoscliConfigSchema = z.object({
   defaultProject: z.string().optional(),
@@ -36,6 +43,7 @@ export const CoscliConfigSchema = z.object({
       plain: z.boolean().optional(),
     })
     .optional(),
+  sync: SyncConfigSchema.optional(),
 })
 export type CoscliConfig = z.infer<typeof CoscliConfigSchema>
 

--- a/src/presenter/json.ts
+++ b/src/presenter/json.ts
@@ -25,6 +25,7 @@ export interface ErrorEnvelope {
     message: string
     hint?: string
   }
+  data?: unknown
 }
 
 /** JsonOutputOptions は JSON 出力のオプション。 */
@@ -65,16 +66,18 @@ export function writeJson<T>(
   stream.write(`${JSON.stringify(output, null, 2)}\n`)
 }
 
-/** writeErrorJson はエラーを JSON として stdout に書き出す。 */
+/** writeErrorJson はエラーを JSON として stdout に書き出す。data を渡すと envelope の data フィールドに含まれる。 */
 export function writeErrorJson(
   code: string,
   message: string,
   hint?: string,
+  data?: unknown,
   stream?: NodeJS.WritableStream,
 ): void {
   const out = stream ?? process.stdout
   const envelope: ErrorEnvelope = {
     error: { code, message, ...(hint ? { hint } : {}) },
+    ...(data !== undefined ? { data } : {}),
   }
   out.write(`${JSON.stringify(envelope, null, 2)}\n`)
 }

--- a/tests/unit/commands/sync/diff.test.ts
+++ b/tests/unit/commands/sync/diff.test.ts
@@ -45,9 +45,9 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
-  process.env["COS_PROJECT"] = undefined
-  process.env["COS_ENABLE_COMMANDS"] = undefined
-  process.env["COS_DISABLE_COMMANDS"] = undefined
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
 })
 
 afterEach(() => {
@@ -65,9 +65,9 @@ describe("syncDiffCommand", () => {
     expect(exitMock).toHaveBeenCalledWith(5)
   })
 
-  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+  it("title も --all も未指定の場合は exit 5 で終了する (TARGET_REQUIRED)", async () => {
     try {
-      await runDiff(defaultArgs({ title: undefined, all: false }))
+      await runDiff(defaultArgs({ title: undefined, all: false, dir: "/tmp/sync" }))
     } catch {
       // process.exit モック後の継続による throw は想定内
     }

--- a/tests/unit/commands/sync/diff.test.ts
+++ b/tests/unit/commands/sync/diff.test.ts
@@ -1,0 +1,100 @@
+/**
+ * sync/diff.test.ts — `cos sync diff [<title>]` コマンドの入力バリデーションテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { syncDiffCommand } from "@/commands/sync/diff"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runDiff(args: Record<string, unknown>) {
+  await (
+    syncDiffCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: undefined,
+    all: false,
+    dir: undefined,
+    project: "テストプロジェクト",
+    profile: undefined,
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("syncDiffCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDiff(defaultArgs({ project: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDiff(defaultArgs({ title: undefined, all: false }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--dir も config.sync.dir も未設定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDiff(defaultArgs({ title: "テストページ", dir: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("sandbox で sync.diff が禁止されている場合は exit 7 で終了する", async () => {
+    try {
+      await runDiff(
+        defaultArgs({
+          title: "テストページ",
+          dir: "/tmp/sync",
+          "enable-commands": "page",
+        }),
+      )
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/commands/sync/pull.test.ts
+++ b/tests/unit/commands/sync/pull.test.ts
@@ -1,0 +1,116 @@
+/**
+ * sync/pull.test.ts — `cos sync pull <title>` コマンドの入力バリデーションテスト。
+ *
+ * 実際の API コールは engine.test.ts でカバーするため、
+ * このファイルでは引数バリデーション・sandbox・exit コードのみを確認する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { syncPullCommand } from "@/commands/sync/pull"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runPull(args: Record<string, unknown>) {
+  await (
+    syncPullCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** デフォルト引数 (最低限必要なフラグ) */
+function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: undefined,
+    all: false,
+    dir: undefined,
+    format: "txt",
+    retries: 0,
+    project: "テストプロジェクト",
+    profile: undefined,
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("syncPullCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPull(defaultArgs({ project: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPull(defaultArgs({ title: undefined, all: false }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--dir も config.sync.dir も未設定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPull(defaultArgs({ title: "テストページ", dir: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--format=md は exit 5 で終了する", async () => {
+    try {
+      await runPull(defaultArgs({ title: "テストページ", dir: "/tmp/sync", format: "md" }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("sandbox で sync.pull が禁止されている場合は exit 7 で終了する", async () => {
+    try {
+      await runPull(
+        defaultArgs({
+          title: "テストページ",
+          dir: "/tmp/sync",
+          "enable-commands": "page",
+        }),
+      )
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/commands/sync/pull.test.ts
+++ b/tests/unit/commands/sync/pull.test.ts
@@ -33,7 +33,6 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
     all: false,
     dir: undefined,
     format: "txt",
-    retries: 0,
     project: "テストプロジェクト",
     profile: undefined,
     json: false,
@@ -52,9 +51,9 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
-  process.env["COS_PROJECT"] = undefined
-  process.env["COS_ENABLE_COMMANDS"] = undefined
-  process.env["COS_DISABLE_COMMANDS"] = undefined
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
 })
 
 afterEach(() => {
@@ -72,9 +71,9 @@ describe("syncPullCommand", () => {
     expect(exitMock).toHaveBeenCalledWith(5)
   })
 
-  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+  it("title も --all も未指定の場合は exit 5 で終了する (TARGET_REQUIRED)", async () => {
     try {
-      await runPull(defaultArgs({ title: undefined, all: false }))
+      await runPull(defaultArgs({ title: undefined, all: false, dir: "/tmp/sync" }))
     } catch {
       // process.exit モック後の継続による throw は想定内
     }

--- a/tests/unit/commands/sync/push.test.ts
+++ b/tests/unit/commands/sync/push.test.ts
@@ -47,9 +47,9 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
-  process.env["COS_PROJECT"] = undefined
-  process.env["COS_ENABLE_COMMANDS"] = undefined
-  process.env["COS_DISABLE_COMMANDS"] = undefined
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
 })
 
 afterEach(() => {
@@ -67,9 +67,9 @@ describe("syncPushCommand", () => {
     expect(exitMock).toHaveBeenCalledWith(5)
   })
 
-  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+  it("title も --all も未指定の場合は exit 5 で終了する (TARGET_REQUIRED)", async () => {
     try {
-      await runPush(defaultArgs({ title: undefined, all: false }))
+      await runPush(defaultArgs({ title: undefined, all: false, dir: "/tmp/sync" }))
     } catch {
       // process.exit モック後の継続による throw は想定内
     }

--- a/tests/unit/commands/sync/push.test.ts
+++ b/tests/unit/commands/sync/push.test.ts
@@ -1,0 +1,102 @@
+/**
+ * sync/push.test.ts — `cos sync push [<title>]` コマンドの入力バリデーションテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { syncPushCommand } from "@/commands/sync/push"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runPush(args: Record<string, unknown>) {
+  await (
+    syncPushCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: undefined,
+    all: false,
+    dir: undefined,
+    format: "txt",
+    retries: "0",
+    project: "テストプロジェクト",
+    profile: undefined,
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_PROJECT"] = undefined
+  process.env["COS_ENABLE_COMMANDS"] = undefined
+  process.env["COS_DISABLE_COMMANDS"] = undefined
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("syncPushCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPush(defaultArgs({ project: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("title も --all も未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPush(defaultArgs({ title: undefined, all: false }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--dir も config.sync.dir も未設定の場合は exit 5 で終了する", async () => {
+    try {
+      await runPush(defaultArgs({ title: "テストページ", dir: undefined }))
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("sandbox で sync.push が禁止されている場合は exit 7 で終了する", async () => {
+    try {
+      await runPush(
+        defaultArgs({
+          title: "テストページ",
+          dir: "/tmp/sync",
+          "enable-commands": "page",
+        }),
+      )
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/core/sync/diff.test.ts
+++ b/tests/unit/core/sync/diff.test.ts
@@ -43,7 +43,7 @@ describe("computeDiff", () => {
     expect(result.modified[0]).toMatchObject({ before: "変更前", after: "変更後" })
   })
 
-  test("全置換はすべての行が added / removed になる", () => {
+  test("全置換は LCS が空になるため modified に分類される", () => {
     const result = computeDiff(["新行1", "新行2"], ["旧行1", "旧行2"])
     expect(result.status).toBe("modified")
   })

--- a/tests/unit/core/sync/diff.test.ts
+++ b/tests/unit/core/sync/diff.test.ts
@@ -1,0 +1,94 @@
+/**
+ * diff.test.ts — LCS 行差分ロジックのテスト。
+ */
+
+import { describe, expect, test } from "bun:test"
+import { computeDiff } from "@/core/sync/diff"
+
+describe("computeDiff", () => {
+  test("同一テキストは in-sync ステータスで差分なし", () => {
+    const result = computeDiff(["行A", "行B", "行C"], ["行A", "行B", "行C"])
+    expect(result.status).toBe("in-sync")
+    expect(result.added).toHaveLength(0)
+    expect(result.removed).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  test("空配列同士は in-sync", () => {
+    const result = computeDiff([], [])
+    expect(result.status).toBe("in-sync")
+  })
+
+  test("ローカルのみ行が増えた場合 added に含まれる", () => {
+    const result = computeDiff(["行A", "行B", "行C"], ["行A", "行B"])
+    expect(result.status).toBe("modified")
+    expect(result.added).toContain("行C")
+    expect(result.removed).toHaveLength(0)
+  })
+
+  test("ローカルから行が削除された場合 removed に含まれる", () => {
+    const result = computeDiff(["行A"], ["行A", "行B", "行C"])
+    expect(result.status).toBe("modified")
+    expect(result.removed).toContain("行B")
+    expect(result.removed).toContain("行C")
+    expect(result.added).toHaveLength(0)
+  })
+
+  test("行の内容が変わった場合 modified に含まれる", () => {
+    const local = ["行A", "変更後", "行C"]
+    const remote = ["行A", "変更前", "行C"]
+    const result = computeDiff(local, remote)
+    expect(result.status).toBe("modified")
+    expect(result.modified).toHaveLength(1)
+    expect(result.modified[0]).toMatchObject({ before: "変更前", after: "変更後" })
+  })
+
+  test("全置換はすべての行が added / removed になる", () => {
+    const result = computeDiff(["新行1", "新行2"], ["旧行1", "旧行2"])
+    expect(result.status).toBe("modified")
+  })
+
+  test("ローカルが空で remote がある場合", () => {
+    const result = computeDiff([], ["行A", "行B"])
+    expect(result.status).toBe("modified")
+    expect(result.removed).toContain("行A")
+    expect(result.removed).toContain("行B")
+    expect(result.added).toHaveLength(0)
+  })
+
+  test("remote が空でローカルがある場合", () => {
+    const result = computeDiff(["行A", "行B"], [])
+    expect(result.status).toBe("modified")
+    expect(result.added).toContain("行A")
+    expect(result.added).toContain("行B")
+    expect(result.removed).toHaveLength(0)
+  })
+
+  test("ローカルに行が挿入された場合 added に含まれる (LCS マッチ中のスキップ)", () => {
+    // local に "新行" が追加され、remote にはない
+    const local = ["行A", "新行", "行B"]
+    const remote = ["行A", "行B"]
+    const result = computeDiff(local, remote)
+    expect(result.status).toBe("modified")
+    expect(result.added).toContain("新行")
+    expect(result.removed).toHaveLength(0)
+  })
+
+  test("リモートに行が挿入された場合 removed に含まれる (LCS マッチ中のスキップ)", () => {
+    // remote に "旧行" があるがローカルにはない
+    const local = ["行A", "行B"]
+    const remote = ["行A", "旧行", "行B"]
+    const result = computeDiff(local, remote)
+    expect(result.status).toBe("modified")
+    expect(result.removed).toContain("旧行")
+    expect(result.added).toHaveLength(0)
+  })
+
+  test("LineDiff の line は 1 始まりのラインナンバー", () => {
+    const local = ["行A", "変更後", "行C"]
+    const remote = ["行A", "変更前", "行C"]
+    const result = computeDiff(local, remote)
+    // 2行目が変更されている
+    expect(result.modified[0]?.line).toBe(2)
+  })
+})

--- a/tests/unit/core/sync/engine.test.ts
+++ b/tests/unit/core/sync/engine.test.ts
@@ -161,7 +161,7 @@ describe("syncPush", () => {
     expect(writer.patch).not.toHaveBeenCalled()
   })
 
-  test("メタが無いとき CONFLICT_NO_META エラーを返す", async () => {
+  test("メタが無いとき META_REQUIRED エラーを返す", async () => {
     writeFileSync(join(TEST_DIR, "テストページ.txt"), "本文\n", "utf-8")
     const client = makeRestClient(makePage())
     const writer = makeWriter()

--- a/tests/unit/core/sync/engine.test.ts
+++ b/tests/unit/core/sync/engine.test.ts
@@ -1,0 +1,332 @@
+/**
+ * engine.test.ts — sync エンジン (pull/push/diff) の純粋関数テスト。
+ *
+ * REST クライアントと ScrapboxWriter をモックで注入し、
+ * ファイルシステムは一時ディレクトリを使う。
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { syncDiff, syncPull, syncPush } from "@/core/sync/engine"
+import type { SyncMeta } from "@/core/sync/meta"
+import { readMeta, writeMeta } from "@/core/sync/meta"
+import type { Page } from "@/schemas/page"
+
+const TEST_DIR = join(tmpdir(), "coscli-engine-test")
+
+/** テスト用 Page オブジェクトを生成するファクトリ */
+function makePage(overrides: Partial<Page> = {}): Page {
+  return {
+    id: "ページID",
+    title: "テストページ",
+    commitId: "コミットABC",
+    created: 1700000000,
+    updated: 1700000000,
+    lines: [
+      { id: "l1", text: "テストページ", userId: "u1", created: 1700000000, updated: 1700000000 },
+      { id: "l2", text: "本文1行目", userId: "u1", created: 1700000000, updated: 1700000000 },
+      { id: "l3", text: "本文2行目", userId: "u1", created: 1700000000, updated: 1700000000 },
+    ],
+    ...overrides,
+  }
+}
+
+/** モック REST クライアントを生成する */
+function makeRestClient(page: Page): CosenseRestClient {
+  return {
+    getPage: mock(() => Promise.resolve(page)),
+    listPages: mock(() =>
+      Promise.resolve({ projectName: "テスト", skip: 0, limit: 100, count: 1, pages: [] }),
+    ),
+    getPageText: mock(() => Promise.resolve("")),
+    getCodeBlock: mock(() => Promise.resolve("")),
+    searchPages: mock(() => Promise.resolve({ query: "", pages: [], projectName: "テスト" })),
+    getProject: mock(() => Promise.resolve({ name: "テスト" })),
+    listProjects: mock(() => Promise.resolve({ projects: [] })),
+    getMe: mock(() => Promise.resolve({ id: "u1", name: "テストユーザー" })),
+  } as unknown as CosenseRestClient
+}
+
+/** モック ScrapboxWriter を生成する */
+function makeWriter(commitId = "新コミットXYZ"): ScrapboxWriter {
+  return {
+    patch: mock(() => Promise.resolve({ commitId, pageId: "ページID" })),
+    insertLines: mock(() => Promise.resolve({ commitId })),
+    deletePage: mock(() => Promise.resolve({ title: "テストページ" })),
+    pinPage: mock(() => Promise.resolve({ title: "テストページ" })),
+    unpinPage: mock(() => Promise.resolve({ title: "テストページ" })),
+  } as unknown as ScrapboxWriter
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe("syncPull", () => {
+  test("ページをローカルに取得してメタファイルを生成する", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // ローカルファイルが作成されている
+    expect(existsSync(join(TEST_DIR, "テストページ.txt"))).toBe(true)
+
+    // メタファイルが作成されている
+    const meta = readMeta(TEST_DIR, "テストプロジェクト", "テストページ")
+    expect(meta).not.toBeNull()
+    expect(meta?.commitId).toBe("コミットABC")
+    expect(meta?.title).toBe("テストページ")
+    expect(meta?.project).toBe("テストプロジェクト")
+  })
+
+  test("タイトル行 (lines[0]) を除いた本文が保存される", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+
+    const result = await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // タイトル行を除いた本文
+    expect(result.lines).toEqual(["本文1行目", "本文2行目"])
+  })
+
+  test("--dry-run 時はファイルを書き込まない", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ", { dryRun: true })
+
+    expect(existsSync(join(TEST_DIR, "テストページ.txt"))).toBe(false)
+  })
+
+  test("既存のメタを上書きして commitId を更新する", async () => {
+    const oldMeta: SyncMeta = {
+      schemaVersion: 1,
+      project: "テストプロジェクト",
+      title: "テストページ",
+      pageId: "ページID",
+      commitId: "古いコミット",
+      lastPulledAt: 0,
+      format: "txt",
+      contentSha256: "旧ハッシュ",
+    }
+    writeMeta(TEST_DIR, oldMeta)
+
+    const page = makePage({ commitId: "新コミットABC" })
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    const meta = readMeta(TEST_DIR, "テストプロジェクト", "テストページ")
+    expect(meta?.commitId).toBe("新コミットABC")
+  })
+})
+
+describe("syncPush", () => {
+  test("ローカルファイルをリモートに push する", async () => {
+    // まず pull してメタを作成
+    const page = makePage()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // ローカルファイルを編集
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "編集した本文\n", "utf-8")
+
+    const writer = makeWriter("新コミットXYZ")
+    const result = await syncPush(client, writer, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.committed).toBe(true)
+    expect(result.newCommitId).toBe("新コミットXYZ")
+    expect(writer.patch).toHaveBeenCalledTimes(1)
+  })
+
+  test("in-sync のとき push しない", async () => {
+    // pull して変更せず push
+    const page = makePage()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    const writer = makeWriter()
+    const result = await syncPush(client, writer, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.committed).toBe(false)
+    expect(result.status).toBe("in-sync")
+    expect(writer.patch).not.toHaveBeenCalled()
+  })
+
+  test("メタが無いとき CONFLICT_NO_META エラーを返す", async () => {
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "本文\n", "utf-8")
+    const client = makeRestClient(makePage())
+    const writer = makeWriter()
+
+    const result = await syncPush(client, writer, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.committed).toBe(false)
+    expect(result.errorCode).toBe("META_REQUIRED")
+  })
+
+  test("ローカルファイルが存在しない場合 LOCAL_NOT_FOUND エラーを返す", async () => {
+    // メタだけ作ってローカルファイルは作らない
+    const meta: SyncMeta = {
+      schemaVersion: 1,
+      project: "テストプロジェクト",
+      title: "テストページ",
+      pageId: "page-id",
+      commitId: "コミットABC",
+      lastPulledAt: Date.now(),
+      format: "txt",
+      contentSha256: "ダミーハッシュ",
+    }
+    writeMeta(TEST_DIR, meta)
+
+    const client = makeRestClient(makePage())
+    const writer = makeWriter()
+    const result = await syncPush(client, writer, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.committed).toBe(false)
+    expect(result.errorCode).toBe("LOCAL_NOT_FOUND")
+  })
+
+  test("--dry-run 時は writer.patch を呼ばない", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "編集した本文\n", "utf-8")
+
+    const writer = makeWriter()
+    const result = await syncPush(client, writer, TEST_DIR, "テストプロジェクト", "テストページ", {
+      dryRun: true,
+    })
+
+    expect(writer.patch).not.toHaveBeenCalled()
+    expect(result.dryRun).toBe(true)
+  })
+
+  test("commitId が一致しない場合 CONFLICT エラーを返す", async () => {
+    const page = makePage({ commitId: "コミットABC" })
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // サーバ側が別コミットに更新された (getPage が別の commitId を返す)
+    const conflictPage = makePage({ commitId: "サーバ最新コミット" })
+    const conflictClient = makeRestClient(conflictPage)
+
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "編集した本文\n", "utf-8")
+
+    const writer = makeWriter()
+    const result = await syncPush(
+      conflictClient,
+      writer,
+      TEST_DIR,
+      "テストプロジェクト",
+      "テストページ",
+    )
+
+    expect(result.committed).toBe(false)
+    expect(result.errorCode).toBe("CONFLICT")
+    expect(result.localCommitId).toBe("コミットABC")
+    expect(result.serverCommitId).toBe("サーバ最新コミット")
+  })
+
+  test("ローカル未編集かつ commitId 不一致は自動再 pull して in-sync (--retries 1)", async () => {
+    const page = makePage({ commitId: "コミットABC" })
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // サーバ側が更新されたが内容は同じ (ローカルは変更していない = contentSha256 一致)
+    const updatedPage = makePage({
+      commitId: "新コミットXYZ",
+      lines: [
+        { id: "l1", text: "テストページ", userId: "u1", created: 1700000000, updated: 1700000000 },
+        { id: "l2", text: "本文1行目", userId: "u1", created: 1700000000, updated: 1700000000 },
+        { id: "l3", text: "本文2行目", userId: "u1", created: 1700000000, updated: 1700000000 },
+      ],
+    })
+    const retryClient = makeRestClient(updatedPage)
+
+    const writer = makeWriter("再プッシュコミット")
+    const result = await syncPush(
+      retryClient,
+      writer,
+      TEST_DIR,
+      "テストプロジェクト",
+      "テストページ",
+      { retries: 1 },
+    )
+
+    // ローカル未編集のため自動再 pull → サーバと同じ内容なので in-sync (push 不要)
+    expect(result.committed).toBe(false)
+    expect(result.errorCode).toBeUndefined()
+  })
+})
+
+describe("syncDiff", () => {
+  test("in-sync のとき in-sync ステータスを返す", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    const result = await syncDiff(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.status).toBe("in-sync")
+    expect(result.diff.added).toHaveLength(0)
+    expect(result.diff.removed).toHaveLength(0)
+  })
+
+  test("ローカルファイルが存在しない場合 local-only ではなく remote-only ステータス", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+
+    const result = await syncDiff(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.status).toBe("remote-only")
+  })
+
+  test("リモートが空でローカルにある場合 local-only ステータス", async () => {
+    // ローカルファイルだけ作成 (メタなし、リモートは空ページ)
+    writeFileSync(join(TEST_DIR, "ローカルのみ.txt"), "ローカルの行\n", "utf-8")
+
+    const emptyPage = makePage({
+      title: "ローカルのみ",
+      lines: [
+        { id: "l1", text: "ローカルのみ", userId: "u1", created: 1700000000, updated: 1700000000 },
+      ],
+    })
+    const client = makeRestClient(emptyPage)
+
+    const result = await syncDiff(client, TEST_DIR, "テストプロジェクト", "ローカルのみ")
+
+    expect(result.status).toBe("local-only")
+    expect(result.local).not.toBeNull()
+    expect(result.remote?.lineCount).toBe(0)
+  })
+
+  test("ローカルの変更を差分として返す", async () => {
+    const page = makePage()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // ローカルファイルを編集 (サーバの行と全く異なる内容にする)
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "新しい本文\n追加行\n", "utf-8")
+
+    const result = await syncDiff(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(result.status).toBe("modified")
+    // LCS が空のとき: 先頭行は modified、残りは added/removed として分類される
+    // 重要なのは status が "modified" であること
+    const allChanges = [
+      ...result.diff.added,
+      ...result.diff.removed,
+      ...result.diff.modified.map((m) => m.after),
+    ]
+    expect(allChanges.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/core/sync/fsname.test.ts
+++ b/tests/unit/core/sync/fsname.test.ts
@@ -66,14 +66,17 @@ describe("safeFsName", () => {
   })
 
   test("FilenameInvalidError は title と reason を持つ", () => {
+    let caughtErr: unknown
     try {
       safeFsName("invalid/title")
+      expect.unreachable("FilenameInvalidError が throw されるべきです")
     } catch (err) {
-      expect(err).toBeInstanceOf(FilenameInvalidError)
-      if (err instanceof FilenameInvalidError) {
-        expect(err.title).toBe("invalid/title")
-        expect(typeof err.reason).toBe("string")
-      }
+      caughtErr = err
+    }
+    expect(caughtErr).toBeInstanceOf(FilenameInvalidError)
+    if (caughtErr instanceof FilenameInvalidError) {
+      expect(caughtErr.title).toBe("invalid/title")
+      expect(typeof caughtErr.reason).toBe("string")
     }
   })
 })

--- a/tests/unit/core/sync/fsname.test.ts
+++ b/tests/unit/core/sync/fsname.test.ts
@@ -1,0 +1,79 @@
+/**
+ * fsname.test.ts — safeFsName バリデーターのテスト。
+ */
+
+import { describe, expect, test } from "bun:test"
+import { FilenameInvalidError, safeFsName } from "@/core/sync/fsname"
+
+describe("safeFsName", () => {
+  test("通常のタイトルはそのまま返す", () => {
+    expect(safeFsName("ハローワールド")).toBe("ハローワールド")
+    expect(safeFsName("hello world")).toBe("hello world")
+    expect(safeFsName("テスト123")).toBe("テスト123")
+    expect(safeFsName("a-b_c.d")).toBe("a-b_c.d")
+  })
+
+  test("スペースを含むタイトルはそのまま返す", () => {
+    expect(safeFsName("hello world")).toBe("hello world")
+  })
+
+  test("ドットのみのタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName(".")).toThrow(FilenameInvalidError)
+    expect(() => safeFsName("..")).toThrow(FilenameInvalidError)
+  })
+
+  test("空文字は FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("")).toThrow(FilenameInvalidError)
+  })
+
+  test("スラッシュを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("dir/file")).toThrow(FilenameInvalidError)
+    expect(() => safeFsName("path/to/page")).toThrow(FilenameInvalidError)
+  })
+
+  test("バックスラッシュを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("dir\\file")).toThrow(FilenameInvalidError)
+  })
+
+  test("コロンを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("C:drive")).toThrow(FilenameInvalidError)
+  })
+
+  test("アスタリスクを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("file*name")).toThrow(FilenameInvalidError)
+  })
+
+  test("クエスチョンマークを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("what?")).toThrow(FilenameInvalidError)
+  })
+
+  test("ダブルクォートを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName('say "hello"')).toThrow(FilenameInvalidError)
+  })
+
+  test("不等号を含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("a<b")).toThrow(FilenameInvalidError)
+    expect(() => safeFsName("a>b")).toThrow(FilenameInvalidError)
+  })
+
+  test("パイプを含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("a|b")).toThrow(FilenameInvalidError)
+  })
+
+  test("制御文字を含むタイトルは FilenameInvalidError を throw する", () => {
+    expect(() => safeFsName("null\x00char")).toThrow(FilenameInvalidError)
+    expect(() => safeFsName("newline\nchar")).toThrow(FilenameInvalidError)
+  })
+
+  test("FilenameInvalidError は title と reason を持つ", () => {
+    try {
+      safeFsName("invalid/title")
+    } catch (err) {
+      expect(err).toBeInstanceOf(FilenameInvalidError)
+      if (err instanceof FilenameInvalidError) {
+        expect(err.title).toBe("invalid/title")
+        expect(typeof err.reason).toBe("string")
+      }
+    }
+  })
+})

--- a/tests/unit/core/sync/local.test.ts
+++ b/tests/unit/core/sync/local.test.ts
@@ -1,0 +1,91 @@
+/**
+ * local.test.ts — ローカルファイル本文 IO と sha256 のテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { contentToString, readLocalContent, sha256, writeLocalContent } from "@/core/sync/local"
+
+const TEST_DIR = join(tmpdir(), "coscli-local-test")
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe("writeLocalContent / readLocalContent", () => {
+  test("本文を txt ファイルとして書き込める", () => {
+    writeLocalContent(TEST_DIR, "テストページ", "txt", ["行A", "行B", "行C"])
+    const filePath = join(TEST_DIR, "テストページ.txt")
+    expect(existsSync(filePath)).toBe(true)
+
+    const content = readFileSync(filePath, "utf-8")
+    expect(content).toBe("行A\n行B\n行C\n")
+  })
+
+  test("readLocalContent でファイルの行配列を読み込める", () => {
+    writeFileSync(join(TEST_DIR, "ページA.txt"), "行1\n行2\n行3\n", "utf-8")
+    const lines = readLocalContent(TEST_DIR, "ページA", "txt")
+    expect(lines).toEqual(["行1", "行2", "行3"])
+  })
+
+  test("readLocalContent はファイルが存在しない場合 null を返す", () => {
+    const result = readLocalContent(TEST_DIR, "存在しないページ", "txt")
+    expect(result).toBeNull()
+  })
+
+  test("空のファイルを書き込んで読み込める", () => {
+    writeLocalContent(TEST_DIR, "空ページ", "txt", [])
+    const lines = readLocalContent(TEST_DIR, "空ページ", "txt")
+    expect(lines).toEqual([])
+  })
+
+  test("末尾の空行は除去される", () => {
+    writeFileSync(join(TEST_DIR, "ページB.txt"), "行1\n行2\n\n", "utf-8")
+    const lines = readLocalContent(TEST_DIR, "ページB", "txt")
+    // 末尾の空行は除去されて ["行1", "行2"] になる
+    expect(lines).toEqual(["行1", "行2"])
+  })
+})
+
+describe("sha256", () => {
+  test("文字列の sha256 ハッシュを返す", () => {
+    const hash = sha256("行A\n行B\n行C\n")
+    expect(typeof hash).toBe("string")
+    expect(hash).toHaveLength(64) // hex 64文字
+  })
+
+  test("同じ内容は同じハッシュを返す", () => {
+    const a = sha256("テストコンテンツ")
+    const b = sha256("テストコンテンツ")
+    expect(a).toBe(b)
+  })
+
+  test("異なる内容は異なるハッシュを返す", () => {
+    const a = sha256("コンテンツA")
+    const b = sha256("コンテンツB")
+    expect(a).not.toBe(b)
+  })
+})
+
+describe("contentToString", () => {
+  test("行配列を改行区切り文字列に変換する", () => {
+    expect(contentToString(["行A", "行B"])).toBe("行A\n行B\n")
+  })
+
+  test("空配列は空文字列になる", () => {
+    expect(contentToString([])).toBe("")
+  })
+})
+
+describe("localFilePath", () => {
+  test("writeLocalContent はタイトルにファイル名を使う", () => {
+    writeLocalContent(TEST_DIR, "マイページ", "txt", ["行1"])
+    expect(existsSync(join(TEST_DIR, "マイページ.txt"))).toBe(true)
+  })
+})

--- a/tests/unit/core/sync/meta.test.ts
+++ b/tests/unit/core/sync/meta.test.ts
@@ -1,0 +1,97 @@
+/**
+ * meta.test.ts — SyncMeta スキーマと read/write のテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type SyncMeta, SyncMetaSchema, readMeta, writeMeta } from "@/core/sync/meta"
+
+const TEST_DIR = join(tmpdir(), "coscli-meta-test")
+
+function makeValidMeta(overrides: Partial<SyncMeta> = {}): SyncMeta {
+  return {
+    schemaVersion: 1,
+    project: "テストプロジェクト",
+    title: "テストページ",
+    pageId: "page-id-123",
+    commitId: "commit-abc",
+    lastPulledAt: 1700000000000,
+    format: "txt",
+    contentSha256: "abcdef1234567890",
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe("SyncMetaSchema", () => {
+  test("有効なメタデータはパースできる", () => {
+    const meta = makeValidMeta()
+    const parsed = SyncMetaSchema.safeParse(meta)
+    expect(parsed.success).toBe(true)
+  })
+
+  test("schemaVersion が 1 でなければ失敗する", () => {
+    const parsed = SyncMetaSchema.safeParse(makeValidMeta({ schemaVersion: 2 as 1 }))
+    expect(parsed.success).toBe(false)
+  })
+
+  test("commitId がなければ失敗する", () => {
+    const { commitId: _, ...rest } = makeValidMeta()
+    const parsed = SyncMetaSchema.safeParse(rest)
+    expect(parsed.success).toBe(false)
+  })
+})
+
+describe("writeMeta / readMeta", () => {
+  test("writeMeta でメタファイルを書き込める", () => {
+    const meta = makeValidMeta()
+    writeMeta(TEST_DIR, meta)
+
+    const metaPath = join(TEST_DIR, ".coscli", "テストプロジェクト", "テストページ.json")
+    expect(existsSync(metaPath)).toBe(true)
+  })
+
+  test("writeMeta は中間ディレクトリを自動作成する", () => {
+    const meta = makeValidMeta({ project: "新プロジェクト", title: "新ページ" })
+    writeMeta(TEST_DIR, meta)
+
+    const metaPath = join(TEST_DIR, ".coscli", "新プロジェクト", "新ページ.json")
+    expect(existsSync(metaPath)).toBe(true)
+  })
+
+  test("readMeta で書き込んだメタデータを読み込める", () => {
+    const meta = makeValidMeta()
+    writeMeta(TEST_DIR, meta)
+    const loaded = readMeta(TEST_DIR, "テストプロジェクト", "テストページ")
+
+    expect(loaded).not.toBeNull()
+    expect(loaded?.commitId).toBe("commit-abc")
+    expect(loaded?.title).toBe("テストページ")
+  })
+
+  test("readMeta はファイルが存在しない場合 null を返す", () => {
+    const result = readMeta(TEST_DIR, "存在しないプロジェクト", "存在しないページ")
+    expect(result).toBeNull()
+  })
+
+  test("metaPath はタイトルをファイル名に使う", () => {
+    const meta = makeValidMeta({ title: "通常タイトル" })
+    writeMeta(TEST_DIR, meta)
+
+    const raw = readFileSync(
+      join(TEST_DIR, ".coscli", "テストプロジェクト", "通常タイトル.json"),
+      "utf-8",
+    )
+    const parsed = JSON.parse(raw) as SyncMeta
+    expect(parsed.title).toBe("通常タイトル")
+  })
+})

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -137,4 +137,27 @@ describe("setConfigValue", () => {
     // output.color は "auto"|"always"|"never" のみ許可
     expect(() => setConfigValue(config, "output.color", "invalid")).toThrow()
   })
+
+  it("sync.dir をドット区切りで設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "sync.dir", "/tmp/sync")
+    expect(updated.sync?.dir).toBe("/tmp/sync")
+  })
+
+  it("sync.format に txt を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "sync.format", "txt")
+    expect(updated.sync?.format).toBe("txt")
+  })
+
+  it("sync.retries に数値を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "sync.retries", 3)
+    expect(updated.sync?.retries).toBe(3)
+  })
+
+  it("sync.format に不正な値を設定するとエラーになる", () => {
+    const config = {}
+    expect(() => setConfigValue(config, "sync.format", "md")).toThrow()
+  })
 })

--- a/tests/unit/presenter/json.test.ts
+++ b/tests/unit/presenter/json.test.ts
@@ -94,6 +94,7 @@ describe("writeErrorJson", () => {
       "NOT_FOUND",
       "ページが見つかりません",
       undefined,
+      undefined,
       stream as unknown as NodeJS.WritableStream,
     )
     const parsed = JSON.parse(stream.output)
@@ -108,6 +109,7 @@ describe("writeErrorJson", () => {
       "AUTH_FAILED",
       "認証に失敗しました",
       "`cos auth login` を実行してください",
+      undefined,
       stream as unknown as NodeJS.WritableStream,
     )
     const parsed = JSON.parse(stream.output)


### PR DESCRIPTION
## Summary

- `cos sync pull [<title>|--all]` — Cosense → ローカル `.txt` ファイルに保存
- `cos sync push [<title>|--all]` — ローカル → Cosense へ push (commitId 楽観ロック競合検出)
- `cos sync diff [<title>|--all]` — LCS ベースの行差分表示 (`--plain` で unified diff 風)
- `--dry-run`, `--dir`, `--retries` フラグ対応
- 同期メタを `<dir>/.coscli/<project>/<title>.json` に保存 (commitId / contentSha256 記録)
- タイトル禁則文字チェック (`FilenameInvalidError`) — exit 5
- 楽観ロック競合 — exit 6; `--retries N` でローカル未編集時は自動 re-pull 試行

## Test plan

- [x] `tests/unit/core/sync/fsname.test.ts` — safeFsName バリデーション (14 tests)
- [x] `tests/unit/core/sync/diff.test.ts` — LCS 行差分アルゴリズム (11 tests)
- [x] `tests/unit/core/sync/meta.test.ts` — SyncMeta read/write (8 tests)
- [x] `tests/unit/core/sync/local.test.ts` — ローカルファイル IO + sha256 (11 tests)
- [x] `tests/unit/core/sync/engine.test.ts` — pull/push/diff ドメインロジック (15 tests)
- [x] `tests/unit/commands/sync/pull.test.ts` — pull コマンド (5 tests)
- [x] `tests/unit/commands/sync/push.test.ts` — push コマンド (4 tests)
- [x] `tests/unit/commands/sync/diff.test.ts` — diff コマンド (4 tests)
- [x] `bunx biome check src tests` — エラーゼロ
- [x] `bun run typecheck` — エラーゼロ
- [x] `bun test` — 288 pass, 0 fail

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 新しい sync コマンド群を追加：cos sync pull / push / diff（単一ページ・--all、--dir/設定読み取り、--json/--plain、dry-run）
  * 差分表示（行単位のdiff）、プッシュ時の再試行/コンフリクト処理、集約出力と終了コード制御

* **改善**
  * ファイル名バリデーション強化（無効タイトルを検出して明確なエラーを返す）
  * ローカル同期メタの永続化とハッシュ検証、ローカルファイル入出力と SHA-256 計算
  * 設定スキーマに sync オプションを追加、エラー出力に追加データ対応

* **テスト**
  * 各コマンドと同期コアの包括的なユニットテストを追加・拡充
<!-- end of auto-generated comment: release notes by coderabbit.ai -->