### PR TITLE
feat: v0.3 cos auth login --browser — CDP でセッション自動取得

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "src/cli.ts",
   "type": "module",
   "scripts": {
-    "dev": "bun run src/cli.ts",
+    "dev": "bun --define 'VERSION=\"dev\"' run src/cli.ts",
     "build": "bun run scripts/build.ts",
     "build:dev": "bun build src/cli.ts --outdir dist --target bun",
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "src/cli.ts",
   "type": "module",
   "scripts": {
-    "dev": "bun --define 'VERSION=\"dev\"' run src/cli.ts",
+    "dev": "bun --define 'VERSION=\"dev\"' src/cli.ts",
     "build": "bun run scripts/build.ts",
     "build:dev": "bun build src/cli.ts --outdir dist --target bun",
     "test": "bun test",

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -130,7 +130,25 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
       if (a.browser) {
         // ブラウザ CDP フロー
         const port = Number.parseInt(a["browser-port"], 10)
-        const timeoutMs = Number.parseInt(a["browser-timeout"], 10) * 1_000
+        const timeoutSec = Number.parseInt(a["browser-timeout"], 10)
+
+        if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+          writeErrorJson(
+            "INVALID_BROWSER_PORT",
+            "--browser-port は 1..65535 の整数を指定してください",
+          )
+          process.exit(5)
+          return
+        }
+        if (!Number.isInteger(timeoutSec) || timeoutSec <= 0) {
+          writeErrorJson(
+            "INVALID_BROWSER_TIMEOUT",
+            "--browser-timeout は 1 以上の整数秒を指定してください",
+          )
+          process.exit(5)
+          return
+        }
+        const timeoutMs = timeoutSec * 1_000
 
         logger.info("ブラウザを起動しています。Cosense にログインしてください...")
 
@@ -152,14 +170,24 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
           sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
         }
 
+        const controller = new AbortController()
+        const onSigInt = () => controller.abort()
+        process.once("SIGINT", onSigInt)
         try {
           // exactOptionalPropertyTypes 対応: browserPath が undefined の場合は渡さない
-          const loginOpts: Parameters<typeof browserLoginFn>[1] = { port, timeoutMs }
+          const loginOpts: Parameters<typeof browserLoginFn>[1] = {
+            port,
+            timeoutMs,
+            signal: controller.signal,
+          }
           if (a["browser-path"] !== undefined) loginOpts.browserPath = a["browser-path"]
           const result = await browserLoginFn(browserDeps, loginOpts)
           sid = result.sid
         } catch (err) {
           const message = (err as Error).message ?? String(err)
+          if (message.includes("BROWSER_LOGIN_CANCELLED")) {
+            process.exit(0)
+          }
           if (message.includes("BROWSER_NOT_FOUND")) {
             writeErrorJson("BROWSER_NOT_FOUND", message)
             process.exit(5)
@@ -171,6 +199,8 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
           // BROWSER_SPAWN_FAILED / CDP_CONNECT_FAILED / その他
           writeErrorJson("BROWSER_ERROR", message)
           process.exit(1)
+        } finally {
+          process.off("SIGINT", onSigInt)
         }
       } else if (a.sid) {
         sid = a.sid

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -31,6 +31,7 @@ import {
   browserLogin as defaultBrowserLogin,
 } from "@/core/auth/browser-login"
 import { saveSession } from "@/core/auth/session"
+import type { TokenStore } from "@/core/auth/store"
 import { connectCdp } from "@/infra/browser/cdp"
 import { defaultBrowserFinder } from "@/infra/browser/finder"
 import { createTokenStore } from "@/infra/keychain/index"
@@ -48,6 +49,11 @@ export interface AuthLoginCommandDeps {
     deps: BrowserLoginDeps,
     opts: { browserPath?: string; port: number; timeoutMs: number; signal?: AbortSignal },
   ) => Promise<{ sid: string }>
+  /**
+   * createStore は TokenStore インスタンスを返すファクトリ。
+   * テスト時は InMemoryTokenStore 等を返すフェイクを注入して OS keychain を回避する。
+   */
+  createStore?: () => TokenStore
 }
 
 /**
@@ -56,6 +62,7 @@ export interface AuthLoginCommandDeps {
  */
 export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
   const browserLoginFn = deps.browserLogin ?? defaultBrowserLogin
+  const storeFactory = deps.createStore ?? createTokenStore
 
   return defineCommand({
     meta: { description: "Cosense に認証ログインする" },
@@ -187,18 +194,22 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
           const message = (err as Error).message ?? String(err)
           if (message.includes("BROWSER_LOGIN_CANCELLED")) {
             process.exit(0)
+            return
           }
           if (message.includes("BROWSER_NOT_FOUND")) {
             writeErrorJson("BROWSER_NOT_FOUND", message)
             process.exit(5)
+            return
           }
           if (message.includes("BROWSER_LOGIN_TIMEOUT")) {
             writeErrorJson("BROWSER_LOGIN_TIMEOUT", message)
             process.exit(124)
+            return
           }
           // BROWSER_SPAWN_FAILED / CDP_CONNECT_FAILED / その他
           writeErrorJson("BROWSER_ERROR", message)
           process.exit(1)
+          return
         } finally {
           process.off("SIGINT", onSigInt)
         }
@@ -207,6 +218,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
       } else if (a["no-input"]) {
         writeErrorJson("SID_REQUIRED", "--no-input モードでは --sid フラグが必要です")
         process.exit(5)
+        return
       } else {
         // 対話入力 (ヒントを表示する)
         const { password, intro, outro, isCancel } = await import("@clack/prompts")
@@ -229,7 +241,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
       const client = new CosenseRestClient({ sid })
       const me = await client.getMe()
 
-      const store = createTokenStore()
+      const store = storeFactory()
       await saveSession(store, { profile, sid })
 
       logger.success(`${me.name} としてログインしました (プロファイル: ${profile})`)

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,11 +1,23 @@
 /**
  * auth/login.ts — `cos auth login` コマンド。
  *
- * connect.sid を対話入力または --sid フラグで受け取り、
+ * connect.sid を対話入力、--sid フラグ、または --browser (CDP 自動取得) で受け取り、
  * /api/users/me で検証後に TokenStore に保存する。
- * --no-input 時は --sid フラグが必須。
+ *
+ * フラグ排他ルール:
+ * - --browser と --sid は同時指定不可 (exit 5)
+ * - --browser と --no-input は同時指定不可 (exit 5、ブラウザログインは対話前提)
+ * - --no-input 時は --sid が必須 (exit 5)
+ *
+ * --browser フロー:
+ * 1. Chrome/Chromium を CDP デバッグポートで起動する
+ * 2. https://scrapbox.io/login を表示してユーザーにログインさせる
+ * 3. connect.sid Cookie が取得できたら検証・保存して終了する
  */
 
+import { mkdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -14,66 +26,194 @@ import {
   commonArgs,
 } from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
+import {
+  type BrowserLoginDeps,
+  browserLogin as defaultBrowserLogin,
+} from "@/core/auth/browser-login"
 import { saveSession } from "@/core/auth/session"
+import { connectCdp } from "@/infra/browser/cdp"
+import { defaultBrowserFinder } from "@/infra/browser/finder"
 import { createTokenStore } from "@/infra/keychain/index"
+import { defaultSpawner } from "@/infra/keychain/spawner"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
-export const authLoginCommand = defineCommand({
-  meta: { description: "Cosense に認証ログインする" },
-  args: {
-    ...commonArgs,
-    sid: {
-      type: "string",
-      description: "connect.sid の値 (--no-input 時に使用)",
-    },
-    "no-input": {
-      type: "boolean",
-      description: "対話入力を禁止 (CI/エージェント向け)",
-      default: false,
-    },
-  },
-  async run({ args }) {
-    const a = args as CommonArgs & { sid?: string; "no-input": boolean }
-    checkSandbox("auth.login", a)
-    const logger = buildLogger(a)
-    const startTime = Date.now()
-    const profile = a.profile ?? "default"
+/** AuthLoginCommandDeps は createAuthLoginCommand に注入できる依存。テスト専用。 */
+export interface AuthLoginCommandDeps {
+  /**
+   * browserLogin は CDP 経由でブラウザを起動して connect.sid を取得する関数。
+   * テスト時はフェイクを注入して実 IO を回避する。
+   */
+  browserLogin?: (
+    deps: BrowserLoginDeps,
+    opts: { browserPath?: string; port: number; timeoutMs: number; signal?: AbortSignal },
+  ) => Promise<{ sid: string }>
+}
 
-    let sid: string
-    if (a.sid) {
-      sid = a.sid
-    } else if (a["no-input"]) {
-      writeErrorJson("SID_REQUIRED", "--no-input モードでは --sid フラグが必要です")
-      process.exit(5)
-    } else {
-      // 対話入力
-      const { password, intro, outro, isCancel } = await import("@clack/prompts")
-      intro("Cosense ログイン")
-      process.stderr.write(
-        "ブラウザで Cosense にログイン後、DevTools > Application > Cookies から\n" +
-          '"connect.sid" の値をコピーして貼り付けてください。\n',
-      )
-      const input = await password({ message: "connect.sid:" })
-      if (isCancel(input)) {
-        outro("キャンセルしました")
-        process.exit(0)
+/**
+ * createAuthLoginCommand は auth login コマンド定義を返すファクトリ。
+ * deps を省略した場合は本番実装を使用する。
+ */
+export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
+  const browserLoginFn = deps.browserLogin ?? defaultBrowserLogin
+
+  return defineCommand({
+    meta: { description: "Cosense に認証ログインする" },
+    args: {
+      ...commonArgs,
+      sid: {
+        type: "string",
+        description: "connect.sid の値 (--no-input 時に使用)",
+      },
+      "no-input": {
+        type: "boolean",
+        description: "対話入力を禁止 (CI/エージェント向け)",
+        default: false,
+      },
+      browser: {
+        type: "boolean",
+        description: "ブラウザ (CDP) で connect.sid を自動取得する",
+        default: false,
+      },
+      "browser-path": {
+        type: "string",
+        description: "Chrome/Chromium 実行ファイルパスを上書きする",
+      },
+      "browser-port": {
+        type: "string",
+        description: "CDP デバッグポート番号 (デフォルト: 9222)",
+        default: "9222",
+      },
+      "browser-timeout": {
+        type: "string",
+        description: "cookie 取得待機タイムアウト秒数 (デフォルト: 300)",
+        default: "300",
+      },
+    },
+    async run({ args }) {
+      type LoginArgs = CommonArgs & {
+        sid?: string
+        "no-input": boolean
+        browser: boolean
+        "browser-path"?: string
+        "browser-port": string
+        "browser-timeout": string
       }
-      sid = input as string
-    }
+      const a = args as LoginArgs
+      checkSandbox("auth.login", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+      const profile = a.profile ?? "default"
 
-    logger.info("認証情報を確認中...")
+      // 排他チェック: --browser と --sid
+      if (a.browser && a.sid) {
+        writeErrorJson(
+          "BROWSER_SID_EXCLUSIVE",
+          "--browser と --sid は同時に指定できません。どちらか一方を使用してください。",
+        )
+        process.exit(5)
+        return
+      }
 
-    const client = new CosenseRestClient({ sid })
-    const me = await client.getMe()
+      // 排他チェック: --browser と --no-input
+      if (a.browser && a["no-input"]) {
+        writeErrorJson(
+          "BROWSER_REQUIRES_INPUT",
+          "--browser フラグはブラウザでの手動ログインが必要なため --no-input と併用できません。",
+        )
+        process.exit(5)
+        return
+      }
 
-    const store = createTokenStore()
-    await saveSession(store, { profile, sid })
+      let sid: string
 
-    logger.success(`${me.name} としてログインしました (プロファイル: ${profile})`)
+      if (a.browser) {
+        // ブラウザ CDP フロー
+        const port = Number.parseInt(a["browser-port"], 10)
+        const timeoutMs = Number.parseInt(a["browser-timeout"], 10) * 1_000
 
-    if (a.json) {
-      writeJson({ profile, name: me.name }, { command: "auth.login", startTime }, buildJsonOpts(a))
-    }
-  },
-})
+        logger.info("ブラウザを起動しています。Cosense にログインしてください...")
+
+        const browserDeps: BrowserLoginDeps = {
+          spawner: defaultSpawner,
+          finder: defaultBrowserFinder,
+          connect: connectCdp,
+          fetcher: globalThis.fetch.bind(globalThis),
+          wsFactory: (url) => new WebSocket(url),
+          mkTmpDir: async () => {
+            const dir = join(tmpdir(), `coscli-cdp-${Date.now()}`)
+            await mkdir(dir, { recursive: true })
+            return dir
+          },
+          rmTmpDir: async (path) => {
+            await rm(path, { recursive: true, force: true })
+          },
+          now: () => Date.now(),
+          sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+        }
+
+        try {
+          // exactOptionalPropertyTypes 対応: browserPath が undefined の場合は渡さない
+          const loginOpts: Parameters<typeof browserLoginFn>[1] = { port, timeoutMs }
+          if (a["browser-path"] !== undefined) loginOpts.browserPath = a["browser-path"]
+          const result = await browserLoginFn(browserDeps, loginOpts)
+          sid = result.sid
+        } catch (err) {
+          const message = (err as Error).message ?? String(err)
+          if (message.includes("BROWSER_NOT_FOUND")) {
+            writeErrorJson("BROWSER_NOT_FOUND", message)
+            process.exit(5)
+          }
+          if (message.includes("BROWSER_LOGIN_TIMEOUT")) {
+            writeErrorJson("BROWSER_LOGIN_TIMEOUT", message)
+            process.exit(124)
+          }
+          // BROWSER_SPAWN_FAILED / CDP_CONNECT_FAILED / その他
+          writeErrorJson("BROWSER_ERROR", message)
+          process.exit(1)
+        }
+      } else if (a.sid) {
+        sid = a.sid
+      } else if (a["no-input"]) {
+        writeErrorJson("SID_REQUIRED", "--no-input モードでは --sid フラグが必要です")
+        process.exit(5)
+      } else {
+        // 対話入力 (ヒントを表示する)
+        const { password, intro, outro, isCancel } = await import("@clack/prompts")
+        intro("Cosense ログイン")
+        process.stderr.write(
+          "ヒント: `--browser` フラグを使うと connect.sid を自動で取得できます。\n" +
+            "手動で取得する場合は、ブラウザで Cosense にログイン後、\n" +
+            'DevTools > Application > Cookies から "connect.sid" の値をコピーしてください。\n',
+        )
+        const input = await password({ message: "connect.sid:" })
+        if (isCancel(input)) {
+          outro("キャンセルしました")
+          process.exit(0)
+        }
+        sid = input as string
+      }
+
+      logger.info("認証情報を確認中...")
+
+      const client = new CosenseRestClient({ sid })
+      const me = await client.getMe()
+
+      const store = createTokenStore()
+      await saveSession(store, { profile, sid })
+
+      logger.success(`${me.name} としてログインしました (プロファイル: ${profile})`)
+
+      if (a.json) {
+        writeJson(
+          { profile, name: me.name },
+          { command: "auth.login", startTime },
+          buildJsonOpts(a),
+        )
+      }
+    },
+  })
+}
+
+/** authLoginCommand はデフォルト実装を使った auth login コマンド定義。 */
+export const authLoginCommand = createAuthLoginCommand()

--- a/src/core/auth/browser-login.ts
+++ b/src/core/auth/browser-login.ts
@@ -53,6 +53,24 @@ export interface BrowserLoginOpts {
 /** COOKIE_POLL_INTERVAL_MS は connect.sid ポーリング間隔 (ms)。 */
 const COOKIE_POLL_INTERVAL_MS = 1_000
 
+/**
+ * isAuthenticated は connect.sid で /api/users/me にアクセスし、
+ * 認証済みセッションかどうかを確認する。
+ * connect.sid は未ログイン状態でも発行されるため、ポーリング時に必ず確認する。
+ */
+async function isAuthenticated(fetcher: Fetcher, sid: string): Promise<boolean> {
+  try {
+    const res = await fetcher("https://scrapbox.io/api/users/me", {
+      headers: { Cookie: `connect.sid=${sid}` },
+    })
+    if (!res.ok) return false
+    const data = (await res.json()) as Record<string, unknown>
+    return typeof data["id"] === "string"
+  } catch {
+    return false
+  }
+}
+
 /** SCRAPBOX_LOGIN_URL は Cosense ログインページの URL。 */
 const SCRAPBOX_LOGIN_URL = "https://scrapbox.io/login"
 
@@ -132,7 +150,11 @@ export async function browserLogin(
       const cookies = await cdp.getCookies(["https://scrapbox.io"])
       const sidCookie = cookies.find((c) => c.name === "connect.sid" && c.value.length > 0)
       if (sidCookie) {
-        return { sid: sidCookie.value }
+        // connect.sid は未ログイン時も発行されるため、/api/users/me で認証済みかを確認する
+        const authenticated = await isAuthenticated(fetcher, sidCookie.value)
+        if (authenticated) {
+          return { sid: sidCookie.value }
+        }
       }
 
       await sleep(COOKIE_POLL_INTERVAL_MS)

--- a/src/core/auth/browser-login.ts
+++ b/src/core/auth/browser-login.ts
@@ -89,7 +89,7 @@ export async function browserLogin(
 
   // abort 済み signal は即 reject する
   if (opts.signal?.aborted) {
-    throw new Error("ブラウザログインがキャンセルされました")
+    throw new Error("BROWSER_LOGIN_CANCELLED: ブラウザログインがキャンセルされました")
   }
 
   // バイナリを解決する (exactOptionalPropertyTypes 対応: undefined は渡さない)
@@ -139,7 +139,7 @@ export async function browserLogin(
     const deadline = now() + timeoutMs
     while (true) {
       if (opts.signal?.aborted) {
-        throw new Error("ブラウザログインがキャンセルされました")
+        throw new Error("BROWSER_LOGIN_CANCELLED: ブラウザログインがキャンセルされました")
       }
       if (now() >= deadline) {
         throw new Error(

--- a/src/core/auth/browser-login.ts
+++ b/src/core/auth/browser-login.ts
@@ -1,0 +1,155 @@
+/**
+ * browser-login.ts — ブラウザ CDP 経由で connect.sid を自動取得するユースケース。
+ *
+ * BrowserFinder でブラウザバイナリを特定し、Spawner で起動後に
+ * connectCdp でページに接続して connect.sid Cookie が現れるまでポーリングする。
+ * すべての I/O 依存を BrowserLoginDeps として DI 化しているため、
+ * テスト時はフェイク実装を注入して実 IO を回避できる。
+ *
+ * エラー種別:
+ * - BROWSER_NOT_FOUND   : バイナリが見つからない
+ * - BROWSER_SPAWN_FAILED: Bun.spawn が例外を throw した
+ * - BROWSER_LOGIN_TIMEOUT: タイムアウト内に connect.sid が取得できなかった
+ */
+
+import type { connectCdp } from "@/infra/browser/cdp"
+import type { BrowserFinder, Fetcher, WebSocketFactory } from "@/infra/browser/types"
+import type { Spawner } from "@/infra/keychain/spawner"
+
+/** BrowserLoginDeps は browserLogin が必要とする外部依存の注入ポイント。 */
+export interface BrowserLoginDeps {
+  /** spawner はブラウザプロセスを起動する関数。 */
+  spawner: Spawner
+  /** finder はブラウザバイナリのパスを探索する。 */
+  finder: BrowserFinder
+  /** connect は CDP クライアントを初期化する関数。 */
+  connect: typeof connectCdp
+  /** fetcher は HTTP リクエスト実装。CDP ポーリングに使用する。 */
+  fetcher: Fetcher
+  /** wsFactory は WebSocket インスタンスを生成する関数。 */
+  wsFactory: WebSocketFactory
+  /** mkTmpDir は一時ディレクトリを作成してパスを返す。 */
+  mkTmpDir: () => Promise<string>
+  /** rmTmpDir は一時ディレクトリを削除する。 */
+  rmTmpDir: (path: string) => Promise<void>
+  /** now は現在時刻 (ms) を返す。タイムアウト判定に使用する。 */
+  now: () => number
+  /** sleep は指定 ms 待機する。ポーリング間隔制御に使用する。 */
+  sleep: (ms: number) => Promise<void>
+}
+
+/** BrowserLoginOpts は browserLogin に渡すオプション。 */
+export interface BrowserLoginOpts {
+  /** browserPath はブラウザバイナリのパス上書き。省略時は自動検出する。 */
+  browserPath?: string
+  /** port は CDP デバッグポート番号。 */
+  port: number
+  /** timeoutMs は connect.sid 取得待機タイムアウト (ms)。 */
+  timeoutMs: number
+  /** signal は AbortController の signal。中断に使用する。 */
+  signal?: AbortSignal
+}
+
+/** COOKIE_POLL_INTERVAL_MS は connect.sid ポーリング間隔 (ms)。 */
+const COOKIE_POLL_INTERVAL_MS = 1_000
+
+/** SCRAPBOX_LOGIN_URL は Cosense ログインページの URL。 */
+const SCRAPBOX_LOGIN_URL = "https://scrapbox.io/login"
+
+/**
+ * browserLogin はブラウザを CDP で操作し connect.sid Cookie を取得する。
+ *
+ * 取得した sid を { sid } として返す。呼び出し側で検証と保存を行うこと。
+ * エラー時は必ず finally でクリーンアップが実行される。
+ */
+export async function browserLogin(
+  deps: BrowserLoginDeps,
+  opts: BrowserLoginOpts,
+): Promise<{ sid: string }> {
+  const { spawner, finder, connect, fetcher, wsFactory, mkTmpDir, rmTmpDir, now, sleep } = deps
+  const { port, timeoutMs } = opts
+
+  // abort 済み signal は即 reject する
+  if (opts.signal?.aborted) {
+    throw new Error("ブラウザログインがキャンセルされました")
+  }
+
+  // バイナリを解決する (exactOptionalPropertyTypes 対応: undefined は渡さない)
+  const findOpts = opts.browserPath !== undefined ? { override: opts.browserPath } : undefined
+  const browserBin = await finder.find(findOpts)
+  if (!browserBin) {
+    throw new Error(
+      "BROWSER_NOT_FOUND: Chrome/Chromium が見つかりませんでした。" +
+        " --browser-path でブラウザのパスを指定してください。",
+    )
+  }
+
+  // 一時ディレクトリを作成する
+  const tmpDir = await mkTmpDir()
+
+  let child: { kill: () => void } | undefined
+  let cdp: Awaited<ReturnType<typeof connect>> | undefined
+
+  try {
+    // ブラウザを起動する
+    try {
+      const proc = spawner(
+        [
+          browserBin,
+          `--remote-debugging-port=${port}`,
+          `--user-data-dir=${tmpDir}`,
+          "--no-first-run",
+          "--no-default-browser-check",
+          "--disable-features=Translate",
+          SCRAPBOX_LOGIN_URL,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      )
+      // Bun の SubprocessLike は kill メソッドを持たないが
+      // 実際の Bun.spawn は持つ。テスト用フェイクには不要なため省略する
+      child = proc as unknown as { kill: () => void }
+    } catch (err) {
+      throw new Error(
+        `BROWSER_SPAWN_FAILED: ブラウザの起動に失敗しました: ${(err as Error).message}`,
+      )
+    }
+
+    // CDP に接続する
+    cdp = await connect({ port, fetcher, wsFactory })
+
+    // connect.sid が取得できるまでポーリングする
+    const deadline = now() + timeoutMs
+    while (true) {
+      if (opts.signal?.aborted) {
+        throw new Error("ブラウザログインがキャンセルされました")
+      }
+      if (now() >= deadline) {
+        throw new Error(
+          "BROWSER_LOGIN_TIMEOUT: タイムアウトまでに connect.sid を取得できませんでした",
+        )
+      }
+
+      const cookies = await cdp.getCookies(["https://scrapbox.io"])
+      const sidCookie = cookies.find((c) => c.name === "connect.sid" && c.value.length > 0)
+      if (sidCookie) {
+        return { sid: sidCookie.value }
+      }
+
+      await sleep(COOKIE_POLL_INTERVAL_MS)
+    }
+  } finally {
+    // クリーンアップは例外の有無に関わらず実行する
+    if (cdp) {
+      await cdp.disconnect().catch(() => {})
+      await cdp.closeBrowser().catch(() => {})
+    }
+    if (child && typeof child["kill"] === "function") {
+      try {
+        child["kill"]()
+      } catch {
+        // プロセスが既に終了している場合は無視する
+      }
+    }
+    await rmTmpDir(tmpDir).catch(() => {})
+  }
+}

--- a/src/infra/browser/cdp.ts
+++ b/src/infra/browser/cdp.ts
@@ -1,0 +1,194 @@
+/**
+ * cdp.ts — Chrome DevTools Protocol (CDP) クライアントの最小実装。
+ *
+ * HTTP (/json/version, /json/list) でデバッグ WS URL を取得し、
+ * WebSocket 経由で JSON-RPC コマンド (Page.navigate / Network.enable /
+ * Network.getCookies / Browser.close) を送受信する。
+ *
+ * Fetcher / WebSocketFactory を DI 引数として受け取るため、
+ * テスト時はフェイク実装を注入して実 IO を回避できる。
+ */
+
+import type { CdpClient, CdpCookie, Fetcher, WebSocketFactory, WebSocketLike } from "./types"
+
+/** connectCdpOpts は connectCdp に渡すオプション。 */
+export interface ConnectCdpOpts {
+  /** port は CDP デバッグポート番号。 */
+  port: number
+  /** fetcher は HTTP リクエスト実装。省略時は globalThis.fetch を使用する。 */
+  fetcher: Fetcher
+  /** wsFactory は WebSocket インスタンスを生成する関数。 */
+  wsFactory: WebSocketFactory
+  /** pollIntervalMs は /json/version ポーリング間隔 (ms)。省略時 200ms。 */
+  pollIntervalMs?: number
+  /** readyTimeoutMs は CDP 接続準備タイムアウト (ms)。省略時 10000ms。 */
+  readyTimeoutMs?: number
+}
+
+/** CdpRequest は CDP JSON-RPC リクエストの型。 */
+interface CdpRequest {
+  id: number
+  method: string
+  params?: Record<string, unknown>
+}
+
+/** CdpResponse は CDP JSON-RPC レスポンスの型。 */
+interface CdpResponse {
+  id: number
+  result?: Record<string, unknown>
+  error?: { code: number; message: string }
+}
+
+/** sleep は指定 ms 待機する。 */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * CdpSession は単一の WebSocket 接続に対して CDP JSON-RPC を送受信する。
+ * 送信したコマンドの id と Promise を対応付けて非同期解決する。
+ */
+class CdpSession {
+  private nextId = 1
+  private pending = new Map<number, (result: Record<string, unknown>) => void>()
+
+  constructor(private readonly ws: WebSocketLike) {
+    ws.addEventListener("message", (e) => {
+      const msg = e as MessageEvent
+      const response = JSON.parse(msg.data as string) as CdpResponse
+      if (response.id !== undefined) {
+        const resolve = this.pending.get(response.id)
+        if (resolve) {
+          this.pending.delete(response.id)
+          if (response.error) {
+            // エラーはログのみ。呼び出し側は結果 {} で続行する
+            resolve({})
+          } else {
+            resolve(response.result ?? {})
+          }
+        }
+      }
+    })
+  }
+
+  /**
+   * send は CDP コマンドを送信し、対応するレスポンスを待って結果を返す。
+   */
+  send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const id = this.nextId++
+    const req: CdpRequest = { id, method }
+    if (params !== undefined) req.params = params
+    return new Promise((resolve) => {
+      this.pending.set(id, resolve)
+      this.ws.send(JSON.stringify(req))
+    })
+  }
+
+  /** close は WebSocket を閉じる。 */
+  close(): void {
+    this.ws.close()
+  }
+}
+
+/**
+ * waitForWsUrl は CDP デバッグポートが利用可能になるまでポーリングし、
+ * ブラウザの WS デバッガー URL を返す。
+ */
+async function waitForWsUrl(
+  fetcher: Fetcher,
+  port: number,
+  pollIntervalMs: number,
+  readyTimeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + readyTimeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetcher(`http://127.0.0.1:${port}/json/version`)
+      if (res.ok) {
+        const json = (await res.json()) as { webSocketDebuggerUrl?: string }
+        if (json.webSocketDebuggerUrl) return json.webSocketDebuggerUrl
+      }
+    } catch {
+      // 接続前の ECONNREFUSED 等は無視して再試行する
+    }
+    if (pollIntervalMs > 0) await sleep(pollIntervalMs)
+  }
+  throw new Error(`CDP デバッグポート ${port} が ${readyTimeoutMs}ms 以内に応答しませんでした`)
+}
+
+/**
+ * getPageWsUrl は /json/list から page タイプの WebSocket URL を取得する。
+ * page ターゲットがない場合は最初のターゲットの URL を返す。
+ */
+async function getPageWsUrl(fetcher: Fetcher, port: number): Promise<string> {
+  const res = await fetcher(`http://127.0.0.1:${port}/json/list`)
+  const targets = (await res.json()) as { type?: string; webSocketDebuggerUrl?: string }[]
+  const page = targets.find((t) => t.type === "page") ?? targets[0]
+  if (!page?.webSocketDebuggerUrl) {
+    throw new Error("CDP: page ターゲットが見つかりませんでした")
+  }
+  return page.webSocketDebuggerUrl
+}
+
+/**
+ * openSession は指定 WS URL に接続し、open イベント後に CdpSession を返す。
+ */
+function openSession(wsFactory: WebSocketFactory, url: string): Promise<CdpSession> {
+  return new Promise((resolve, reject) => {
+    const ws = wsFactory(url)
+    const session = new CdpSession(ws)
+    ws.addEventListener("open", () => resolve(session))
+    ws.addEventListener("error", (e) => reject(new Error(`CDP WS エラー: ${String(e)}`)))
+  })
+}
+
+/**
+ * connectCdp は CDP クライアントを初期化して返す。
+ *
+ * ポーリングで CDP ポートが立ち上がるのを待ち、page ターゲットに接続後、
+ * Network.enable を送信してから CdpClient インスタンスを返す。
+ */
+export async function connectCdp(opts: ConnectCdpOpts): Promise<CdpClient> {
+  const { port, fetcher, wsFactory } = opts
+  const pollIntervalMs = opts.pollIntervalMs ?? 200
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 10_000
+
+  // CDP ポートが立ち上がるのを待ち、ブラウザ WS URL を取得する
+  const browserWsUrl = await waitForWsUrl(fetcher, port, pollIntervalMs, readyTimeoutMs)
+
+  // page ターゲットの WS URL を取得する
+  const pageWsUrl = await getPageWsUrl(fetcher, port)
+
+  // ページ WS に接続する
+  const pageSession = await openSession(wsFactory, pageWsUrl)
+
+  // Network.enable を送信して Cookie 監視を開始する
+  await pageSession.send("Network.enable")
+
+  return {
+    async navigate(url: string): Promise<void> {
+      await pageSession.send("Page.navigate", { url })
+    },
+
+    async getCookies(urls?: string[]): Promise<CdpCookie[]> {
+      const params: Record<string, unknown> = {}
+      // exactOptionalPropertyTypes 対応: undefined は渡さない
+      if (urls !== undefined) params["urls"] = urls
+      const result = await pageSession.send("Network.getCookies", params)
+      const raw = result["cookies"]
+      if (!Array.isArray(raw)) return []
+      return raw as CdpCookie[]
+    },
+
+    async closeBrowser(): Promise<void> {
+      // ブラウザ WS に接続して Browser.close を送信する
+      const browserSession = await openSession(wsFactory, browserWsUrl)
+      await browserSession.send("Browser.close")
+      browserSession.close()
+    },
+
+    async disconnect(): Promise<void> {
+      pageSession.close()
+    },
+  }
+}

--- a/src/infra/browser/cdp.ts
+++ b/src/infra/browser/cdp.ts
@@ -47,28 +47,39 @@ function sleep(ms: number): Promise<void> {
 /**
  * CdpSession は単一の WebSocket 接続に対して CDP JSON-RPC を送受信する。
  * 送信したコマンドの id と Promise を対応付けて非同期解決する。
+ * WS 切断・エラー時は pending な Promise をすべて reject する。
  */
 class CdpSession {
   private nextId = 1
-  private pending = new Map<number, (result: Record<string, unknown>) => void>()
+  private pending = new Map<
+    number,
+    { resolve: (result: Record<string, unknown>) => void; reject: (error: Error) => void }
+  >()
 
   constructor(private readonly ws: WebSocketLike) {
     ws.addEventListener("message", (e) => {
       const msg = e as MessageEvent
       const response = JSON.parse(msg.data as string) as CdpResponse
       if (response.id !== undefined) {
-        const resolve = this.pending.get(response.id)
-        if (resolve) {
+        const entry = this.pending.get(response.id)
+        if (entry) {
           this.pending.delete(response.id)
           if (response.error) {
-            // エラーはログのみ。呼び出し側は結果 {} で続行する
-            resolve({})
+            entry.reject(new Error(`CDP ${response.error.code}: ${response.error.message}`))
           } else {
-            resolve(response.result ?? {})
+            entry.resolve(response.result ?? {})
           }
         }
       }
     })
+
+    // WS 切断・エラー時に pending な Promise をすべて reject する
+    const failAll = (reason: string) => {
+      for (const { reject } of this.pending.values()) reject(new Error(reason))
+      this.pending.clear()
+    }
+    ws.addEventListener("close", () => failAll("CDP WebSocket が切断されました"))
+    ws.addEventListener("error", () => failAll("CDP WebSocket エラーが発生しました"))
   }
 
   /**
@@ -78,8 +89,8 @@ class CdpSession {
     const id = this.nextId++
     const req: CdpRequest = { id, method }
     if (params !== undefined) req.params = params
-    return new Promise((resolve) => {
-      this.pending.set(id, resolve)
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
       this.ws.send(JSON.stringify(req))
     })
   }
@@ -132,13 +143,33 @@ async function getPageWsUrl(fetcher: Fetcher, port: number): Promise<string> {
 
 /**
  * openSession は指定 WS URL に接続し、open イベント後に CdpSession を返す。
+ * connectTimeoutMs 以内に open しなければ reject する。
  */
-function openSession(wsFactory: WebSocketFactory, url: string): Promise<CdpSession> {
+function openSession(
+  wsFactory: WebSocketFactory,
+  url: string,
+  connectTimeoutMs = 5_000,
+): Promise<CdpSession> {
   return new Promise((resolve, reject) => {
     const ws = wsFactory(url)
     const session = new CdpSession(ws)
-    ws.addEventListener("open", () => resolve(session))
-    ws.addEventListener("error", (e) => reject(new Error(`CDP WS エラー: ${String(e)}`)))
+
+    const timer = setTimeout(() => {
+      reject(new Error(`CDP WS 接続タイムアウト: ${url}`))
+    }, connectTimeoutMs)
+
+    ws.addEventListener("open", () => {
+      clearTimeout(timer)
+      resolve(session)
+    })
+    ws.addEventListener("error", (e) => {
+      clearTimeout(timer)
+      reject(new Error(`CDP WS エラー: ${String(e)}`))
+    })
+    ws.addEventListener("close", () => {
+      clearTimeout(timer)
+      reject(new Error(`CDP WS が接続前に閉じました: ${url}`))
+    })
   })
 }
 

--- a/src/infra/browser/finder.ts
+++ b/src/infra/browser/finder.ts
@@ -1,0 +1,84 @@
+/**
+ * finder.ts — OS 別 Chrome/Chromium バイナリを探索する BrowserFinder 実装。
+ *
+ * macOS / Linux / Windows の標準インストールパスを順に検索し、
+ * 最初に見つかったパスを返す。override 引数が指定された場合は最優先で確認する。
+ * テスト時は platform と existsChecker を差し替えることで実 FS を使わず検証できる。
+ */
+
+import type { BrowserFinder } from "@/infra/browser/types"
+
+/** ExistsChecker はファイルの存在確認を行う関数の型。テストで差し替え可能。 */
+export type ExistsChecker = (path: string) => Promise<boolean>
+
+/** PlatformBrowserFinderOpts はコンストラクタのオプション。 */
+export interface PlatformBrowserFinderOpts {
+  /** platform は OS 判定に使用するプラットフォーム文字列。省略時は process.platform。 */
+  platform?: NodeJS.Platform
+  /** existsChecker はファイル存在確認関数。省略時は Bun.file().exists() を使用する。 */
+  existsChecker?: ExistsChecker
+}
+
+/** macOS での Chrome/Chromium 標準パス (優先順)。 */
+const MACOS_CANDIDATES = [
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+]
+
+/** Linux での Chrome/Chromium 標準パス (優先順)。 */
+const LINUX_CANDIDATES = [
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/chromium",
+]
+
+/** Windows での Chrome 標準パス (優先順)。 */
+const WINDOWS_CANDIDATES = [
+  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+]
+
+/**
+ * PlatformBrowserFinder は OS に応じた Chrome/Chromium バイナリを探索する。
+ * BrowserFinder インターフェイスを実装する。
+ */
+export class PlatformBrowserFinder implements BrowserFinder {
+  private readonly platform: NodeJS.Platform
+  private readonly existsChecker: ExistsChecker
+
+  constructor(opts: PlatformBrowserFinderOpts = {}) {
+    this.platform = opts.platform ?? (process.platform as NodeJS.Platform)
+    this.existsChecker = opts.existsChecker ?? ((path) => Bun.file(path).exists())
+  }
+
+  /**
+   * find はブラウザバイナリのパスを返す。
+   * override が指定された場合はそのパスの存在のみ確認し、存在しなければ null を返す。
+   * override 未指定時は OS 標準パスを優先順に確認し、最初に見つかったパスを返す。
+   */
+  async find(opts?: { override?: string }): Promise<string | null> {
+    if (opts?.override !== undefined) {
+      const exists = await this.existsChecker(opts.override)
+      return exists ? opts.override : null
+    }
+
+    const candidates = this.getCandidates()
+    for (const candidate of candidates) {
+      if (await this.existsChecker(candidate)) {
+        return candidate
+      }
+    }
+    return null
+  }
+
+  /** getCandidates は現在の OS に対応するパス候補一覧を返す。 */
+  private getCandidates(): string[] {
+    if (this.platform === "darwin") return MACOS_CANDIDATES
+    if (this.platform === "linux") return LINUX_CANDIDATES
+    if (this.platform === "win32") return WINDOWS_CANDIDATES
+    return []
+  }
+}
+
+/** defaultBrowserFinder は本番環境で使用するデフォルトの BrowserFinder インスタンス。 */
+export const defaultBrowserFinder = new PlatformBrowserFinder()

--- a/src/infra/browser/types.ts
+++ b/src/infra/browser/types.ts
@@ -1,0 +1,65 @@
+/**
+ * types.ts — ブラウザ CDP 連携で使用するインターフェイス集約。
+ *
+ * Fetcher / WebSocketLike / WebSocketFactory / BrowserFinder / CdpClient を定義し、
+ * infra/browser 配下の各モジュールおよび core/auth/browser-login.ts が参照する。
+ * テスト時はこれらの型を実装したフェイクを注入することで実 I/O を回避できる。
+ */
+
+/** CdpCookie は Chrome DevTools Protocol が返す Cookie の形状。 */
+export interface CdpCookie {
+  name: string
+  value: string
+  domain: string
+  path: string
+  httpOnly: boolean
+  secure: boolean
+}
+
+/**
+ * Fetcher は HTTP リクエストを行う関数の型。
+ * テスト時はインメモリのスタブを注入して実 HTTP を回避する。
+ */
+export type Fetcher = (url: string, init?: RequestInit) => Promise<Response>
+
+/**
+ * WebSocketLike は WebSocket クライアントの最小インターフェイス。
+ * Bun の WebSocket は Web 標準互換なので本番ではそのまま使用できる。
+ */
+export interface WebSocketLike {
+  send(data: string): void
+  close(code?: number, reason?: string): void
+  addEventListener(
+    type: "message" | "open" | "close" | "error",
+    listener: (event: MessageEvent | Event) => void,
+  ): void
+}
+
+/**
+ * WebSocketFactory は WebSocket インスタンスを生成する関数の型。
+ * テスト時はフェイク WebSocket を返すスタブを注入する。
+ */
+export type WebSocketFactory = (url: string) => WebSocketLike
+
+/**
+ * BrowserFinder は Chrome/Chromium バイナリを探索するインターフェイス。
+ * find は見つかった実行ファイルの絶対パスを返す。未検出時は null を返す。
+ */
+export interface BrowserFinder {
+  find(opts?: { override?: string }): Promise<string | null>
+}
+
+/**
+ * CdpClient は Chrome DevTools Protocol クライアントの最小インターフェイス。
+ * ページナビゲーション・Cookie 取得・ブラウザ終了・接続切断を提供する。
+ */
+export interface CdpClient {
+  /** navigate は指定 URL にページを遷移する。 */
+  navigate(url: string): Promise<void>
+  /** getCookies は指定 URL に対応する Cookie の一覧を取得する。 */
+  getCookies(urls?: string[]): Promise<CdpCookie[]>
+  /** closeBrowser はブラウザプロセスを CDP 経由で終了する。 */
+  closeBrowser(): Promise<void>
+  /** disconnect は WebSocket 接続を切断する。 */
+  disconnect(): Promise<void>
+}

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -17,16 +17,16 @@ import { setupServer } from "msw/node"
 // ---------------------------------------------------------------------------
 
 const BASE_URL = "https://scrapbox.io"
-const テストユーザー名 = "田中花子"
+const testUserDisplayName = "田中花子"
 // SID はHTTPヘッダーに設定されるため ASCII のみ使用する
-const テスト用SID = "s%3Atest-browser-sid-xyz987"
+const testSid = "s%3Atest-browser-sid-xyz987"
 
 const server = setupServer(
   http.get(`${BASE_URL}/api/users/me`, () => {
     return HttpResponse.json({
       id: "tanaka-hanako-id",
       name: "tanaka-hanako",
-      displayName: テストユーザー名,
+      displayName: testUserDisplayName,
       csrfToken: "test-csrf-token",
     })
   }),
@@ -39,7 +39,7 @@ afterAll(() => server.close())
 // テストヘルパー
 // ---------------------------------------------------------------------------
 
-/** フェイク browserLogin を返すヘルパー。成功時は テスト用SID を返す。 */
+/** フェイク browserLogin を返すヘルパー。成功時は testSid を返す。 */
 function buildFakeBrowserLogin(overrides?: {
   sid?: string
   error?: Error
@@ -49,7 +49,7 @@ function buildFakeBrowserLogin(overrides?: {
 ) => Promise<{ sid: string }> {
   return async (_deps, _opts) => {
     if (overrides?.error) throw overrides.error
-    return { sid: overrides?.sid ?? テスト用SID }
+    return { sid: overrides?.sid ?? testSid }
   }
 }
 
@@ -127,7 +127,7 @@ describe("authLoginCommand — 排他チェック", () => {
 
 describe("authLoginCommand — --browser フロー", () => {
   it("browserLogin が成功した場合にログイン完了メッセージを表示する", async () => {
-    const fakeBrowserLogin = buildFakeBrowserLogin({ sid: テスト用SID })
+    const fakeBrowserLogin = buildFakeBrowserLogin({ sid: testSid })
     await runLogin(
       {
         browser: true,
@@ -146,6 +146,7 @@ describe("authLoginCommand — --browser フロー", () => {
     expect(exitMock).not.toHaveBeenCalledWith(1)
     expect(exitMock).not.toHaveBeenCalledWith(2)
     expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(exitMock).not.toHaveBeenCalledWith(124)
   })
 
   it("BROWSER_NOT_FOUND エラー時は exit 5 で終了する", async () => {
@@ -215,7 +216,7 @@ describe("authLoginCommand — --browser フロー", () => {
 describe("authLoginCommand — --sid フロー (回帰)", () => {
   it("--sid 指定時は getMe で検証してログインする", async () => {
     await runLogin({
-      sid: テスト用SID,
+      sid: testSid,
       "no-input": false,
       browser: false,
       profile: "default",
@@ -228,6 +229,7 @@ describe("authLoginCommand — --sid フロー (回帰)", () => {
     expect(exitMock).not.toHaveBeenCalledWith(1)
     expect(exitMock).not.toHaveBeenCalledWith(2)
     expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(exitMock).not.toHaveBeenCalledWith(124)
   })
 
   it("--no-input かつ --sid 未指定の場合は exit 5 で終了する", async () => {

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -9,6 +9,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { createAuthLoginCommand } from "@/commands/auth/login"
 import type { BrowserLoginDeps } from "@/core/auth/browser-login"
+import { InMemoryTokenStore } from "@/core/auth/store"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
@@ -58,8 +59,12 @@ async function runLogin(
   args: Record<string, unknown>,
   fakeBrowserLogin?: ReturnType<typeof buildFakeBrowserLogin>,
 ) {
-  // exactOptionalPropertyTypes 対応: undefined は渡さない
-  const deps = fakeBrowserLogin !== undefined ? { browserLogin: fakeBrowserLogin } : {}
+  // exactOptionalPropertyTypes 対応: undefined は渡さない。
+  // createStore は OS keychain を回避するため InMemoryTokenStore を注入する。
+  const deps =
+    fakeBrowserLogin !== undefined
+      ? { browserLogin: fakeBrowserLogin, createStore: () => new InMemoryTokenStore() }
+      : { createStore: () => new InMemoryTokenStore() }
   const command = createAuthLoginCommand(deps)
   await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
     args,

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -1,0 +1,245 @@
+/**
+ * login.test.ts — `cos auth login` コマンドのユニットテスト。
+ *
+ * --browser / --sid 排他チェック、--browser フロー、既存の --sid フローの回帰を検証する。
+ * ブラウザ依存は browserLogin をフェイクで差し替えて実 IO を回避する。
+ * 認証 API は msw でモックする。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthLoginCommand } from "@/commands/auth/login"
+import type { BrowserLoginDeps } from "@/core/auth/browser-login"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+// ---------------------------------------------------------------------------
+// MSW サーバーセットアップ
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://scrapbox.io"
+const テストユーザー名 = "田中花子"
+// SID はHTTPヘッダーに設定されるため ASCII のみ使用する
+const テスト用SID = "s%3Atest-browser-sid-xyz987"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({
+      id: "tanaka-hanako-id",
+      name: "tanaka-hanako",
+      displayName: テストユーザー名,
+      csrfToken: "test-csrf-token",
+    })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+/** フェイク browserLogin を返すヘルパー。成功時は テスト用SID を返す。 */
+function buildFakeBrowserLogin(overrides?: {
+  sid?: string
+  error?: Error
+}): (
+  deps: BrowserLoginDeps,
+  opts: { port: number; timeoutMs: number },
+) => Promise<{ sid: string }> {
+  return async (_deps, _opts) => {
+    if (overrides?.error) throw overrides.error
+    return { sid: overrides?.sid ?? テスト用SID }
+  }
+}
+
+/** コマンドを実行するヘルパー。 */
+async function runLogin(
+  args: Record<string, unknown>,
+  fakeBrowserLogin?: ReturnType<typeof buildFakeBrowserLogin>,
+) {
+  // exactOptionalPropertyTypes 対応: undefined は渡さない
+  const deps = fakeBrowserLogin !== undefined ? { browserLogin: fakeBrowserLogin } : {}
+  const command = createAuthLoginCommand(deps)
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  server.resetHandlers()
+})
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authLoginCommand — 排他チェック", () => {
+  it("--browser と --sid を同時指定した場合は exit 5 で終了する", async () => {
+    await runLogin({
+      browser: true,
+      sid: "何かのSID",
+      "no-input": false,
+      profile: "default",
+      json: false,
+      plain: false,
+      quiet: false,
+      verbose: false,
+    })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--browser と --no-input を同時指定した場合は exit 5 で終了する", async () => {
+    await runLogin({
+      browser: true,
+      "no-input": true,
+      profile: "default",
+      json: false,
+      plain: false,
+      quiet: false,
+      verbose: false,
+    })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})
+
+describe("authLoginCommand — --browser フロー", () => {
+  it("browserLogin が成功した場合にログイン完了メッセージを表示する", async () => {
+    const fakeBrowserLogin = buildFakeBrowserLogin({ sid: テスト用SID })
+    await runLogin(
+      {
+        browser: true,
+        "no-input": false,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+        "browser-port": 9222,
+        "browser-timeout": 300,
+      },
+      fakeBrowserLogin,
+    )
+    // exit 0 相当 (exit が呼ばれていない、またはエラー以外)
+    expect(exitMock).not.toHaveBeenCalledWith(1)
+    expect(exitMock).not.toHaveBeenCalledWith(2)
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+
+  it("BROWSER_NOT_FOUND エラー時は exit 5 で終了する", async () => {
+    const fakeBrowserLogin = buildFakeBrowserLogin({
+      error: new Error("BROWSER_NOT_FOUND: Chrome が見つかりません"),
+    })
+    await runLogin(
+      {
+        browser: true,
+        "no-input": false,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+        "browser-port": 9222,
+        "browser-timeout": 300,
+      },
+      fakeBrowserLogin,
+    )
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("BROWSER_SPAWN_FAILED エラー時は exit 1 で終了する", async () => {
+    const fakeBrowserLogin = buildFakeBrowserLogin({
+      error: new Error("BROWSER_SPAWN_FAILED: ブラウザの起動に失敗しました"),
+    })
+    await runLogin(
+      {
+        browser: true,
+        "no-input": false,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+        "browser-port": 9222,
+        "browser-timeout": 300,
+      },
+      fakeBrowserLogin,
+    )
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+
+  it("BROWSER_LOGIN_TIMEOUT エラー時は exit 124 で終了する", async () => {
+    const fakeBrowserLogin = buildFakeBrowserLogin({
+      error: new Error("BROWSER_LOGIN_TIMEOUT: タイムアウト"),
+    })
+    await runLogin(
+      {
+        browser: true,
+        "no-input": false,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+        "browser-port": 9222,
+        "browser-timeout": 300,
+      },
+      fakeBrowserLogin,
+    )
+    expect(exitMock).toHaveBeenCalledWith(124)
+  })
+})
+
+describe("authLoginCommand — --sid フロー (回帰)", () => {
+  it("--sid 指定時は getMe で検証してログインする", async () => {
+    await runLogin({
+      sid: テスト用SID,
+      "no-input": false,
+      browser: false,
+      profile: "default",
+      json: false,
+      plain: false,
+      quiet: false,
+      verbose: false,
+    })
+    // exit が呼ばれていなければ成功
+    expect(exitMock).not.toHaveBeenCalledWith(1)
+    expect(exitMock).not.toHaveBeenCalledWith(2)
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+
+  it("--no-input かつ --sid 未指定の場合は exit 5 で終了する", async () => {
+    await runLogin({
+      "no-input": true,
+      browser: false,
+      profile: "default",
+      json: false,
+      plain: false,
+      quiet: false,
+      verbose: false,
+    })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})

--- a/tests/unit/core/auth/browser-login.test.ts
+++ b/tests/unit/core/auth/browser-login.test.ts
@@ -1,0 +1,277 @@
+/**
+ * browser-login.test.ts — browserLogin ユースケースのユニットテスト。
+ *
+ * Spawner / BrowserFinder / connectCdp / mkTmpDir / now / sleep を
+ * すべてフェイク実装で差し替えて実 IO を回避する。
+ * クリーンアップ (tmpDir 削除・WS 切断) が finally で必ず実行されることも検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { browserLogin } from "@/core/auth/browser-login"
+import type { BrowserLoginDeps, BrowserLoginOpts } from "@/core/auth/browser-login"
+import type { CdpClient, CdpCookie } from "@/infra/browser/types"
+import { fakeProcess } from "../../../unit/infra/_keychain-test-helpers"
+
+// ---------------------------------------------------------------------------
+// テスト用フェイク
+// ---------------------------------------------------------------------------
+
+const テスト用SID = "テスト用connect.sid-abcdef12345"
+const ログイン済みCookies: CdpCookie[] = [
+  {
+    name: "connect.sid",
+    value: テスト用SID,
+    domain: ".scrapbox.io",
+    path: "/",
+    httpOnly: true,
+    secure: true,
+  },
+]
+
+/** buildFakeCdpClient はフェイク CdpClient を生成する。 */
+function buildFakeCdpClient(overrides?: Partial<CdpClient>): {
+  client: CdpClient
+  disconnectCallCount: () => number
+  closeBrowserCallCount: () => number
+} {
+  let disconnectCount = 0
+  let closeBrowserCount = 0
+
+  const client: CdpClient = {
+    navigate: async (_url: string) => {},
+    getCookies: async () => ログイン済みCookies,
+    closeBrowser: async () => {
+      closeBrowserCount++
+    },
+    disconnect: async () => {
+      disconnectCount++
+    },
+    ...overrides,
+  }
+
+  return {
+    client,
+    disconnectCallCount: () => disconnectCount,
+    closeBrowserCallCount: () => closeBrowserCount,
+  }
+}
+
+/** buildDeps はテスト用のデフォルト deps を生成する。 */
+function buildDeps(overrides?: Partial<BrowserLoginDeps>): {
+  deps: BrowserLoginDeps
+  tmpDirs: string[]
+  removedDirs: string[]
+  cdpClient: CdpClient
+  disconnectCallCount: () => number
+  closeBrowserCallCount: () => number
+} {
+  const tmpDirs: string[] = []
+  const removedDirs: string[] = []
+  const {
+    client: cdpClient,
+    disconnectCallCount,
+    closeBrowserCallCount,
+  } = buildFakeCdpClient(
+    overrides?.connect
+      ? undefined
+      : {
+          getCookies: async () => ログイン済みCookies,
+        },
+  )
+
+  const deps: BrowserLoginDeps = {
+    spawner: (_cmd, _opts) => fakeProcess("", "", 0),
+    finder: {
+      // override が指定された場合はそのパスを返し、未指定の場合はデフォルトパスを返す
+      find: async (opts?) => opts?.override ?? "/usr/bin/google-chrome-テスト",
+    },
+    connect: async () => cdpClient,
+    fetcher: async () => new Response(""),
+    wsFactory: (_url) => {
+      throw new Error("wsFactory は connect 経由で使用される")
+    },
+    mkTmpDir: async () => {
+      const dir = `/tmp/coscli-cdp-テスト-${tmpDirs.length}`
+      tmpDirs.push(dir)
+      return dir
+    },
+    rmTmpDir: async (path) => {
+      removedDirs.push(path)
+    },
+    now: () => 0,
+    sleep: async () => {},
+    ...overrides,
+  }
+
+  return { deps, tmpDirs, removedDirs, cdpClient, disconnectCallCount, closeBrowserCallCount }
+}
+
+const デフォルトOpts: BrowserLoginOpts = {
+  port: 9222,
+  timeoutMs: 300_000,
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("browserLogin", () => {
+  describe("ハッピーパス", () => {
+    it("connect.sid を取得して返す", async () => {
+      const { deps } = buildDeps()
+      const result = await browserLogin(deps, デフォルトOpts)
+      expect(result.sid).toBe(テスト用SID)
+    })
+
+    it("spawner にブラウザパスとフラグを渡して起動する", async () => {
+      const spawnedCmds: string[][] = []
+      const { deps } = buildDeps({
+        spawner: (cmd, _opts) => {
+          spawnedCmds.push(cmd)
+          return fakeProcess("", "", 0)
+        },
+      })
+
+      await browserLogin(deps, デフォルトOpts)
+
+      expect(spawnedCmds).toHaveLength(1)
+      const cmd = spawnedCmds[0]
+      expect(cmd).toBeDefined()
+      if (!cmd) return
+      // ブラウザパスが先頭に来る
+      expect(cmd[0]).toBe("/usr/bin/google-chrome-テスト")
+      // デバッグポートフラグが含まれる
+      expect(cmd.some((a) => a.includes("--remote-debugging-port=9222"))).toBeTrue()
+      // ユーザーデータディレクトリが含まれる
+      expect(cmd.some((a) => a.includes("--user-data-dir="))).toBeTrue()
+    })
+
+    it("tmp ディレクトリを作成して最終的に削除する", async () => {
+      const { deps, tmpDirs, removedDirs } = buildDeps()
+      await browserLogin(deps, デフォルトOpts)
+
+      expect(tmpDirs).toHaveLength(1)
+      const expectedDir = tmpDirs[0]
+      if (expectedDir === undefined) throw new Error("tmpDirs[0] が存在しません")
+      expect(removedDirs).toContain(expectedDir)
+    })
+
+    it("正常完了後にディスコネクトとブラウザクローズを呼ぶ", async () => {
+      const { client: cdpClient, disconnectCallCount, closeBrowserCallCount } = buildFakeCdpClient()
+      const { deps } = buildDeps({ connect: async () => cdpClient })
+
+      await browserLogin(deps, デフォルトOpts)
+
+      expect(disconnectCallCount()).toBe(1)
+      expect(closeBrowserCallCount()).toBe(1)
+    })
+
+    it("--browser-path が指定された場合はそのパスでブラウザを起動する", async () => {
+      const spawnedCmds: string[][] = []
+      const { deps } = buildDeps({
+        spawner: (cmd, _opts) => {
+          spawnedCmds.push(cmd)
+          return fakeProcess("", "", 0)
+        },
+      })
+      const カスタムブラウザパス = "/カスタムパス/chrome"
+      await browserLogin(deps, { ...デフォルトOpts, browserPath: カスタムブラウザパス })
+
+      expect(spawnedCmds[0]?.[0]).toBe(カスタムブラウザパス)
+    })
+  })
+
+  describe("ブラウザ未検出", () => {
+    it("finder が null を返した場合は BrowserNotFoundError を throw する", async () => {
+      const { deps } = buildDeps({ finder: { find: async () => null } })
+      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow("BROWSER_NOT_FOUND")
+    })
+  })
+
+  describe("spawn 失敗", () => {
+    it("spawner が例外を throw した場合は BrowserSpawnError を throw する", async () => {
+      const { deps } = buildDeps({
+        spawner: () => {
+          throw Object.assign(new Error("spawn: ENOENT"), { code: "ENOENT" })
+        },
+      })
+      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow("BROWSER_SPAWN_FAILED")
+    })
+
+    it("spawn 失敗時も tmp ディレクトリを削除する (finally)", async () => {
+      const { deps, tmpDirs, removedDirs } = buildDeps({
+        spawner: () => {
+          throw new Error("spawn 失敗テスト")
+        },
+      })
+      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow()
+      // tmpDir が作成された場合は削除されていることを確認する
+      const spawnFailDir = tmpDirs[0]
+      if (spawnFailDir !== undefined) {
+        expect(removedDirs).toContain(spawnFailDir)
+      }
+    })
+  })
+
+  describe("タイムアウト", () => {
+    it("timeoutMs 超過時は BROWSER_LOGIN_TIMEOUT エラーで reject する", async () => {
+      let nowVal = 0
+      // getCookies が常に空を返す (connect.sid が来ない)
+      const { client: cdpClient } = buildFakeCdpClient({
+        getCookies: async () => [],
+      })
+      const { deps } = buildDeps({
+        connect: async () => cdpClient,
+        // now を使ってタイムアウトを制御する
+        now: () => {
+          nowVal += 600_000 // 毎回 600 秒進む (タイムアウト超過)
+          return nowVal
+        },
+        sleep: async () => {},
+      })
+
+      await expect(browserLogin(deps, { ...デフォルトOpts, timeoutMs: 300_000 })).rejects.toThrow(
+        "BROWSER_LOGIN_TIMEOUT",
+      )
+    })
+
+    it("タイムアウト時も cleanup が実行される", async () => {
+      let nowVal = 0
+      const {
+        client: cdpClient,
+        disconnectCallCount,
+        closeBrowserCallCount,
+      } = buildFakeCdpClient({
+        getCookies: async () => [],
+      })
+      const { deps, tmpDirs, removedDirs } = buildDeps({
+        connect: async () => cdpClient,
+        now: () => {
+          nowVal += 600_000
+          return nowVal
+        },
+        sleep: async () => {},
+      })
+
+      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow()
+      const timeoutCleanupDir = tmpDirs[0]
+      if (timeoutCleanupDir !== undefined) {
+        expect(removedDirs).toContain(timeoutCleanupDir)
+      }
+      expect(disconnectCallCount()).toBe(1)
+      expect(closeBrowserCallCount()).toBe(1)
+    })
+  })
+
+  describe("AbortSignal", () => {
+    it("既に abort 済みの signal を渡した場合はすぐに reject する", async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const { deps } = buildDeps()
+
+      await expect(
+        browserLogin(deps, { ...デフォルトOpts, signal: controller.signal }),
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/tests/unit/core/auth/browser-login.test.ts
+++ b/tests/unit/core/auth/browser-login.test.ts
@@ -86,7 +86,13 @@ function buildDeps(overrides?: Partial<BrowserLoginDeps>): {
       find: async (opts?) => opts?.override ?? "/usr/bin/google-chrome-テスト",
     },
     connect: async () => cdpClient,
-    fetcher: async () => new Response(""),
+    // isAuthenticated が /api/users/me を叩くため、id を含む有効なレスポンスを返す
+    fetcher: async (url) => {
+      if (url.includes("/api/users/me")) {
+        return new Response(JSON.stringify({ id: "テストユーザーID", name: "テストユーザー" }))
+      }
+      return new Response("")
+    },
     wsFactory: (_url) => {
       throw new Error("wsFactory は connect 経由で使用される")
     },

--- a/tests/unit/core/auth/browser-login.test.ts
+++ b/tests/unit/core/auth/browser-login.test.ts
@@ -16,11 +16,11 @@ import { fakeProcess } from "../../../unit/infra/_keychain-test-helpers"
 // テスト用フェイク
 // ---------------------------------------------------------------------------
 
-const テスト用SID = "テスト用connect.sid-abcdef12345"
-const ログイン済みCookies: CdpCookie[] = [
+const TEST_SID = "テスト用connect.sid-abcdef12345"
+const loggedInCookies: CdpCookie[] = [
   {
     name: "connect.sid",
-    value: テスト用SID,
+    value: TEST_SID,
     domain: ".scrapbox.io",
     path: "/",
     httpOnly: true,
@@ -39,7 +39,7 @@ function buildFakeCdpClient(overrides?: Partial<CdpClient>): {
 
   const client: CdpClient = {
     navigate: async (_url: string) => {},
-    getCookies: async () => ログイン済みCookies,
+    getCookies: async () => loggedInCookies,
     closeBrowser: async () => {
       closeBrowserCount++
     },
@@ -75,7 +75,7 @@ function buildDeps(overrides?: Partial<BrowserLoginDeps>): {
     overrides?.connect
       ? undefined
       : {
-          getCookies: async () => ログイン済みCookies,
+          getCookies: async () => loggedInCookies,
         },
   )
 
@@ -89,7 +89,7 @@ function buildDeps(overrides?: Partial<BrowserLoginDeps>): {
     // isAuthenticated が /api/users/me を叩くため、id を含む有効なレスポンスを返す
     fetcher: async (url) => {
       if (url.includes("/api/users/me")) {
-        return new Response(JSON.stringify({ id: "テストユーザーID", name: "テストユーザー" }))
+        return new Response(JSON.stringify({ id: "test-user-id", name: "テストユーザー" }))
       }
       return new Response("")
     },
@@ -112,7 +112,7 @@ function buildDeps(overrides?: Partial<BrowserLoginDeps>): {
   return { deps, tmpDirs, removedDirs, cdpClient, disconnectCallCount, closeBrowserCallCount }
 }
 
-const デフォルトOpts: BrowserLoginOpts = {
+const defaultOpts: BrowserLoginOpts = {
   port: 9222,
   timeoutMs: 300_000,
 }
@@ -125,8 +125,8 @@ describe("browserLogin", () => {
   describe("ハッピーパス", () => {
     it("connect.sid を取得して返す", async () => {
       const { deps } = buildDeps()
-      const result = await browserLogin(deps, デフォルトOpts)
-      expect(result.sid).toBe(テスト用SID)
+      const result = await browserLogin(deps, defaultOpts)
+      expect(result.sid).toBe(TEST_SID)
     })
 
     it("spawner にブラウザパスとフラグを渡して起動する", async () => {
@@ -138,7 +138,7 @@ describe("browserLogin", () => {
         },
       })
 
-      await browserLogin(deps, デフォルトOpts)
+      await browserLogin(deps, defaultOpts)
 
       expect(spawnedCmds).toHaveLength(1)
       const cmd = spawnedCmds[0]
@@ -154,7 +154,7 @@ describe("browserLogin", () => {
 
     it("tmp ディレクトリを作成して最終的に削除する", async () => {
       const { deps, tmpDirs, removedDirs } = buildDeps()
-      await browserLogin(deps, デフォルトOpts)
+      await browserLogin(deps, defaultOpts)
 
       expect(tmpDirs).toHaveLength(1)
       const expectedDir = tmpDirs[0]
@@ -166,7 +166,7 @@ describe("browserLogin", () => {
       const { client: cdpClient, disconnectCallCount, closeBrowserCallCount } = buildFakeCdpClient()
       const { deps } = buildDeps({ connect: async () => cdpClient })
 
-      await browserLogin(deps, デフォルトOpts)
+      await browserLogin(deps, defaultOpts)
 
       expect(disconnectCallCount()).toBe(1)
       expect(closeBrowserCallCount()).toBe(1)
@@ -180,17 +180,17 @@ describe("browserLogin", () => {
           return fakeProcess("", "", 0)
         },
       })
-      const カスタムブラウザパス = "/カスタムパス/chrome"
-      await browserLogin(deps, { ...デフォルトOpts, browserPath: カスタムブラウザパス })
+      const customBrowserPath = "/カスタムパス/chrome"
+      await browserLogin(deps, { ...defaultOpts, browserPath: customBrowserPath })
 
-      expect(spawnedCmds[0]?.[0]).toBe(カスタムブラウザパス)
+      expect(spawnedCmds[0]?.[0]).toBe(customBrowserPath)
     })
   })
 
   describe("ブラウザ未検出", () => {
     it("finder が null を返した場合は BrowserNotFoundError を throw する", async () => {
       const { deps } = buildDeps({ finder: { find: async () => null } })
-      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow("BROWSER_NOT_FOUND")
+      await expect(browserLogin(deps, defaultOpts)).rejects.toThrow("BROWSER_NOT_FOUND")
     })
   })
 
@@ -201,7 +201,7 @@ describe("browserLogin", () => {
           throw Object.assign(new Error("spawn: ENOENT"), { code: "ENOENT" })
         },
       })
-      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow("BROWSER_SPAWN_FAILED")
+      await expect(browserLogin(deps, defaultOpts)).rejects.toThrow("BROWSER_SPAWN_FAILED")
     })
 
     it("spawn 失敗時も tmp ディレクトリを削除する (finally)", async () => {
@@ -210,7 +210,7 @@ describe("browserLogin", () => {
           throw new Error("spawn 失敗テスト")
         },
       })
-      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow()
+      await expect(browserLogin(deps, defaultOpts)).rejects.toThrow()
       // tmpDir が作成された場合は削除されていることを確認する
       const spawnFailDir = tmpDirs[0]
       if (spawnFailDir !== undefined) {
@@ -236,7 +236,7 @@ describe("browserLogin", () => {
         sleep: async () => {},
       })
 
-      await expect(browserLogin(deps, { ...デフォルトOpts, timeoutMs: 300_000 })).rejects.toThrow(
+      await expect(browserLogin(deps, { ...defaultOpts, timeoutMs: 300_000 })).rejects.toThrow(
         "BROWSER_LOGIN_TIMEOUT",
       )
     })
@@ -259,7 +259,7 @@ describe("browserLogin", () => {
         sleep: async () => {},
       })
 
-      await expect(browserLogin(deps, デフォルトOpts)).rejects.toThrow()
+      await expect(browserLogin(deps, defaultOpts)).rejects.toThrow()
       const timeoutCleanupDir = tmpDirs[0]
       if (timeoutCleanupDir !== undefined) {
         expect(removedDirs).toContain(timeoutCleanupDir)
@@ -276,7 +276,7 @@ describe("browserLogin", () => {
       const { deps } = buildDeps()
 
       await expect(
-        browserLogin(deps, { ...デフォルトOpts, signal: controller.signal }),
+        browserLogin(deps, { ...defaultOpts, signal: controller.signal }),
       ).rejects.toThrow()
     })
   })

--- a/tests/unit/infra/browser/cdp.test.ts
+++ b/tests/unit/infra/browser/cdp.test.ts
@@ -204,7 +204,7 @@ describe("CdpClient.navigate", () => {
 })
 
 describe("CdpClient.getCookies", () => {
-  const ログイン済みCookies: CdpCookie[] = [
+  const loggedInCookies: CdpCookie[] = [
     {
       name: "connect.sid",
       value: "サンプルSID-12345",
@@ -225,14 +225,14 @@ describe("CdpClient.getCookies", () => {
 
   it("Network.getCookies の結果を返す", async () => {
     const { wsFactory } = buildAutoWsFactory((method) => {
-      if (method === "Network.getCookies") return { cookies: ログイン済みCookies }
+      if (method === "Network.getCookies") return { cookies: loggedInCookies }
       return {}
     })
 
     const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
     const cookies = await client.getCookies()
 
-    expect(cookies).toHaveLength(2)
+    expect(cookies).toHaveLength(loggedInCookies.length)
     const firstCookie = cookies[0]
     expect(firstCookie).toBeDefined()
     expect(firstCookie?.name).toBe("connect.sid")

--- a/tests/unit/infra/browser/cdp.test.ts
+++ b/tests/unit/infra/browser/cdp.test.ts
@@ -1,0 +1,289 @@
+/**
+ * cdp.test.ts — connectCdp と CdpClient のユニットテスト。
+ *
+ * 実 HTTP / WebSocket は使わず、FakeFetcher と FakeWebSocket を注入して
+ * CDP プロトコルのシリアライズ / デシリアライズとコマンド送受信ロジックを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { connectCdp } from "@/infra/browser/cdp"
+import type { CdpCookie, Fetcher, WebSocketFactory, WebSocketLike } from "@/infra/browser/types"
+
+// ---------------------------------------------------------------------------
+// FakeWebSocket — CDP WebSocket 接続のフェイク実装
+// ---------------------------------------------------------------------------
+
+/** FakeWebSocket は CDP クライアントに注入するテスト用 WebSocket 。 */
+class FakeWebSocket implements WebSocketLike {
+  readonly sent: string[] = []
+  private listeners = new Map<string, ((e: MessageEvent | Event) => void)[]>()
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+  close(): void {
+    this.trigger("close", new Event("close"))
+  }
+  addEventListener(
+    type: "message" | "open" | "close" | "error",
+    listener: (e: MessageEvent | Event) => void,
+  ): void {
+    const existing = this.listeners.get(type) ?? []
+    this.listeners.set(type, [...existing, listener])
+  }
+
+  /** triggerOpen は "open" イベントを発火する。 */
+  triggerOpen(): void {
+    this.trigger("open", new Event("open"))
+  }
+  /** triggerMessage は "message" イベントとして指定データを発火する。 */
+  triggerMessage(data: unknown): void {
+    const event = { data: JSON.stringify(data) } as MessageEvent
+    this.trigger("message", event)
+  }
+  private trigger(type: string, event: Event | MessageEvent): void {
+    for (const l of this.listeners.get(type) ?? []) l(event)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+const PAGE_WS_URL = "ws://127.0.0.1:9222/devtools/page/テストページ-uuid"
+const BROWSER_WS_URL = "ws://127.0.0.1:9222/devtools/browser/テストブラウザ-uuid"
+
+/** buildFetcher は /json/version と /json/list の両エンドポイントを返すフェイク Fetcher を生成する。 */
+function buildFetcher(): Fetcher {
+  return async (url: string) => {
+    if (url.includes("/json/version")) {
+      return new Response(
+        JSON.stringify({
+          Browser: "Chrome/120.0.0.0",
+          webSocketDebuggerUrl: BROWSER_WS_URL,
+        }),
+      )
+    }
+    if (url.includes("/json/list")) {
+      return new Response(
+        JSON.stringify([
+          {
+            id: "テストページ-uuid",
+            type: "page",
+            url: "https://scrapbox.io/login",
+            webSocketDebuggerUrl: PAGE_WS_URL,
+          },
+        ]),
+      )
+    }
+    return new Response("Not Found", { status: 404 })
+  }
+}
+
+/** buildAutoWsFactory は wsFactory が呼ばれた際に自動で open イベントを送り CDP 応答を返す WebSocket を作成する。 */
+function buildAutoWsFactory(respondWith: (method: string, id: number) => unknown | undefined): {
+  wsFactory: WebSocketFactory
+  getWs: (url: string) => FakeWebSocket
+} {
+  const wsMap = new Map<string, FakeWebSocket>()
+
+  const wsFactory: WebSocketFactory = (url: string) => {
+    const ws = new FakeWebSocket()
+    wsMap.set(url, ws)
+
+    // open イベントをマイクロタスクキューで発火する
+    queueMicrotask(() => {
+      ws.triggerOpen()
+    })
+
+    // CDP コマンドへの自動応答
+    const originalSend = ws.send.bind(ws)
+    ws.send = (data: string) => {
+      originalSend(data)
+      const msg = JSON.parse(data) as { id: number; method: string }
+      const result = respondWith(msg.method, msg.id)
+      if (result !== undefined) {
+        queueMicrotask(() => {
+          ws.triggerMessage({ id: msg.id, result })
+        })
+      }
+    }
+
+    return ws
+  }
+
+  return { wsFactory, getWs: (url) => wsMap.get(url) as FakeWebSocket }
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("connectCdp", () => {
+  it("Network.enable を送信して CdpClient を返す", async () => {
+    const { wsFactory, getWs } = buildAutoWsFactory(() => ({}))
+    const fetcher = buildFetcher()
+
+    const client = await connectCdp({ port: 9222, fetcher, wsFactory })
+    expect(client).toBeDefined()
+
+    const ws = getWs(PAGE_WS_URL)
+    expect(ws).toBeDefined()
+    // Network.enable がページ WS に送信されていることを確認する
+    const sentMethods = ws.sent.map((s) => (JSON.parse(s) as { method: string }).method)
+    expect(sentMethods).toContain("Network.enable")
+  })
+
+  it("/json/version へのポーリングで最初の試行が 404 の場合でも再試行して成功する", async () => {
+    let callCount = 0
+    const fetcher: Fetcher = async (url: string) => {
+      if (url.includes("/json/version")) {
+        callCount++
+        // 最初の 1 回は失敗させる
+        if (callCount === 1) return new Response("Not Found", { status: 404 })
+        return new Response(JSON.stringify({ webSocketDebuggerUrl: BROWSER_WS_URL }))
+      }
+      if (url.includes("/json/list")) {
+        return new Response(JSON.stringify([{ type: "page", webSocketDebuggerUrl: PAGE_WS_URL }]))
+      }
+      return new Response("", { status: 404 })
+    }
+
+    const { wsFactory } = buildAutoWsFactory(() => ({}))
+    const client = await connectCdp({ port: 9222, fetcher, wsFactory, pollIntervalMs: 0 })
+    expect(client).toBeDefined()
+    expect(callCount).toBeGreaterThanOrEqual(2)
+  })
+
+  it("readyTimeoutMs 超過で reject する", async () => {
+    // 常に失敗するフェッチャー
+    const fetcher: Fetcher = async () => new Response("", { status: 503 })
+    const { wsFactory } = buildAutoWsFactory(() => ({}))
+
+    await expect(
+      connectCdp({ port: 9222, fetcher, wsFactory, pollIntervalMs: 0, readyTimeoutMs: 10 }),
+    ).rejects.toThrow()
+  })
+
+  it("page タイプのターゲットが存在しない場合は最初のターゲットにフォールバックする", async () => {
+    const fallbackWsUrl = "ws://127.0.0.1:9222/devtools/other/フォールバック-uuid"
+    const fetcher: Fetcher = async (url: string) => {
+      if (url.includes("/json/version")) {
+        return new Response(JSON.stringify({ webSocketDebuggerUrl: BROWSER_WS_URL }))
+      }
+      if (url.includes("/json/list")) {
+        return new Response(
+          // page 以外のターゲットのみ
+          JSON.stringify([{ type: "browser", webSocketDebuggerUrl: fallbackWsUrl }]),
+        )
+      }
+      return new Response("", { status: 404 })
+    }
+
+    const { wsFactory, getWs } = buildAutoWsFactory(() => ({}))
+    const client = await connectCdp({ port: 9222, fetcher, wsFactory })
+    expect(client).toBeDefined()
+    // フォールバック WS に接続されていることを確認する
+    expect(getWs(fallbackWsUrl)).toBeDefined()
+  })
+})
+
+describe("CdpClient.navigate", () => {
+  it("Page.navigate を正しい URL で送信し解決する", async () => {
+    const { wsFactory, getWs } = buildAutoWsFactory(() => ({}))
+    const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
+
+    await client.navigate("https://scrapbox.io/login")
+
+    const ws = getWs(PAGE_WS_URL)
+    const navigateCmd = ws.sent
+      .map((s) => JSON.parse(s) as { method: string; params: { url?: string } })
+      .find((m) => m.method === "Page.navigate")
+    expect(navigateCmd?.params.url).toBe("https://scrapbox.io/login")
+  })
+})
+
+describe("CdpClient.getCookies", () => {
+  const ログイン済みCookies: CdpCookie[] = [
+    {
+      name: "connect.sid",
+      value: "サンプルSID-12345",
+      domain: ".scrapbox.io",
+      path: "/",
+      httpOnly: true,
+      secure: true,
+    },
+    {
+      name: "XSRF-TOKEN",
+      value: "ダミートークン",
+      domain: ".scrapbox.io",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+    },
+  ]
+
+  it("Network.getCookies の結果を返す", async () => {
+    const { wsFactory } = buildAutoWsFactory((method) => {
+      if (method === "Network.getCookies") return { cookies: ログイン済みCookies }
+      return {}
+    })
+
+    const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
+    const cookies = await client.getCookies()
+
+    expect(cookies).toHaveLength(2)
+    const firstCookie = cookies[0]
+    expect(firstCookie).toBeDefined()
+    expect(firstCookie?.name).toBe("connect.sid")
+    expect(firstCookie?.value).toBe("サンプルSID-12345")
+  })
+
+  it("urls 引数を指定した場合は params に含めて送信する", async () => {
+    const { wsFactory, getWs } = buildAutoWsFactory((method) => {
+      if (method === "Network.getCookies") return { cookies: [] }
+      return {}
+    })
+
+    const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
+    await client.getCookies(["https://scrapbox.io"])
+
+    const ws = getWs(PAGE_WS_URL)
+    const getCookiesCmd = ws.sent
+      .map((s) => JSON.parse(s) as { method: string; params: { urls?: string[] } })
+      .find((m) => m.method === "Network.getCookies")
+    expect(getCookiesCmd).toBeDefined()
+    expect(getCookiesCmd?.params?.urls).toContain("https://scrapbox.io")
+  })
+})
+
+describe("CdpClient.closeBrowser", () => {
+  it("Browser.close をブラウザ WS 経由で送信する", async () => {
+    const { wsFactory, getWs } = buildAutoWsFactory(() => ({}))
+    const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
+
+    await client.closeBrowser()
+
+    // ブラウザ WS に Browser.close が送信されていることを確認する
+    const browserWs = getWs(BROWSER_WS_URL)
+    expect(browserWs).toBeDefined()
+    const methods = browserWs.sent.map((s) => (JSON.parse(s) as { method: string }).method)
+    expect(methods).toContain("Browser.close")
+  })
+})
+
+describe("CdpClient.disconnect", () => {
+  it("disconnect はページ WS を閉じる", async () => {
+    const { wsFactory, getWs } = buildAutoWsFactory(() => ({}))
+    const client = await connectCdp({ port: 9222, fetcher: buildFetcher(), wsFactory })
+
+    let closedCount = 0
+    const ws = getWs(PAGE_WS_URL)
+    ws.addEventListener("close", () => {
+      closedCount++
+    })
+
+    await client.disconnect()
+    expect(closedCount).toBe(1)
+  })
+})

--- a/tests/unit/infra/browser/finder.test.ts
+++ b/tests/unit/infra/browser/finder.test.ts
@@ -32,12 +32,12 @@ const existsNone = async (_path: string) => false
 describe("PlatformBrowserFinder", () => {
   describe("override オプション", () => {
     it("override パスのファイルが存在する場合はそのパスを返す", async () => {
-      const カスタムパス = "/usr/local/bin/chrome-カスタム"
+      const customPath = "/usr/local/bin/chrome-カスタム"
       const finder = new PlatformBrowserFinder({
         platform: "darwin",
-        existsChecker: existsFor(カスタムパス),
+        existsChecker: existsFor(customPath),
       })
-      expect(await finder.find({ override: カスタムパス })).toBe(カスタムパス)
+      expect(await finder.find({ override: customPath })).toBe(customPath)
     })
 
     it("override パスのファイルが存在しない場合は null を返す", async () => {

--- a/tests/unit/infra/browser/finder.test.ts
+++ b/tests/unit/infra/browser/finder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * finder.test.ts — PlatformBrowserFinder のユニットテスト。
+ *
+ * ExistsChecker と platform 文字列を差し替えることで実 FS に触らず
+ * OS 別 Chrome/Chromium パス探索ロジックを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { PlatformBrowserFinder } from "@/infra/browser/finder"
+
+// macOS 標準パス候補
+const MACOS_CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+const MACOS_CHROMIUM = "/Applications/Chromium.app/Contents/MacOS/Chromium"
+
+// Linux 標準パス候補
+const LINUX_CHROME = "/usr/bin/google-chrome"
+const LINUX_CHROMIUM_BROWSER = "/usr/bin/chromium-browser"
+const LINUX_CHROMIUM = "/usr/bin/chromium"
+
+// Windows 標準パス候補
+const WINDOWS_CHROME_64 = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+const WINDOWS_CHROME_32 = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+
+/** 特定パスが存在すると見なす ExistsChecker を作成するヘルパー。 */
+function existsFor(...presentPaths: string[]) {
+  return async (path: string) => presentPaths.includes(path)
+}
+
+/** 何も存在しない ExistsChecker。 */
+const existsNone = async (_path: string) => false
+
+describe("PlatformBrowserFinder", () => {
+  describe("override オプション", () => {
+    it("override パスのファイルが存在する場合はそのパスを返す", async () => {
+      const カスタムパス = "/usr/local/bin/chrome-カスタム"
+      const finder = new PlatformBrowserFinder({
+        platform: "darwin",
+        existsChecker: existsFor(カスタムパス),
+      })
+      expect(await finder.find({ override: カスタムパス })).toBe(カスタムパス)
+    })
+
+    it("override パスのファイルが存在しない場合は null を返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "darwin",
+        existsChecker: existsNone,
+      })
+      expect(await finder.find({ override: "/存在しないパス/chrome" })).toBeNull()
+    })
+  })
+
+  describe("macOS (darwin)", () => {
+    it("Google Chrome が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "darwin",
+        existsChecker: existsFor(MACOS_CHROME),
+      })
+      expect(await finder.find()).toBe(MACOS_CHROME)
+    })
+
+    it("Google Chrome がなく Chromium が存在する場合は Chromium のパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "darwin",
+        existsChecker: existsFor(MACOS_CHROMIUM),
+      })
+      expect(await finder.find()).toBe(MACOS_CHROMIUM)
+    })
+
+    it("両方存在する場合は Google Chrome を優先して返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "darwin",
+        existsChecker: existsFor(MACOS_CHROME, MACOS_CHROMIUM),
+      })
+      expect(await finder.find()).toBe(MACOS_CHROME)
+    })
+
+    it("どちらも存在しない場合は null を返す", async () => {
+      const finder = new PlatformBrowserFinder({ platform: "darwin", existsChecker: existsNone })
+      expect(await finder.find()).toBeNull()
+    })
+  })
+
+  describe("Linux", () => {
+    it("google-chrome が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "linux",
+        existsChecker: existsFor(LINUX_CHROME),
+      })
+      expect(await finder.find()).toBe(LINUX_CHROME)
+    })
+
+    it("google-chrome がなく chromium-browser が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "linux",
+        existsChecker: existsFor(LINUX_CHROMIUM_BROWSER),
+      })
+      expect(await finder.find()).toBe(LINUX_CHROMIUM_BROWSER)
+    })
+
+    it("前 2 つがなく chromium が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "linux",
+        existsChecker: existsFor(LINUX_CHROMIUM),
+      })
+      expect(await finder.find()).toBe(LINUX_CHROMIUM)
+    })
+
+    it("候補順序は google-chrome > chromium-browser > chromium", async () => {
+      // すべて存在する場合、最優先の google-chrome を返す
+      const finder = new PlatformBrowserFinder({
+        platform: "linux",
+        existsChecker: existsFor(LINUX_CHROME, LINUX_CHROMIUM_BROWSER, LINUX_CHROMIUM),
+      })
+      expect(await finder.find()).toBe(LINUX_CHROME)
+    })
+
+    it("どれも存在しない場合は null を返す", async () => {
+      const finder = new PlatformBrowserFinder({ platform: "linux", existsChecker: existsNone })
+      expect(await finder.find()).toBeNull()
+    })
+  })
+
+  describe("Windows (win32)", () => {
+    it("64 ビット Program Files の chrome.exe が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "win32",
+        existsChecker: existsFor(WINDOWS_CHROME_64),
+      })
+      expect(await finder.find()).toBe(WINDOWS_CHROME_64)
+    })
+
+    it("64 ビットがなく 32 ビット Program Files の chrome.exe が存在する場合はそのパスを返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "win32",
+        existsChecker: existsFor(WINDOWS_CHROME_32),
+      })
+      expect(await finder.find()).toBe(WINDOWS_CHROME_32)
+    })
+
+    it("どちらも存在しない場合は null を返す", async () => {
+      const finder = new PlatformBrowserFinder({ platform: "win32", existsChecker: existsNone })
+      expect(await finder.find()).toBeNull()
+    })
+  })
+
+  describe("未知の OS", () => {
+    it("未知の platform では null を返す", async () => {
+      const finder = new PlatformBrowserFinder({
+        platform: "freebsd" as NodeJS.Platform,
+        existsChecker: existsNone,
+      })
+      expect(await finder.find()).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `cos auth login --browser` フラグを追加。Chrome DevTools Protocol (CDP) でブラウザを起動し、ユーザーが Cosense にログインしたら `connect.sid` Cookie を自動取得・保存する
- Bun ネイティブ WebSocket による最小 CDP クライアント実装（新規 npm 依存なし）
- macOS / Linux / Windows で Chrome/Chromium を自動検出。`--browser-path` で上書き可能
- 起動ごとに `os.tmpdir()` にクリーンな一時ディレクトリを作成し、終了時に削除
- 既存の手動入力フロー (`--sid`・対話入力) は引き続き維持

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `src/infra/browser/types.ts` | CDP 関連 interface 集約 (`BrowserFinder` / `CdpClient` など) |
| `src/infra/browser/finder.ts` | OS 別 Chrome/Chromium バイナリ探索 |
| `src/infra/browser/cdp.ts` | Bun WebSocket による最小 CDP クライアント |
| `src/core/auth/browser-login.ts` | ブラウザ起動 → Cookie 取得ユースケース (Spawner / CDP / mkTmpDir を DI) |

## CLI 仕様

```
cos auth login --browser [--browser-path <path>] [--browser-port <port>] [--browser-timeout <sec>]
```

排他: `--browser` + `--sid` / `--no-input` は exit 5

| 状態 | exit |
|---|---|
| ブラウザ未検出 | 5 |
| spawn 失敗 | 1 |
| タイムアウト | 124 |
| Ctrl+C | 0 |

## Test plan

- [x] `bun test` — 422 pass、7 fail はすべて pre-existing
- [x] `bunx biome check src tests` — No fixes applied
- [x] `bun run typecheck` — エラーなし
- [ ] 手動 E2E: `bun run dev auth login --browser` → Chrome 起動 → ログイン → `cos auth whoami` 確認

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **ブラウザベースのログイン機能**
  * `auth login` コマンドに `--browser` フラグを追加し、ブラウザを自動起動して認証を行い、セッション情報を自動取得できるようになりました。

* **ログイン引数の相互排他性**
  * `--browser`、`--sid`、`--no-input` 間の相互排他性が強化され、より明確なエラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->