### PR TITLE
feat: cos serve --rest — ローカル REST プロキシサーバー (Issue #8)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,9 @@ import { syncPushCommand } from "@/commands/sync/push"
 // 変換コマンド
 import { convertCommand } from "@/commands/convert"
 
+// サーブコマンド
+import { serveCommand } from "@/commands/serve"
+
 /** page サブコマンドグループ */
 const pageCommand = defineCommand({
   meta: { description: "ページ操作コマンド" },
@@ -171,6 +174,7 @@ const main = defineCommand({
     config: configCommand,
     sync: syncCommand,
     convert: convertCommand,
+    serve: serveCommand,
   },
 })
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -52,7 +52,6 @@ const PORT_MAX = 65535
 
 /**
  * makeServeCommand は ServeDeps を受け取り、citty コマンドを返すファクトリ。
- *
  * deps を省略すると本番実装 (実際の Bun.serve 起動) を使用する。
  * テスト時は deps にモックを渡してフローを検証する。
  */
@@ -114,9 +113,15 @@ export function makeServeCommand(deps: ServeDeps = {}) {
         return
       }
 
-      // 2. --port バリデーション
-      const portNum = Number.parseInt(a.port, 10)
-      if (!Number.isFinite(portNum) || portNum < PORT_MIN || portNum > PORT_MAX) {
+      // 2. --port バリデーション（先頭数値のみ通す parseInt を避け、厳密な整数文字列を検証する）
+      const isIntegerString = /^\d+$/.test(a.port)
+      const portNum = Number(a.port)
+      if (
+        !isIntegerString ||
+        !Number.isInteger(portNum) ||
+        portNum < PORT_MIN ||
+        portNum > PORT_MAX
+      ) {
         writeErrorJson(
           "INVALID_PORT",
           `--port の値が無効です: ${a.port}`,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -170,8 +170,7 @@ export function makeServeCommand(deps: ServeDeps = {}) {
       process.once("SIGINT", onSig)
       process.once("SIGTERM", onSig)
 
-      // 11. サーバ起動（startServer は signal abort で resolve）
-      // 起動完了後にログ・envelope を出力するため先にメッセージを出す
+      // 11. サーバ起動前にログ・envelope を出力（起動中であることをユーザーに示す）
       const url = `http://${a.host}:${portNum}`
       if (a.json) {
         const jsonOpts = buildJsonOpts(a)
@@ -193,10 +192,15 @@ export function makeServeCommand(deps: ServeDeps = {}) {
         logger.info(`Listening on ${url}  project=${project}${writeDisabled}${authInfo}`)
       }
 
-      await startServerFn(ctx, { port: portNum, hostname: a.host, signal: controller.signal })
+      // 12. サーバ起動（startServer は signal abort で resolve）
+      // finally でシグナルハンドラを確実にクリーンアップする
+      try {
+        await startServerFn(ctx, { port: portNum, hostname: a.host, signal: controller.signal })
+      } finally {
+        process.off("SIGINT", onSig)
+        process.off("SIGTERM", onSig)
+      }
 
-      process.off("SIGINT", onSig)
-      process.off("SIGTERM", onSig)
       process.exit(0)
     },
   })
@@ -216,6 +220,11 @@ async function startBunServer(
     hostname: opts.hostname,
     fetch: fetchHandler,
   })
+  // signal が既に abort 済みの場合は即座に停止する（race condition 対策）
+  if (opts.signal.aborted) {
+    server.stop(true)
+    return
+  }
   await new Promise<void>((resolve) => {
     opts.signal.addEventListener(
       "abort",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,0 +1,232 @@
+/**
+ * serve.ts — `cos serve --rest` コマンド。
+ *
+ * CSRF トークン取得・セッション認証を隠蔽したローカル HTTP プロキシを起動する。
+ * AI エージェントや外部ツールが Cosense API を curl/fetch で操作できるようにする。
+ * Bun.serve() を使い追加依存ゼロ。Ctrl+C (SIGINT/SIGTERM) で graceful shutdown。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+  requireSid,
+} from "@/commands/_shared"
+import { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { createScrapboxWriter } from "@/core/api/ws"
+import { createPolicy } from "@/core/sandbox"
+import { createFetchHandler } from "@/core/server/rest"
+import type { ServerContext } from "@/core/server/types"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/**
+ * ServeDeps は makeServeCommand に渡す依存オブジェクト。
+ *
+ * テスト時にモックを注入できるようにするための DI interface。
+ * startServer は signal を受け取り、abort されたら resolve する。
+ */
+export interface ServeDeps {
+  /** セッション ID 取得関数 (省略時: requireSid) */
+  getSid?: (profile?: string) => Promise<string>
+  /** ScrapboxWriter 生成関数 (省略時: createScrapboxWriter) */
+  createWriter?: (sid: string, dryRun: boolean) => Promise<ScrapboxWriter>
+  /** HTTP サーバ起動関数 (省略時: 実際の Bun.serve)。signal が abort されたら resolve すること。 */
+  startServer?: (
+    ctx: ServerContext,
+    opts: { port: number; hostname: string; signal: AbortSignal },
+  ) => Promise<void>
+}
+
+/** DEFAULT_PORT はデフォルトリッスンポート。 */
+const DEFAULT_PORT = 8080
+/** DEFAULT_HOST はデフォルトリッスンホスト。外部公開防止のためループバックに限定。 */
+const DEFAULT_HOST = "127.0.0.1"
+/** PORT_MIN/MAX は許容ポート範囲。 */
+const PORT_MIN = 1
+const PORT_MAX = 65535
+
+/**
+ * makeServeCommand は ServeDeps を受け取り、citty コマンドを返すファクトリ。
+ *
+ * deps を省略すると本番実装 (実際の Bun.serve 起動) を使用する。
+ * テスト時は deps にモックを渡してフローを検証する。
+ */
+export function makeServeCommand(deps: ServeDeps = {}) {
+  const getSidFn = deps.getSid ?? requireSid
+  const createWriterFn =
+    deps.createWriter ?? ((sid, dryRun) => createScrapboxWriter({ sid, dryRun }))
+  const startServerFn = deps.startServer ?? startBunServer
+
+  return defineCommand({
+    meta: { description: "ローカル REST プロキシサーバーを起動する" },
+    args: {
+      ...commonArgs,
+      rest: {
+        type: "boolean" as const,
+        description: "REST プロキシモードで起動する",
+        default: false,
+      },
+      port: {
+        type: "string" as const,
+        description: `リッスンポート (デフォルト: ${DEFAULT_PORT})`,
+        default: String(DEFAULT_PORT),
+      },
+      host: {
+        type: "string" as const,
+        description: `リッスンホスト (デフォルト: ${DEFAULT_HOST})`,
+        default: DEFAULT_HOST,
+      },
+      token: {
+        type: "string" as const,
+        description: "プロキシ Bearer 認証トークン (設定時のみ要求)",
+      },
+      "allow-write": {
+        type: "boolean" as const,
+        description: "POST/PUT/DELETE (書き込み系) エンドポイントを有効化する",
+        default: false,
+      },
+    },
+
+    async run({ args }) {
+      const a = args as CommonArgs & {
+        rest: boolean
+        port: string
+        host: string
+        token?: string
+        "allow-write": boolean
+      }
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      // 1. --rest 必須チェック
+      if (!a.rest) {
+        writeErrorJson(
+          "MODE_REQUIRED",
+          "--rest フラグを指定してください",
+          "--rest を付けて再実行してください",
+        )
+        process.exit(5)
+        return
+      }
+
+      // 2. --port バリデーション
+      const portNum = Number.parseInt(a.port, 10)
+      if (!Number.isFinite(portNum) || portNum < PORT_MIN || portNum > PORT_MAX) {
+        writeErrorJson(
+          "INVALID_PORT",
+          `--port の値が無効です: ${a.port}`,
+          `${PORT_MIN}〜${PORT_MAX} の整数を指定してください`,
+        )
+        process.exit(5)
+        return
+      }
+
+      // 3. sandbox チェック（プロジェクト取得より前）
+      checkSandbox("serve.rest", a)
+
+      // 4. --project 必須チェック
+      const project = requireProject(a)
+
+      // 5. 認証
+      const sid = await getSidFn(a.profile)
+
+      // 6. --host 外部公開警告
+      if (a.host !== DEFAULT_HOST) {
+        logger.warn(
+          `--host=${a.host} が指定されています。外部ネットワークからアクセス可能になる場合があります。`,
+        )
+      }
+
+      // 7. sandbox ポリシー生成（ハンドラ内の二段ガード用）
+      const enableStr = a["enable-commands"] ?? process.env["COS_ENABLE_COMMANDS"]
+      const disableStr = a["disable-commands"] ?? process.env["COS_DISABLE_COMMANDS"]
+      const policyOpts: Parameters<typeof createPolicy>[0] = {}
+      if (enableStr !== undefined) policyOpts.enableStr = enableStr
+      if (disableStr !== undefined) policyOpts.disableStr = disableStr
+      const policy = createPolicy(policyOpts)
+
+      // 8. クライアント生成
+      const restClient = new CosenseRestClient({ sid })
+      const writer = await createWriterFn(sid, a["dry-run"])
+
+      // 9. ServerContext 組み立て（exactOptionalPropertyTypes 対応: token undefined は渡さない）
+      const ctxBase = {
+        restClient,
+        writer,
+        project,
+        policy,
+        allowWrite: a["allow-write"],
+      }
+      const ctx: ServerContext = a.token !== undefined ? { ...ctxBase, token: a.token } : ctxBase
+
+      // 10. Graceful shutdown の AbortController を設定
+      const controller = new AbortController()
+      const onSig = () => controller.abort()
+      process.once("SIGINT", onSig)
+      process.once("SIGTERM", onSig)
+
+      // 11. サーバ起動（startServer は signal abort で resolve）
+      // 起動完了後にログ・envelope を出力するため先にメッセージを出す
+      const url = `http://${a.host}:${portNum}`
+      if (a.json) {
+        const jsonOpts = buildJsonOpts(a)
+        writeJson(
+          {
+            url,
+            port: portNum,
+            host: a.host,
+            project,
+            allowWrite: a["allow-write"],
+            tokenRequired: a.token !== undefined,
+          },
+          { command: "serve.rest", startTime },
+          jsonOpts,
+        )
+      } else {
+        const writeDisabled = a["allow-write"] ? "" : "  write=disabled"
+        const authInfo = a.token !== undefined ? "  auth=token" : ""
+        logger.info(`Listening on ${url}  project=${project}${writeDisabled}${authInfo}`)
+      }
+
+      await startServerFn(ctx, { port: portNum, hostname: a.host, signal: controller.signal })
+
+      process.off("SIGINT", onSig)
+      process.off("SIGTERM", onSig)
+      process.exit(0)
+    },
+  })
+}
+
+/**
+ * startBunServer は Bun.serve() を使った本番サーバ起動関数。
+ * signal が abort されるとサーバを停止して resolve する。
+ */
+async function startBunServer(
+  ctx: ServerContext,
+  opts: { port: number; hostname: string; signal: AbortSignal },
+): Promise<void> {
+  const fetchHandler = createFetchHandler(ctx)
+  const server = Bun.serve({
+    port: opts.port,
+    hostname: opts.hostname,
+    fetch: fetchHandler,
+  })
+  await new Promise<void>((resolve) => {
+    opts.signal.addEventListener(
+      "abort",
+      () => {
+        server.stop(true)
+        resolve()
+      },
+      { once: true },
+    )
+  })
+}
+
+/** serveCommand はデフォルト依存を使った本番コマンド。 */
+export const serveCommand = makeServeCommand()

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -57,10 +57,7 @@ function buildErrorResponse(
   })
 }
 
-/**
- * toHttpResponse は任意の例外を HTTP Response に変換する。
- * ルートハンドラの catch 節から呼ぶことで統一したエラーレスポンスを返せる。
- */
+/** toHttpResponse は任意の例外を HTTP Response に変換する。ルートハンドラの catch 節から呼ぶことで統一したエラーレスポンスを返せる。 */
 export function toHttpResponse(err: unknown): Response {
   if (err instanceof AuthError) {
     return buildErrorResponse(401, "AUTH_REQUIRED", err.message)

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -87,6 +87,6 @@ export function toHttpResponse(err: unknown): Response {
   if (err instanceof SyntaxError) {
     return buildErrorResponse(400, "INVALID_JSON", err.message)
   }
-  const message = err instanceof Error ? err.message : "予期しないエラーが発生しました"
-  return buildErrorResponse(500, "INTERNAL_ERROR", message)
+  // 内部エラーの詳細はクライアントに漏洩させず、汎用メッセージを返す
+  return buildErrorResponse(500, "INTERNAL_ERROR", "予期しないエラーが発生しました")
 }

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -1,0 +1,92 @@
+/**
+ * errors.ts — HTTP サーバ層のエラー変換ユーティリティ。
+ *
+ * 各例外クラスを適切な HTTP ステータスコードと JSON エラーボディに変換する。
+ * すべてのルートハンドラは catch した例外をこの関数に渡して Response を生成する。
+ */
+
+import {
+  AuthError,
+  CosenseApiError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} from "@/core/api/rest"
+import { PolicyError } from "@/core/sandbox"
+import { ZodError } from "zod"
+
+/** ErrorCode は HTTP エラーレスポンスで使用するエラーコード一覧。 */
+export type ErrorCode =
+  | "AUTH_REQUIRED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "RATE_LIMITED"
+  | "VENDOR_ERROR"
+  | "VALIDATION_ERROR"
+  | "POLICY_DENIED"
+  | "INVALID_JSON"
+  | "PROXY_AUTH_REQUIRED"
+  | "WRITE_DISABLED"
+  | "ROUTE_NOT_FOUND"
+  | "INTERNAL_ERROR"
+
+/** ErrorBody は HTTP エラーレスポンスのボディ形式。 */
+interface ErrorBody {
+  ok: false
+  error: {
+    code: ErrorCode
+    message: string
+    hint?: string
+  }
+}
+
+/** buildErrorResponse は HTTP エラーレスポンスを生成する。 */
+function buildErrorResponse(
+  status: number,
+  code: ErrorCode,
+  message: string,
+  hint?: string,
+): Response {
+  const body: ErrorBody = {
+    ok: false,
+    error: hint ? { code, message, hint } : { code, message },
+  }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+/**
+ * toHttpResponse は任意の例外を HTTP Response に変換する。
+ * ルートハンドラの catch 節から呼ぶことで統一したエラーレスポンスを返せる。
+ */
+export function toHttpResponse(err: unknown): Response {
+  if (err instanceof AuthError) {
+    return buildErrorResponse(401, "AUTH_REQUIRED", err.message)
+  }
+  if (err instanceof ForbiddenError) {
+    return buildErrorResponse(403, "FORBIDDEN", err.message)
+  }
+  if (err instanceof NotFoundError) {
+    return buildErrorResponse(404, "NOT_FOUND", err.message)
+  }
+  if (err instanceof RateLimitError) {
+    return buildErrorResponse(429, "RATE_LIMITED", err.message)
+  }
+  // CosenseApiError のサブクラスより先に判定済みなので、ここは他の CosenseApiError
+  if (err instanceof CosenseApiError) {
+    return buildErrorResponse(err.status, "VENDOR_ERROR", err.message)
+  }
+  if (err instanceof PolicyError) {
+    return buildErrorResponse(403, "POLICY_DENIED", err.message)
+  }
+  if (err instanceof ZodError) {
+    return buildErrorResponse(400, "VALIDATION_ERROR", err.issues.map((i) => i.message).join(", "))
+  }
+  if (err instanceof SyntaxError) {
+    return buildErrorResponse(400, "INVALID_JSON", err.message)
+  }
+  const message = err instanceof Error ? err.message : "予期しないエラーが発生しました"
+  return buildErrorResponse(500, "INTERNAL_ERROR", message)
+}

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -102,23 +102,23 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
       const url = new URL(req.url)
       const pathname = url.pathname
 
-      // プロキシ token 認証チェック（healthz を含むすべてのルートに適用）
-      const tokenError = checkToken(ctx, req)
-      if (tokenError) return tokenError
-
       // ルートマッチング
       const matched = route(req.method, pathname)
       if (!matched) return buildRouteNotFoundResponse(req.method, pathname)
 
       const { key, params } = matched
 
-      // healthz は sandbox・認証不要
+      // healthz は token 認証・sandbox チェックをスキップ
       if (key === "healthz") {
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         })
       }
+
+      // プロキシ token 認証チェック（healthz 以外のすべてのルートに適用）
+      const tokenError = checkToken(ctx, req)
+      if (tokenError) return tokenError
 
       // 書き込み系ルートで allowWrite=false なら即座に 405
       const isWrite = key === "createPage" || key === "editPage" || key === "deletePage"
@@ -143,13 +143,36 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
 
       // ルートハンドラ
       if (key === "listPages") {
-        const skip = url.searchParams.get("skip")
-        const limit = url.searchParams.get("limit")
+        const skipStr = url.searchParams.get("skip")
+        const limitStr = url.searchParams.get("limit")
         const sort = url.searchParams.get("sort") ?? undefined
+
+        // skip/limit は整数のみ許可（NaN 防止）
+        const skip = skipStr !== null ? Number.parseInt(skipStr, 10) : undefined
+        const limit = limitStr !== null ? Number.parseInt(limitStr, 10) : undefined
+        if (skip !== undefined && !Number.isFinite(skip)) {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error: { code: "VALIDATION_ERROR", message: "skip は整数である必要があります" },
+            }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          )
+        }
+        if (limit !== undefined && !Number.isFinite(limit)) {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error: { code: "VALIDATION_ERROR", message: "limit は整数である必要があります" },
+            }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          )
+        }
+
         const result = await listPages(ctx.restClient, {
           project: ctx.project,
-          ...(skip !== null ? { skip: Number(skip) } : {}),
-          ...(limit !== null ? { limit: Number(limit) } : {}),
+          ...(skip !== undefined ? { skip } : {}),
+          ...(limit !== undefined ? { limit } : {}),
           ...(sort !== undefined ? { sort } : {}),
         })
         return buildOkResponse(result)

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -1,0 +1,208 @@
+/**
+ * rest.ts — Bun.serve に渡す fetch ハンドラの生成。
+ *
+ * createFetchHandler に ServerContext を渡すことで、
+ * Cosense API への認証付きプロキシとして機能する fetch ハンドラを返す。
+ * ハンドラは純粋関数として単体テスト可能。
+ */
+
+import { createPage, deletePage, editPage, getPage, getPageText, listPages } from "@/core/pages"
+import { PolicyError } from "@/core/sandbox"
+import { toHttpResponse } from "@/core/server/errors"
+import { route } from "@/core/server/router"
+import type { ServerContext } from "@/core/server/types"
+import { CreatePageBody, EditPageBody } from "@/core/server/types"
+
+/** SuccessBody は成功時の HTTP レスポンスボディ形式。 */
+interface SuccessBody<T> {
+  ok: true
+  data: T
+}
+
+/** buildOkResponse は成功時の JSON レスポンスを生成する。 */
+function buildOkResponse<T>(data: T, status = 200): Response {
+  const body: SuccessBody<T> = { ok: true, data }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+/** WRITE_DISABLED_ERROR は書き込み無効時のレスポンス。 */
+function buildWriteDisabledResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: { code: "WRITE_DISABLED", message: "--allow-write を指定してください" },
+    }),
+    { status: 405, headers: { "Content-Type": "application/json" } },
+  )
+}
+
+/** buildRouteNotFoundResponse は未知ルートのレスポンス。 */
+function buildRouteNotFoundResponse(method: string, pathname: string): Response {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: { code: "ROUTE_NOT_FOUND", message: `${method} ${pathname} は定義されていません` },
+    }),
+    { status: 404, headers: { "Content-Type": "application/json" } },
+  )
+}
+
+/**
+ * checkToken はプロキシ Bearer トークンを検証する。
+ * ctx.token が設定されている場合のみ検証し、
+ * 一致しない場合は 401 PROXY_AUTH_REQUIRED のレスポンスを返す。
+ * 問題なければ null を返す。
+ */
+function checkToken(ctx: ServerContext, req: Request): Response | null {
+  if (!ctx.token) return null
+  const auth = req.headers.get("Authorization")
+  if (!auth || auth !== `Bearer ${ctx.token}`) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: { code: "PROXY_AUTH_REQUIRED", message: "Bearer トークンが必要です" },
+      }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    )
+  }
+  return null
+}
+
+/**
+ * checkPolicy は sandbox ポリシーを検証する。
+ * PolicyError が返った場合は 403 のレスポンスを返す。null なら通過。
+ */
+function checkPolicy(ctx: ServerContext, command: string): Response | null {
+  const err = ctx.policy.allow(command)
+  if (err instanceof PolicyError) {
+    return toHttpResponse(err)
+  }
+  return null
+}
+
+/**
+ * parseJsonBody は JSON リクエストボディをパースする。
+ * パースに失敗した場合は SyntaxError をスローし、toHttpResponse で 400 に変換される。
+ */
+async function parseJsonBody(req: Request): Promise<unknown> {
+  const text = await req.text()
+  return JSON.parse(text)
+}
+
+/**
+ * createFetchHandler は ServerContext を受け取り、
+ * Bun.serve の fetch オプションに渡す Request → Response ハンドラを返す。
+ */
+export function createFetchHandler(ctx: ServerContext): (req: Request) => Promise<Response> {
+  return async (req: Request): Promise<Response> => {
+    try {
+      const url = new URL(req.url)
+      const pathname = url.pathname
+
+      // プロキシ token 認証チェック（healthz を含むすべてのルートに適用）
+      const tokenError = checkToken(ctx, req)
+      if (tokenError) return tokenError
+
+      // ルートマッチング
+      const matched = route(req.method, pathname)
+      if (!matched) return buildRouteNotFoundResponse(req.method, pathname)
+
+      const { key, params } = matched
+
+      // healthz は sandbox・認証不要
+      if (key === "healthz") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+
+      // 書き込み系ルートで allowWrite=false なら即座に 405
+      const isWrite = key === "createPage" || key === "editPage" || key === "deletePage"
+      if (isWrite && !ctx.allowWrite) {
+        return buildWriteDisabledResponse()
+      }
+
+      // sandbox ポリシーチェック（ルートキーをコマンド名に変換）
+      const commandMap: Record<string, string> = {
+        listPages: "page.list",
+        getPage: "page.get",
+        getPageText: "page.text",
+        createPage: "page.new",
+        editPage: "page.edit",
+        deletePage: "page.delete",
+      }
+      const commandName = commandMap[key]
+      if (commandName) {
+        const policyError = checkPolicy(ctx, commandName)
+        if (policyError) return policyError
+      }
+
+      // ルートハンドラ
+      if (key === "listPages") {
+        const skip = url.searchParams.get("skip")
+        const limit = url.searchParams.get("limit")
+        const sort = url.searchParams.get("sort") ?? undefined
+        const result = await listPages(ctx.restClient, {
+          project: ctx.project,
+          ...(skip !== null ? { skip: Number(skip) } : {}),
+          ...(limit !== null ? { limit: Number(limit) } : {}),
+          ...(sort !== undefined ? { sort } : {}),
+        })
+        return buildOkResponse(result)
+      }
+
+      if (key === "getPage") {
+        const title = params["title"] ?? ""
+        const result = await getPage(ctx.restClient, { project: ctx.project, title })
+        return buildOkResponse(result)
+      }
+
+      if (key === "getPageText") {
+        const title = params["title"] ?? ""
+        const text = await getPageText(ctx.restClient, { project: ctx.project, title })
+        return new Response(text, {
+          status: 200,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        })
+      }
+
+      if (key === "createPage") {
+        const raw = await parseJsonBody(req)
+        const body = CreatePageBody.parse(raw)
+        const result = await createPage(ctx.writer, {
+          project: ctx.project,
+          title: body.title,
+          lines: body.lines,
+        })
+        return buildOkResponse(result)
+      }
+
+      if (key === "editPage") {
+        const title = params["title"] ?? ""
+        const raw = await parseJsonBody(req)
+        const body = EditPageBody.parse(raw)
+        const result = await editPage(ctx.writer, {
+          project: ctx.project,
+          title,
+          lines: body.lines,
+        })
+        return buildOkResponse(result)
+      }
+
+      if (key === "deletePage") {
+        const title = params["title"] ?? ""
+        const result = await deletePage(ctx.writer, { project: ctx.project, title })
+        return buildOkResponse(result)
+      }
+
+      // ここには到達しないが型安全のためフォールバック
+      return buildRouteNotFoundResponse(req.method, pathname)
+    } catch (err) {
+      return toHttpResponse(err)
+    }
+  }
+}

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -9,7 +9,7 @@
 import { createPage, deletePage, editPage, getPage, getPageText, listPages } from "@/core/pages"
 import { PolicyError } from "@/core/sandbox"
 import { toHttpResponse } from "@/core/server/errors"
-import { route } from "@/core/server/router"
+import { type RouteKey, route } from "@/core/server/router"
 import type { ServerContext } from "@/core/server/types"
 import { CreatePageBody, EditPageBody } from "@/core/server/types"
 
@@ -127,7 +127,8 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
       }
 
       // sandbox ポリシーチェック（ルートキーをコマンド名に変換）
-      const commandMap: Record<string, string> = {
+      // 網羅型にして新規 RouteKey 追加時のコンパイルエラーでチェック漏れを防ぐ
+      const commandMap: Record<Exclude<RouteKey, "healthz">, string> = {
         listPages: "page.list",
         getPage: "page.get",
         getPageText: "page.text",
@@ -135,11 +136,8 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
         editPage: "page.edit",
         deletePage: "page.delete",
       }
-      const commandName = commandMap[key]
-      if (commandName) {
-        const policyError = checkPolicy(ctx, commandName)
-        if (policyError) return policyError
-      }
+      const policyError = checkPolicy(ctx, commandMap[key as Exclude<RouteKey, "healthz">])
+      if (policyError) return policyError
 
       // ルートハンドラ
       if (key === "listPages") {
@@ -147,10 +145,11 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
         const limitStr = url.searchParams.get("limit")
         const sort = url.searchParams.get("sort") ?? undefined
 
-        // skip/limit は整数のみ許可（NaN 防止）
-        const skip = skipStr !== null ? Number.parseInt(skipStr, 10) : undefined
-        const limit = limitStr !== null ? Number.parseInt(limitStr, 10) : undefined
-        if (skip !== undefined && !Number.isFinite(skip)) {
+        // skip/limit は整数文字列のみ許可（parseInt は先頭数値を通すため正規表現で検証）
+        const intPattern = /^-?\d+$/
+        const skip = skipStr !== null && intPattern.test(skipStr) ? Number(skipStr) : undefined
+        const limit = limitStr !== null && intPattern.test(limitStr) ? Number(limitStr) : undefined
+        if (skipStr !== null && skip === undefined) {
           return new Response(
             JSON.stringify({
               ok: false,
@@ -159,7 +158,7 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
             { status: 400, headers: { "Content-Type": "application/json" } },
           )
         }
-        if (limit !== undefined && !Number.isFinite(limit)) {
+        if (limitStr !== null && limit === undefined) {
           return new Response(
             JSON.stringify({
               ok: false,

--- a/src/core/server/router.ts
+++ b/src/core/server/router.ts
@@ -81,8 +81,9 @@ const ROUTES: RouteDef[] = [
  * マッチした場合は RouteMatch を、マッチしない場合は null を返す。
  */
 export function route(method: string, pathname: string): RouteMatch | null {
+  const upperMethod = method.toUpperCase()
   for (const def of ROUTES) {
-    if (def.method !== method) continue
+    if (def.method !== upperMethod) continue
     const match = def.pattern.exec(pathname)
     if (!match) continue
 
@@ -91,8 +92,12 @@ export function route(method: string, pathname: string): RouteMatch | null {
       const name = def.paramNames[i]
       const value = match[i + 1]
       if (name !== undefined && value !== undefined) {
-        // URL エンコードされたパスセグメントをデコードする
-        params[name] = decodeURIComponent(value)
+        // malformed な URL エンコードは 404 扱いにするため null を返す
+        try {
+          params[name] = decodeURIComponent(value)
+        } catch {
+          return null
+        }
       }
     }
     return { key: def.key, params }

--- a/src/core/server/router.ts
+++ b/src/core/server/router.ts
@@ -1,0 +1,101 @@
+/**
+ * router.ts — HTTP メソッドとパスを対応するハンドラキーと params にマッピングする。
+ *
+ * パステンプレート（例: /api/pages/:title）を正規表現で評価し、
+ * params オブジェクトにデコード済みの値を格納して返す。
+ */
+
+/** RouteKey はルーターが識別する各エンドポイントのキー。 */
+export type RouteKey =
+  | "healthz"
+  | "listPages"
+  | "getPage"
+  | "getPageText"
+  | "createPage"
+  | "editPage"
+  | "deletePage"
+
+/** RouteMatch はマッチ結果。key でハンドラを選択し params で動的セグメントを取得する。 */
+export interface RouteMatch {
+  key: RouteKey
+  params: Record<string, string>
+}
+
+/** RouteDef はルート定義。メソッド・テンプレート・named capture group で構成する。 */
+interface RouteDef {
+  method: string
+  pattern: RegExp
+  key: RouteKey
+  paramNames: string[]
+}
+
+/** ROUTES は全ルート定義の一覧。上から順に評価する。 */
+const ROUTES: RouteDef[] = [
+  {
+    method: "GET",
+    pattern: /^\/healthz$/,
+    key: "healthz",
+    paramNames: [],
+  },
+  {
+    method: "GET",
+    // /text サフィックスを先に評価してから /:title にフォールバックするため先に定義
+    pattern: /^\/api\/pages\/([^/]+)\/text$/,
+    key: "getPageText",
+    paramNames: ["title"],
+  },
+  {
+    method: "GET",
+    pattern: /^\/api\/pages\/([^/]+)$/,
+    key: "getPage",
+    paramNames: ["title"],
+  },
+  {
+    method: "GET",
+    pattern: /^\/api\/pages$/,
+    key: "listPages",
+    paramNames: [],
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/pages$/,
+    key: "createPage",
+    paramNames: [],
+  },
+  {
+    method: "PUT",
+    pattern: /^\/api\/pages\/([^/]+)$/,
+    key: "editPage",
+    paramNames: ["title"],
+  },
+  {
+    method: "DELETE",
+    pattern: /^\/api\/pages\/([^/]+)$/,
+    key: "deletePage",
+    paramNames: ["title"],
+  },
+]
+
+/**
+ * route はリクエストの HTTP メソッドとパスをルート定義と照合する。
+ * マッチした場合は RouteMatch を、マッチしない場合は null を返す。
+ */
+export function route(method: string, pathname: string): RouteMatch | null {
+  for (const def of ROUTES) {
+    if (def.method !== method) continue
+    const match = def.pattern.exec(pathname)
+    if (!match) continue
+
+    const params: Record<string, string> = {}
+    for (let i = 0; i < def.paramNames.length; i++) {
+      const name = def.paramNames[i]
+      const value = match[i + 1]
+      if (name !== undefined && value !== undefined) {
+        // URL エンコードされたパスセグメントをデコードする
+        params[name] = decodeURIComponent(value)
+      }
+    }
+    return { key: def.key, params }
+  }
+  return null
+}

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -26,15 +26,21 @@ export interface ServerContext {
   allowWrite: boolean
 }
 
+/** MAX_LINES は 1 リクエストで送信できる行数の上限。 */
+const MAX_LINES = 10000
+
 /** CreatePageBody は POST /api/pages のリクエストボディスキーマ。 */
 export const CreatePageBody = z.object({
   title: z.string().min(1, "title は必須です"),
-  lines: z.array(z.string()),
+  lines: z.array(z.string()).max(MAX_LINES, `lines は ${MAX_LINES} 行以下である必要があります`),
 })
 
 /** EditPageBody は PUT /api/pages/:title のリクエストボディスキーマ。 */
 export const EditPageBody = z.object({
-  lines: z.array(z.string()).min(1, "lines は 1 行以上必要です"),
+  lines: z
+    .array(z.string())
+    .min(1, "lines は 1 行以上必要です")
+    .max(MAX_LINES, `lines は ${MAX_LINES} 行以下である必要があります`),
 })
 
 export type CreatePageBodyType = z.infer<typeof CreatePageBody>

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -1,0 +1,41 @@
+/**
+ * types.ts — HTTP サーバ層の共有型定義。
+ *
+ * ServerContext はサーバ起動時に 1 度生成され、
+ * すべてのルートハンドラが参照する認証・設定情報を保持する。
+ */
+
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import type { Policy } from "@/core/sandbox"
+import { z } from "zod"
+
+/** ServerContext はサーバプロセス全体で共有する実行コンテキスト。 */
+export interface ServerContext {
+  /** Cosense REST API クライアント。認証済み sid を保持する。 */
+  restClient: CosenseRestClient
+  /** Cosense WS 書き込みクライアント。 */
+  writer: ScrapboxWriter
+  /** 対象プロジェクト名。起動時に固定され変更不可。 */
+  project: string
+  /** sandbox ポリシー。起動時の --enable-commands/--disable-commands から生成。 */
+  policy: Policy
+  /** プロキシ Bearer トークン。設定時のみ Authorization ヘッダ検証を行う。 */
+  token?: string
+  /** true のとき POST/PUT/DELETE を有効化する。既定は false（読み取り専用）。 */
+  allowWrite: boolean
+}
+
+/** CreatePageBody は POST /api/pages のリクエストボディスキーマ。 */
+export const CreatePageBody = z.object({
+  title: z.string().min(1, "title は必須です"),
+  lines: z.array(z.string()),
+})
+
+/** EditPageBody は PUT /api/pages/:title のリクエストボディスキーマ。 */
+export const EditPageBody = z.object({
+  lines: z.array(z.string()).min(1, "lines は 1 行以上必要です"),
+})
+
+export type CreatePageBodyType = z.infer<typeof CreatePageBody>
+export type EditPageBodyType = z.infer<typeof EditPageBody>

--- a/tests/integration/serve.smoke.test.ts
+++ b/tests/integration/serve.smoke.test.ts
@@ -1,0 +1,65 @@
+/**
+ * serve.smoke.test.ts — Bun.serve を実際に起動する統合スモークテスト。
+ *
+ * port: 0 で起動し OS にポートを自動割り当てさせることで競合を回避する。
+ * /healthz に GET してステータス 200 を確認後、サーバを停止する。
+ * ネットワーク接続は不要（ローカルループバックのみ）。
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { createPolicy } from "@/core/sandbox"
+import { createFetchHandler } from "@/core/server/rest"
+import type { ServerContext } from "@/core/server/types"
+
+/** スモークテスト用のダミー ScrapboxWriter。実際の WS 接続は行わない。 */
+const dummyWriter: ScrapboxWriter = {
+  patch: async () => ({ commitId: "dummy", pageId: "dummy" }),
+  insertLines: async () => ({ commitId: "dummy" }),
+  deletePage: async () => ({ title: "dummy" }),
+  pinPage: async () => ({ title: "dummy" }),
+  unpinPage: async () => ({ title: "dummy" }),
+}
+
+let server: ReturnType<typeof Bun.serve>
+let assignedPort = 0
+
+beforeAll(() => {
+  const ctx: ServerContext = {
+    restClient: new CosenseRestClient({ sid: "smoke-test-sid" }),
+    writer: dummyWriter,
+    project: "smoke-test-project",
+    policy: createPolicy({}),
+    allowWrite: false,
+  }
+
+  const fetchHandler = createFetchHandler(ctx)
+  // port: 0 で起動すると OS が空きポートを自動割り当てする
+  server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: fetchHandler,
+  })
+  assignedPort = server.port ?? 0
+})
+
+afterAll(() => {
+  server.stop(true)
+})
+
+describe("Bun.serve スモークテスト", () => {
+  it("サーバが起動し /healthz が 200 を返す", async () => {
+    const res = await fetch(`http://127.0.0.1:${assignedPort}/healthz`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean }
+    expect(body.ok).toBe(true)
+  })
+
+  it("存在しないパスは 404 ROUTE_NOT_FOUND を返す", async () => {
+    const res = await fetch(`http://127.0.0.1:${assignedPort}/not-exist`)
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe("ROUTE_NOT_FOUND")
+  })
+})

--- a/tests/integration/serve.smoke.test.ts
+++ b/tests/integration/serve.smoke.test.ts
@@ -41,7 +41,8 @@ beforeAll(() => {
     hostname: "127.0.0.1",
     fetch: fetchHandler,
   })
-  assignedPort = server.port ?? 0
+  if (server.port === undefined) throw new Error("サーバのポートが取得できませんでした")
+  assignedPort = server.port
 })
 
 afterAll(() => {

--- a/tests/unit/commands/serve.test.ts
+++ b/tests/unit/commands/serve.test.ts
@@ -1,0 +1,232 @@
+/**
+ * serve.test.ts — `cos serve --rest` コマンドのテスト。
+ *
+ * DI (deps) で startServer・getSid をモック注入し、
+ * バリデーション・終了コード・起動メッセージを検証する。
+ * Bun.serve の実起動は tests/integration/serve.smoke.test.ts で別途検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { type ServeDeps, makeServeCommand } from "@/commands/serve"
+
+// ----- デフォルト引数 -----
+
+const defaultArgs = {
+  rest: true,
+  port: "8080",
+  host: "127.0.0.1",
+  token: undefined,
+  "allow-write": false,
+  project: "テストプロジェクト",
+  profile: undefined,
+  json: false,
+  plain: false,
+  "results-only": false,
+  select: undefined,
+  "dry-run": false,
+  "enable-commands": undefined,
+  "disable-commands": undefined,
+  verbose: undefined,
+  quiet: false,
+}
+
+// ----- セットアップ -----
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+const writtenChunks: string[] = []
+const stderrChunks: string[] = []
+
+beforeEach(() => {
+  writtenChunks.length = 0
+  stderrChunks.length = 0
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writtenChunks.push(String(chunk))
+    return true
+  })
+  stderrMock = spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    stderrChunks.push(String(chunk))
+    return true
+  })
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+})
+
+/** runServe は makeServeCommand の run を呼び出すヘルパー。 */
+async function runServe(args: Record<string, unknown>, deps?: ServeDeps): Promise<void> {
+  const cmd = makeServeCommand(deps)
+  await (cmd.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 即座に resolve する startServer モック。 */
+const immediateStartServer: ServeDeps["startServer"] = async () => {}
+
+/** 常に "テストSID" を返す getSid モック。 */
+const mockGetSid: ServeDeps["getSid"] = async () => "テストSID"
+
+/** ScrapboxWriter のスタブ実装。 */
+const stubWriter: import("@/core/api/ws").ScrapboxWriter = {
+  patch: async () => ({ commitId: "test", pageId: "test" }),
+  insertLines: async () => ({ commitId: "test" }),
+  deletePage: async () => ({ title: "test" }),
+  pinPage: async () => ({ title: "test" }),
+  unpinPage: async () => ({ title: "test" }),
+}
+
+/** 即座に stubWriter を返す createWriter モック。 */
+const mockCreateWriter: ServeDeps["createWriter"] = async () => stubWriter
+
+describe("makeServeCommand", () => {
+  describe("バリデーション", () => {
+    it("--rest 未指定の場合は exit 5 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, rest: false },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, project: undefined },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--port=0 は範囲外のため exit 5 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, port: "0" },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--port=65536 は範囲外のため exit 5 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, port: "65536" },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--port=abc は数値でないため exit 5 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, port: "abc" },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("sandbox", () => {
+    it("serve.rest が disable-commands に含まれている場合は exit 7 で終了する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, "disable-commands": "serve.rest" },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe("認証エラー", () => {
+    it("sid 取得失敗（未ログイン）の場合は exit 2 で終了する", async () => {
+      try {
+        await runServe(defaultArgs, {
+          getSid: async () => {
+            process.exit(2)
+            throw new Error("unreachable")
+          },
+          createWriter: mockCreateWriter,
+          startServer: immediateStartServer,
+        })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+  })
+
+  describe("正常起動", () => {
+    it("startServer が呼ばれる", async () => {
+      let called = false
+      try {
+        await runServe(defaultArgs, {
+          getSid: mockGetSid,
+          createWriter: mockCreateWriter,
+          startServer: async () => {
+            called = true
+          },
+        })
+      } catch {
+        // 想定内
+      }
+      expect(called).toBe(true)
+    })
+
+    it("--json 指定時に起動 envelope を stdout に出力する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, json: true },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      const output = writtenChunks.join("")
+      expect(output).toContain('"port"')
+      expect(output).toContain("8080")
+    })
+
+    it("--json なし時に起動メッセージを stderr に出力する", async () => {
+      try {
+        await runServe(defaultArgs, {
+          getSid: mockGetSid,
+          createWriter: mockCreateWriter,
+          startServer: immediateStartServer,
+        })
+      } catch {
+        // 想定内
+      }
+      const output = stderrChunks.join("")
+      expect(output).toContain("8080")
+    })
+  })
+})

--- a/tests/unit/core/server/errors.test.ts
+++ b/tests/unit/core/server/errors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * toHttpResponse のテスト。
+ * 各例外クラスが期待する HTTP ステータスコードと error.code に変換されることを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  AuthError,
+  CosenseApiError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} from "@/core/api/rest"
+import { PolicyError } from "@/core/sandbox"
+import { toHttpResponse } from "@/core/server/errors"
+import { ZodError } from "zod"
+
+/** レスポンスボディを JSON としてパースするヘルパー。 */
+async function parseBody(res: Response): Promise<{ error: { code: string; message: string } }> {
+  return res.json() as Promise<{ error: { code: string; message: string } }>
+}
+
+describe("toHttpResponse", () => {
+  it("AuthError は 401 AUTH_REQUIRED を返す", async () => {
+    const res = toHttpResponse(new AuthError())
+    expect(res.status).toBe(401)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("AUTH_REQUIRED")
+  })
+
+  it("ForbiddenError は 403 FORBIDDEN を返す", async () => {
+    const res = toHttpResponse(new ForbiddenError())
+    expect(res.status).toBe(403)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("FORBIDDEN")
+  })
+
+  it("NotFoundError は 404 NOT_FOUND を返す", async () => {
+    const res = toHttpResponse(new NotFoundError("テストページ"))
+    expect(res.status).toBe(404)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("NOT_FOUND")
+  })
+
+  it("RateLimitError は 429 RATE_LIMITED を返す", async () => {
+    const res = toHttpResponse(new RateLimitError())
+    expect(res.status).toBe(429)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("RATE_LIMITED")
+  })
+
+  it("CosenseApiError はステータスをそのまま使い VENDOR_ERROR を返す", async () => {
+    const res = toHttpResponse(new CosenseApiError(503, "Service Unavailable"))
+    expect(res.status).toBe(503)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("VENDOR_ERROR")
+  })
+
+  it("PolicyError は 403 POLICY_DENIED を返す", async () => {
+    const res = toHttpResponse(new PolicyError("page.delete"))
+    expect(res.status).toBe(403)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("POLICY_DENIED")
+  })
+
+  it("ZodError は 400 VALIDATION_ERROR を返す", async () => {
+    const zodErr = new ZodError([
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "undefined",
+        path: ["title"],
+        message: "必須項目",
+      },
+    ])
+    const res = toHttpResponse(zodErr)
+    expect(res.status).toBe(400)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+  })
+
+  it("SyntaxError は 400 INVALID_JSON を返す", async () => {
+    const res = toHttpResponse(new SyntaxError("Unexpected token"))
+    expect(res.status).toBe(400)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("INVALID_JSON")
+  })
+
+  it("未知のエラーは 500 INTERNAL_ERROR を返す", async () => {
+    const res = toHttpResponse(new Error("予期しないエラー"))
+    expect(res.status).toBe(500)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("INTERNAL_ERROR")
+  })
+
+  it("非 Error オブジェクトは 500 INTERNAL_ERROR を返す", async () => {
+    const res = toHttpResponse("文字列エラー")
+    expect(res.status).toBe(500)
+    const body = await parseBody(res)
+    expect(body.error.code).toBe("INTERNAL_ERROR")
+  })
+
+  it("レスポンスの Content-Type は application/json", () => {
+    const res = toHttpResponse(new AuthError())
+    expect(res.headers.get("Content-Type")).toBe("application/json")
+  })
+})

--- a/tests/unit/core/server/errors.test.ts
+++ b/tests/unit/core/server/errors.test.ts
@@ -86,11 +86,13 @@ describe("toHttpResponse", () => {
     expect(body.error.code).toBe("INVALID_JSON")
   })
 
-  it("未知のエラーは 500 INTERNAL_ERROR を返す", async () => {
-    const res = toHttpResponse(new Error("予期しないエラー"))
+  it("未知のエラーは 500 INTERNAL_ERROR を返し、内部詳細を漏洩しない", async () => {
+    const res = toHttpResponse(new Error("内部実装の詳細"))
     expect(res.status).toBe(500)
     const body = await parseBody(res)
     expect(body.error.code).toBe("INTERNAL_ERROR")
+    // 内部エラーメッセージをクライアントに漏洩させず汎用メッセージを返す
+    expect(body.error.message).toBe("予期しないエラーが発生しました")
   })
 
   it("非 Error オブジェクトは 500 INTERNAL_ERROR を返す", async () => {
@@ -98,6 +100,7 @@ describe("toHttpResponse", () => {
     expect(res.status).toBe(500)
     const body = await parseBody(res)
     expect(body.error.code).toBe("INTERNAL_ERROR")
+    expect(body.error.message).toBe("予期しないエラーが発生しました")
   })
 
   it("レスポンスの Content-Type は application/json", () => {

--- a/tests/unit/core/server/rest.test.ts
+++ b/tests/unit/core/server/rest.test.ts
@@ -1,0 +1,331 @@
+/**
+ * createFetchHandler のテスト。
+ *
+ * Bun.serve への接続なしに fetch ハンドラを純粋関数として単体テストする。
+ * 上流 Cosense REST は msw でモックし、ScrapboxWriter はインメモリモックを注入する。
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { CosenseRestClient } from "@/core/api/rest"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { createPolicy } from "@/core/sandbox"
+import { createFetchHandler } from "@/core/server/rest"
+import type { ServerContext } from "@/core/server/types"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import pageDetailFixture from "../../../fixtures/page-detail.json"
+import pageListFixture from "../../../fixtures/page-list.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_SID = "s%3Atest-connect-sid"
+const TEST_TITLE_RAW = "Hello World"
+const TEST_TITLE_ENCODED = "Hello%20World"
+
+// msw でモック ScrapboxWriter（WS 層のスタブ）
+const mockWriter: ScrapboxWriter = {
+  patch: async () => ({ commitId: "commit-abc", pageId: "page-id-abc" }),
+  insertLines: async () => ({ commitId: "commit-insert" }),
+  deletePage: async () => ({ title: TEST_TITLE_RAW }),
+  pinPage: async () => ({ title: TEST_TITLE_RAW }),
+  unpinPage: async () => ({ title: TEST_TITLE_RAW }),
+}
+
+const server = setupServer(
+  // msw は :project をデコードして params に渡すため、TEST_PROJECT（日本語）とそのまま比較する
+  http.get(`${BASE_URL}/api/pages/:project`, ({ params }) => {
+    if (params["project"] === TEST_PROJECT) {
+      return HttpResponse.json(pageListFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+    // encodePageTitle はスペースを _ に変換するため _ をスペースに戻して比較
+    const decodedTitle = decodeURIComponent(params["title"] as string).replace(/_/g, " ")
+    if (params["project"] === TEST_PROJECT && decodedTitle === TEST_TITLE_RAW) {
+      return HttpResponse.json(pageDetailFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/:title/text`, ({ params }) => {
+    const decodedTitle = decodeURIComponent(params["title"] as string).replace(/_/g, " ")
+    if (params["project"] === TEST_PROJECT && decodedTitle === TEST_TITLE_RAW) {
+      return new HttpResponse("Hello World\n最初の行\n2行目", {
+        headers: { "Content-Type": "text/plain" },
+      })
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+/** テスト用のデフォルト ServerContext を生成する。 */
+function makeContext(overrides?: Partial<ServerContext>): ServerContext {
+  return {
+    restClient: new CosenseRestClient({ sid: TEST_SID }),
+    writer: mockWriter,
+    project: TEST_PROJECT,
+    policy: createPolicy({}),
+    allowWrite: false,
+    ...overrides,
+  }
+}
+
+describe("createFetchHandler", () => {
+  describe("GET /healthz", () => {
+    it("200 と ok:true を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/healthz"))
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ ok: true })
+    })
+  })
+
+  describe("GET /api/pages — listPages", () => {
+    it("200 と pages 一覧を envelope で返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/api/pages"))
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { ok: boolean; data: typeof pageListFixture }
+      expect(body.ok).toBe(true)
+      expect(body.data.projectName).toBe(TEST_PROJECT)
+      expect(body.data.pages).toHaveLength(2)
+    })
+  })
+
+  describe("GET /api/pages/:title — getPage", () => {
+    it("既存ページは 200 と詳細データを envelope で返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`))
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { ok: boolean; data: typeof pageDetailFixture }
+      expect(body.ok).toBe(true)
+      expect(body.data.title).toBe(TEST_TITLE_RAW)
+    })
+
+    it("存在しないページは 404 NOT_FOUND を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(
+        new Request("http://localhost/api/pages/%E5%AD%98%E5%9C%A8%E3%81%97%E3%81%AA%E3%81%84"),
+      )
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { ok: boolean; error: { code: string } }
+      expect(body.ok).toBe(false)
+      expect(body.error.code).toBe("NOT_FOUND")
+    })
+  })
+
+  describe("GET /api/pages/:title/text — getPageText", () => {
+    it("既存ページのテキストを text/plain で返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}/text`),
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get("Content-Type")).toContain("text/plain")
+      const text = await res.text()
+      expect(text).toContain("Hello World")
+    })
+  })
+
+  describe("未知のルート", () => {
+    it("存在しないパスは 404 ROUTE_NOT_FOUND を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/unknown/path"))
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("ROUTE_NOT_FOUND")
+    })
+  })
+
+  describe("書き込みエンドポイント — allowWrite=false（既定）", () => {
+    it("POST /api/pages は 405 WRITE_DISABLED を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "新規ページ", lines: ["内容"] }),
+        }),
+      )
+      expect(res.status).toBe(405)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("WRITE_DISABLED")
+    })
+
+    it("PUT /api/pages/:title は 405 WRITE_DISABLED を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lines: ["更新内容"] }),
+        }),
+      )
+      expect(res.status).toBe(405)
+    })
+
+    it("DELETE /api/pages/:title は 405 WRITE_DISABLED を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, {
+          method: "DELETE",
+        }),
+      )
+      expect(res.status).toBe(405)
+    })
+  })
+
+  describe("書き込みエンドポイント — allowWrite=true", () => {
+    it("POST /api/pages は writer.patch を呼び 200 を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "新規ページ", lines: ["行1", "行2"] }),
+        }),
+      )
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { ok: boolean; data: { commitId: string } }
+      expect(body.ok).toBe(true)
+      expect(body.data.commitId).toBe("commit-abc")
+    })
+
+    it("PUT /api/pages/:title は writer.patch を呼び 200 を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lines: ["更新行"] }),
+        }),
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it("DELETE /api/pages/:title は writer.deletePage を呼び 200 を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, {
+          method: "DELETE",
+        }),
+      )
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { ok: boolean; data: { title: string } }
+      expect(body.ok).toBe(true)
+      expect(body.data.title).toBe(TEST_TITLE_RAW)
+    })
+
+    it("POST body のバリデーション失敗（title なし）は 400 VALIDATION_ERROR を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lines: ["行のみ"] }),
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("VALIDATION_ERROR")
+    })
+
+    it("PUT body のバリデーション失敗（lines なし）は 400 VALIDATION_ERROR を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }),
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("不正な JSON body は 400 INVALID_JSON を返す", async () => {
+      const handler = createFetchHandler(makeContext({ allowWrite: true }))
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "不正なJSON{{{",
+        }),
+      )
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("INVALID_JSON")
+    })
+  })
+
+  describe("sandbox ポリシー", () => {
+    it("page.list が拒否されたら 403 POLICY_DENIED を返す", async () => {
+      const handler = createFetchHandler(
+        makeContext({ policy: createPolicy({ disableStr: "page.list" }) }),
+      )
+      const res = await handler(new Request("http://localhost/api/pages"))
+      expect(res.status).toBe(403)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("POLICY_DENIED")
+    })
+
+    it("page.get が拒否されたら 403 POLICY_DENIED を返す", async () => {
+      const handler = createFetchHandler(
+        makeContext({ policy: createPolicy({ disableStr: "page.get" }) }),
+      )
+      const res = await handler(new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`))
+      expect(res.status).toBe(403)
+    })
+
+    it("page.delete が拒否されたら 403 POLICY_DENIED を返す", async () => {
+      const handler = createFetchHandler(
+        makeContext({ allowWrite: true, policy: createPolicy({ disableStr: "page.delete" }) }),
+      )
+      const res = await handler(
+        new Request(`http://localhost/api/pages/${TEST_TITLE_ENCODED}`, { method: "DELETE" }),
+      )
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe("token 認証", () => {
+    // HTTP ヘッダは ASCII のみ有効なため ASCII のみのトークンを使用する
+    const TEST_TOKEN = "test-secret-token-abc"
+    const tokenCtx = makeContext({ token: TEST_TOKEN })
+
+    it("token 設定時に Authorization ヘッダなしは 401 PROXY_AUTH_REQUIRED を返す", async () => {
+      const handler = createFetchHandler(tokenCtx)
+      const res = await handler(new Request("http://localhost/api/pages"))
+      expect(res.status).toBe(401)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("PROXY_AUTH_REQUIRED")
+    })
+
+    it("token 設定時に不正な Bearer は 401 PROXY_AUTH_REQUIRED を返す", async () => {
+      const handler = createFetchHandler(tokenCtx)
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          headers: { Authorization: "Bearer wrong-token" },
+        }),
+      )
+      expect(res.status).toBe(401)
+    })
+
+    it("token 設定時に正しい Bearer は 200 を返す", async () => {
+      const handler = createFetchHandler(tokenCtx)
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+        }),
+      )
+      expect(res.status).toBe(200)
+    })
+  })
+})

--- a/tests/unit/core/server/rest.test.ts
+++ b/tests/unit/core/server/rest.test.ts
@@ -98,6 +98,30 @@ describe("createFetchHandler", () => {
       expect(body.data.projectName).toBe(TEST_PROJECT)
       expect(body.data.pages).toHaveLength(2)
     })
+
+    it("skip=10abc（先頭が数値の不正値）は 400 VALIDATION_ERROR を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/api/pages?skip=10abc"))
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("VALIDATION_ERROR")
+    })
+
+    it("limit=1.5（小数）は 400 VALIDATION_ERROR を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/api/pages?limit=1.5"))
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("VALIDATION_ERROR")
+    })
+
+    it("skip=abc（非数値）は 400 VALIDATION_ERROR を返す", async () => {
+      const handler = createFetchHandler(makeContext())
+      const res = await handler(new Request("http://localhost/api/pages?skip=abc"))
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("VALIDATION_ERROR")
+    })
   })
 
   describe("GET /api/pages/:title — getPage", () => {

--- a/tests/unit/core/server/router.test.ts
+++ b/tests/unit/core/server/router.test.ts
@@ -75,17 +75,41 @@ describe("route", () => {
     })
   })
 
+  describe("HTTP メソッド大文字正規化", () => {
+    it("小文字の get もマッチする", () => {
+      const result = route("get", "/healthz")
+      expect(result).not.toBeNull()
+      expect(result?.key).toBe("healthz")
+    })
+
+    it("小文字の delete もマッチする", () => {
+      const result = route("delete", "/api/pages/my-page")
+      expect(result).not.toBeNull()
+      expect(result?.key).toBe("deletePage")
+    })
+  })
+
+  describe("malformed URL エンコード", () => {
+    it("不正なパーセントエンコードは null を返す", () => {
+      expect(route("GET", "/api/pages/%E0%A4%A")).toBeNull()
+    })
+  })
+
   describe("マッチしないケース", () => {
     it("未知のパスは null を返す", () => {
       expect(route("GET", "/unknown")).toBeNull()
     })
 
     it("正しいパスでも間違った HTTP メソッドは null を返す", () => {
-      expect(route("POST", "/api/pages/タイトル")).toBeNull()
+      expect(route("POST", "/api/pages/%E3%82%BF%E3%82%A4%E3%83%88%E3%83%AB")).toBeNull()
     })
 
     it("PATCH メソッドは定義されていないため null を返す", () => {
-      expect(route("PATCH", "/api/pages/タイトル")).toBeNull()
+      expect(route("PATCH", "/api/pages/%E3%82%BF%E3%82%A4%E3%83%88%E3%83%AB")).toBeNull()
+    })
+
+    it("trailing slash は null を返す", () => {
+      expect(route("GET", "/api/pages/")).toBeNull()
     })
   })
 })

--- a/tests/unit/core/server/router.test.ts
+++ b/tests/unit/core/server/router.test.ts
@@ -1,0 +1,91 @@
+/**
+ * router のテスト。
+ * path テンプレートマッチと params 抽出の正確性を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { route } from "@/core/server/router"
+
+describe("route", () => {
+  describe("GET /healthz", () => {
+    it("マッチし params は空", () => {
+      const result = route("GET", "/healthz")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({})
+    })
+  })
+
+  describe("GET /api/pages", () => {
+    it("マッチし params は空", () => {
+      const result = route("GET", "/api/pages")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({})
+    })
+  })
+
+  describe("GET /api/pages/:title", () => {
+    it("ASCII タイトルをマッチし params.title を返す", () => {
+      const result = route("GET", "/api/pages/hello-world")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "hello-world" })
+    })
+
+    it("パーセントエンコードされたタイトルをデコードして返す", () => {
+      const result = route("GET", "/api/pages/%E6%97%A5%E6%9C%AC%E8%AA%9E")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "日本語" })
+    })
+
+    it("スペースを含むタイトル（%20）をデコードして返す", () => {
+      const result = route("GET", "/api/pages/foo%20bar")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "foo bar" })
+    })
+  })
+
+  describe("GET /api/pages/:title/text", () => {
+    it("マッチし params.title を返す", () => {
+      const result = route("GET", "/api/pages/my-page/text")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "my-page" })
+    })
+  })
+
+  describe("POST /api/pages", () => {
+    it("POST メソッドでマッチする", () => {
+      const result = route("POST", "/api/pages")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({})
+    })
+  })
+
+  describe("PUT /api/pages/:title", () => {
+    it("PUT メソッドでマッチし params.title を返す", () => {
+      const result = route("PUT", "/api/pages/my-page")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "my-page" })
+    })
+  })
+
+  describe("DELETE /api/pages/:title", () => {
+    it("DELETE メソッドでマッチし params.title を返す", () => {
+      const result = route("DELETE", "/api/pages/my-page")
+      expect(result).not.toBeNull()
+      expect(result?.params).toEqual({ title: "my-page" })
+    })
+  })
+
+  describe("マッチしないケース", () => {
+    it("未知のパスは null を返す", () => {
+      expect(route("GET", "/unknown")).toBeNull()
+    })
+
+    it("正しいパスでも間違った HTTP メソッドは null を返す", () => {
+      expect(route("POST", "/api/pages/タイトル")).toBeNull()
+    })
+
+    it("PATCH メソッドは定義されていないため null を返す", () => {
+      expect(route("PATCH", "/api/pages/タイトル")).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `cos serve --rest --port=8080 --project=<proj>` で Cosense API への認証付き HTTP プロキシを起動
- AI エージェントや外部ツールが `curl http://localhost:8080/api/pages` 形式で Cosense を操作可能
- `--allow-write` で書き込み系エンドポイント (POST/PUT/DELETE) をオプトイン
- `--token` でプロキシ自体への Bearer 認証を任意追加
- Bun.serve() を使い追加依存ゼロ、SIGINT/SIGTERM で graceful shutdown

## 新規エンドポイント

| HTTP | パス | 機能 |
|---|---|---|
| GET | `/healthz` | ヘルスチェック（token 認証スキップ） |
| GET | `/api/pages` | ページ一覧（skip/limit/sort 対応） |
| GET | `/api/pages/:title` | ページ詳細取得 |
| GET | `/api/pages/:title/text` | ページテキスト取得 |
| POST | `/api/pages` | ページ作成（--allow-write 必須） |
| PUT | `/api/pages/:title` | ページ編集（--allow-write 必須） |
| DELETE | `/api/pages/:title` | ページ削除（--allow-write 必須） |

## 新規ファイル

- `src/commands/serve.ts` — CLI エントリポイント（DI ファクトリパターン）
- `src/core/server/rest.ts` — `createFetchHandler` 純粋関数
- `src/core/server/router.ts` — パステンプレートマッチ
- `src/core/server/errors.ts` — 例外 → HTTP Response 変換
- `src/core/server/types.ts` — ServerContext / Zod ボディスキーマ
- テスト 60 件追加（unit 58 件 + integration smoke 2 件）

## Test plan

- [x] `bun test` — 482 pass / 7 fail（7 件は pre-existing）
- [x] `bunx biome check src tests` — エラーなし
- [x] `bun run typecheck` — エラーなし
- [x] CodeRabbit 指摘 17 件に対応済み（healthz token bypass、race condition 修正、エラー情報漏洩防止など）

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ローカルRESTプロキシサーバーを起動できる新しい`serve`コマンドを追加しました。ポート指定やサンドボックスポリシー設定に対応しています。

* **テスト**
  * 統合テストとユニットテストを追加し、サーバー機能を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->