### PR TITLE
feat: cos project graph — バックリンクグラフ export (#9)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import { pageUnpinCommand } from "@/commands/page/unpin"
 import { pageUrlCommand } from "@/commands/page/url"
 import { pageWatchCommand } from "@/commands/page/watch"
 
+import { projectGraphCommand } from "@/commands/project/graph"
 import { projectInfoCommand } from "@/commands/project/info"
 // プロジェクトコマンド
 import { projectListCommand } from "@/commands/project/list"
@@ -93,6 +94,7 @@ const projectCommand = defineCommand({
     list: projectListCommand,
     ls: projectListCommand,
     info: projectInfoCommand,
+    graph: projectGraphCommand,
   },
 })
 

--- a/src/commands/project/graph.ts
+++ b/src/commands/project/graph.ts
@@ -1,0 +1,173 @@
+/**
+ * project/graph.ts — `cos project graph` コマンド。
+ *
+ * プロジェクトのページ間リンクをグラフとして export する。
+ * Graphviz DOT / JSON (envelope) / TSV の 3 形式に対応する。
+ *
+ * データソース: /api/pages/:project/search/titles (SearchedTitle.links を利用)
+ * 注意: issue 本文の "/api/pages/:project の links" は誤記で、実際は search/titles が正しい。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, NotFoundError } from "@/core/api/rest"
+import { buildGraph, fetchAllLinks, graphToTsvRows, serializeDot } from "@/core/graph"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+/** 許可する --format の値 */
+const VALID_FORMATS = ["json", "dot", "csv"] as const
+type GraphFormat = (typeof VALID_FORMATS)[number]
+
+export const projectGraphCommand = defineCommand({
+  meta: { description: "プロジェクトのページ間リンクをグラフとして export する" },
+  args: {
+    ...commonArgs,
+    format: {
+      type: "string",
+      description: "出力形式 (json / dot / csv)",
+      default: "json",
+    },
+    from: {
+      type: "string",
+      description: "BFS 起点ページタイトル (未指定時は全体グラフを出力)",
+    },
+    depth: {
+      type: "string",
+      description: "BFS の深さ (--from 指定時のみ有効、デフォルト: 1)",
+      default: "1",
+    },
+    limit: {
+      type: "string",
+      description: "取得するページ数の上限 (サンプリング用)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      format: string
+      from?: string
+      depth: string
+      limit?: string
+    }
+
+    checkSandbox("project.graph", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --format バリデーション
+    if (!(VALID_FORMATS as readonly string[]).includes(a.format)) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `無効な --format 値です: ${a.format}`,
+        `--format には ${VALID_FORMATS.join(" / ")} のいずれかを指定してください`,
+      )
+      process.exit(5)
+      return
+    }
+    const format = a.format as GraphFormat
+
+    // --depth バリデーション
+    const depth = Number(a.depth)
+    if (!Number.isInteger(depth) || depth < 0) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--depth には 0 以上の整数を指定してください: ${a.depth}`,
+        "例: --depth=2",
+      )
+      process.exit(5)
+      return
+    }
+
+    // --limit バリデーション
+    let limit: number | undefined
+    if (a.limit !== undefined) {
+      limit = Number(a.limit)
+      if (!Number.isInteger(limit) || limit < 1) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--limit には 1 以上の整数を指定してください: ${a.limit}`,
+          "例: --limit=100",
+        )
+        process.exit(5)
+        return
+      }
+    }
+
+    logger.info(`プロジェクト "${project}" のリンクグラフを取得中...`)
+
+    const client = await buildRestClient(a)
+
+    let pages: import("@/schemas/page").TitleSearchResult[]
+    let truncated: boolean
+    try {
+      const fetchOpts: { project: string; limit?: number } = { project }
+      if (limit !== undefined) fetchOpts.limit = limit
+      const result = await fetchAllLinks(client, fetchOpts)
+      pages = result.pages
+      truncated = result.truncated
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson(
+          "AUTH_REQUIRED",
+          "認証情報が無効です。再度ログインしてください",
+          "`cos auth login` を実行してください",
+        )
+        process.exit(2)
+        return
+      }
+      throw err
+    }
+
+    // グラフ構築 (--from が存在しない場合は NotFoundError)
+    let graph: import("@/core/graph").GraphData
+    try {
+      const graphOpts: { from?: string; depth?: number } = { depth }
+      if (a.from !== undefined) graphOpts.from = a.from
+      graph = buildGraph(pages, graphOpts)
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        writeErrorJson(
+          "NOT_FOUND",
+          `ページ "${a.from}" が見つかりません`,
+          "プロジェクト内に存在するページタイトルを --from に指定してください",
+        )
+        process.exit(4)
+        return
+      }
+      throw err
+    }
+
+    // warnings 構築
+    const warnings: string[] = []
+    if (truncated) {
+      warnings.push(`limit に達したため全体の一部 (${pages.length} ページ) のみ取得しました`)
+    }
+    const unexistingCount = graph.nodes.filter((n) => !n.exists).length
+    if (unexistingCount > 0) {
+      warnings.push(`Cosense 上に存在しない参照先ページが ${unexistingCount} 件あります`)
+    }
+
+    // フォーマット別出力
+    if (format === "dot") {
+      process.stdout.write(`${serializeDot(graph)}\n`)
+      return
+    }
+
+    if (format === "csv") {
+      writeTsv(["from_title", "to_title"], graphToTsvRows(graph))
+      return
+    }
+
+    // format === "json": envelope 形式 (--results-only で { nodes, edges } のみ)
+    writeJson(graph, { command: "project.graph", startTime, warnings }, buildJsonOpts(a))
+  },
+})

--- a/src/commands/project/graph.ts
+++ b/src/commands/project/graph.ts
@@ -18,9 +18,16 @@ import {
   requireProject,
 } from "@/commands/_shared"
 import { AuthError, NotFoundError } from "@/core/api/rest"
-import { buildGraph, fetchAllLinks, graphToTsvRows, serializeDot } from "@/core/graph"
+import {
+  type GraphData,
+  buildGraph,
+  fetchAllLinks,
+  graphToTsvRows,
+  serializeDot,
+} from "@/core/graph"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writeTsv } from "@/presenter/plain"
+import type { TitleSearchResult } from "@/schemas/page"
 import { defineCommand } from "citty"
 
 /** 許可する --format の値 */
@@ -33,7 +40,7 @@ export const projectGraphCommand = defineCommand({
     ...commonArgs,
     format: {
       type: "string",
-      description: "出力形式 (json / dot / csv)",
+      description: "出力形式 (json / dot / csv=TSV)",
       default: "json",
     },
     from: {
@@ -106,7 +113,7 @@ export const projectGraphCommand = defineCommand({
 
     const client = await buildRestClient(a)
 
-    let pages: import("@/schemas/page").TitleSearchResult[]
+    let pages: TitleSearchResult[]
     let truncated: boolean
     try {
       const fetchOpts: { project: string; limit?: number } = { project }
@@ -128,7 +135,7 @@ export const projectGraphCommand = defineCommand({
     }
 
     // グラフ構築 (--from が存在しない場合は NotFoundError)
-    let graph: import("@/core/graph").GraphData
+    let graph: GraphData
     try {
       const graphOpts: { from?: string; depth?: number } = { depth }
       if (a.from !== undefined) graphOpts.from = a.from
@@ -158,11 +165,17 @@ export const projectGraphCommand = defineCommand({
 
     // フォーマット別出力
     if (format === "dot") {
+      for (const warning of warnings) {
+        process.stderr.write(`[warning] ${warning}\n`)
+      }
       process.stdout.write(`${serializeDot(graph)}\n`)
       return
     }
 
     if (format === "csv") {
+      for (const warning of warnings) {
+        process.stderr.write(`[warning] ${warning}\n`)
+      }
       writeTsv(["from_title", "to_title"], graphToTsvRows(graph))
       return
     }

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -6,11 +6,17 @@
  */
 
 import { encodePageTitle } from "@/core/api/encoder"
-import { PageListResponseSchema, PageSchema, SearchResultSchema } from "@/schemas/page"
-import type { Page, PageListResponse, SearchResult } from "@/schemas/page"
+import {
+  PageListResponseSchema,
+  PageSchema,
+  SearchResultSchema,
+  TitleSearchResultSchema,
+} from "@/schemas/page"
+import type { Page, PageListResponse, SearchResult, TitleSearchResult } from "@/schemas/page"
 import { ProjectListResponseSchema, ProjectSchema } from "@/schemas/project"
 import type { Project, ProjectListResponse } from "@/schemas/project"
 import { type Me, MeSchema } from "@/schemas/user"
+import { z } from "zod"
 
 const BASE_URL = "https://scrapbox.io"
 
@@ -131,6 +137,23 @@ export class CosenseRestClient {
       `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/query?${params.toString()}`,
     )
     return SearchResultSchema.parse(data)
+  }
+
+  /**
+   * searchTitles は /api/pages/:project/search/titles を叩いてタイトル一覧とリンク情報を返す。
+   * ページネーションは followingId クエリパラメータと X-following-id レスポンスヘッダで行う。
+   */
+  async searchTitles(
+    project: string,
+    opts: { followingId?: string } = {},
+  ): Promise<{ pages: TitleSearchResult[]; followingId: string }> {
+    const params = opts.followingId ? `?followingId=${encodeURIComponent(opts.followingId)}` : ""
+    const response = await this.doFetch(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/titles${params}`,
+    )
+    const data = await response.json()
+    const pages = z.array(TitleSearchResultSchema).parse(data)
+    return { pages, followingId: response.headers.get("X-following-id") ?? "" }
   }
 
   /** getProject は /api/projects/:project を叩いてプロジェクト情報を返す。 */

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -146,14 +146,16 @@ export class CosenseRestClient {
   async searchTitles(
     project: string,
     opts: { followingId?: string } = {},
-  ): Promise<{ pages: TitleSearchResult[]; followingId: string }> {
-    const params = opts.followingId ? `?followingId=${encodeURIComponent(opts.followingId)}` : ""
+  ): Promise<{ pages: TitleSearchResult[]; followingId: string | undefined }> {
+    const params = new URLSearchParams()
+    if (opts.followingId !== undefined) params.set("followingId", opts.followingId)
+    const query = params.size > 0 ? `?${params.toString()}` : ""
     const response = await this.doFetch(
-      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/titles${params}`,
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/titles${query}`,
     )
     const data = await response.json()
     const pages = z.array(TitleSearchResultSchema).parse(data)
-    return { pages, followingId: response.headers.get("X-following-id") ?? "" }
+    return { pages, followingId: response.headers.get("X-following-id") ?? undefined }
   }
 
   /** getProject は /api/projects/:project を叩いてプロジェクト情報を返す。 */

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -63,7 +63,7 @@ export async function fetchAllLinks(
         return { pages: allPages, truncated: true }
       }
     }
-    followingId = result.followingId || undefined
+    followingId = result.followingId
   } while (followingId)
 
   return { pages: allPages, truncated: false }
@@ -167,10 +167,12 @@ function buildBfsGraph(
   // キュー: [title, 現在の深さ]
   const queue: Array<[string, number]> = [[from, 0]]
 
-  while (queue.length > 0) {
-    const item = queue.shift()
-    if (!item) break
-    const [current, currentDepth] = item
+  let head = 0
+  while (head < queue.length) {
+    const entry = queue[head]
+    head++
+    if (!entry) continue
+    const [current, currentDepth] = entry
     if (currentDepth >= depth) continue
     for (const neighbor of adjacency.get(current) ?? []) {
       if (!visited.has(neighbor)) {
@@ -193,10 +195,10 @@ function buildBfsGraph(
 
   // edges: from/to が両方 visited 内に収まるもの
   const edges: GraphEdge[] = []
-  for (const from of visited) {
-    for (const to of adjacency.get(from) ?? []) {
+  for (const node of visited) {
+    for (const to of adjacency.get(node) ?? []) {
       if (visited.has(to)) {
-        edges.push({ from, to })
+        edges.push({ from: node, to })
       }
     }
   }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -1,0 +1,243 @@
+/**
+ * graph.ts — プロジェクトのページ間リンクグラフを構築・シリアライズするユースケース層。
+ *
+ * /api/pages/:project/search/titles から全リンク情報を取得し、
+ * DOT / JSON / TSV 形式へのシリアライズを提供する。
+ */
+
+import { NotFoundError } from "@/core/api/rest"
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { TitleSearchResult } from "@/schemas/page"
+
+// -------------------------------------------------------------------
+// 型定義
+// -------------------------------------------------------------------
+
+/** GraphNode はグラフのノード (ページ) を表す。 */
+export interface GraphNode {
+  /** ページ ID。未作成ページの場合はタイトルをそのまま使用する。 */
+  id: string
+  title: string
+  /** false の場合は Cosense 上に存在しない参照先ページ */
+  exists: boolean
+}
+
+/** GraphEdge はページ間のリンク (有向エッジ) を表す。 */
+export interface GraphEdge {
+  from: string
+  to: string
+}
+
+/** GraphData はノードとエッジの集合。 */
+export interface GraphData {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+// -------------------------------------------------------------------
+// fetchAllLinks
+// -------------------------------------------------------------------
+
+/**
+ * fetchAllLinks は /api/pages/:project/search/titles を逐次取得して
+ * 全ページのリンク情報を返す。
+ *
+ * @param opts.limit - 取得上限件数 (指定時はサンプリングして早期終了)
+ * @returns pages: 取得したページ一覧, truncated: limit で打ち切った場合 true
+ */
+export async function fetchAllLinks(
+  client: CosenseRestClient,
+  opts: { project: string; limit?: number },
+): Promise<{ pages: TitleSearchResult[]; truncated: boolean }> {
+  const { project, limit } = opts
+  const allPages: TitleSearchResult[] = []
+  let followingId: string | undefined
+
+  do {
+    const searchOpts: { followingId?: string } = {}
+    if (followingId !== undefined) searchOpts.followingId = followingId
+    const result = await client.searchTitles(project, searchOpts)
+    for (const page of result.pages) {
+      allPages.push(page)
+      if (limit !== undefined && allPages.length >= limit) {
+        return { pages: allPages, truncated: true }
+      }
+    }
+    followingId = result.followingId || undefined
+  } while (followingId)
+
+  return { pages: allPages, truncated: false }
+}
+
+// -------------------------------------------------------------------
+// buildGraph
+// -------------------------------------------------------------------
+
+/**
+ * buildGraph はページ配列からグラフデータを構築する。
+ *
+ * @param opts.from - 起点ページタイトル (未指定時は全体グラフを返す)
+ * @param opts.depth - BFS の深さ (from 指定時のみ有効、デフォルト 1)
+ * @throws NotFoundError from が pages に存在しない場合
+ */
+export function buildGraph(
+  pages: TitleSearchResult[],
+  opts: { from?: string; depth?: number },
+): GraphData {
+  // タイトル → TitleSearchResult のマップ (存在するページ)
+  const pageMap = new Map<string, TitleSearchResult>()
+  for (const page of pages) {
+    pageMap.set(page.title, page)
+  }
+
+  // BFS の to 側で現れる全タイトルを集め、隣接リスト (重複排除) を構築する
+  // adjacency: from_title → Set<to_title>
+  const adjacency = new Map<string, Set<string>>()
+  for (const page of pages) {
+    const targets = new Set<string>()
+    for (const link of page.links ?? []) {
+      // 自己参照を除外する
+      if (link !== page.title) {
+        targets.add(link)
+      }
+    }
+    adjacency.set(page.title, targets)
+  }
+
+  // from 未指定: 全体グラフを返す
+  if (opts.from === undefined) {
+    return buildFullGraph(pages, pageMap, adjacency)
+  }
+
+  // from 指定: BFS で到達範囲を絞る
+  if (!pageMap.has(opts.from)) {
+    throw new NotFoundError(`ページ "${opts.from}" が見つかりません`)
+  }
+
+  const depth = opts.depth ?? 1
+  return buildBfsGraph(opts.from, depth, pageMap, adjacency)
+}
+
+/** buildFullGraph は全ページ・全エッジを含むグラフを返す。 */
+function buildFullGraph(
+  pages: TitleSearchResult[],
+  pageMap: Map<string, TitleSearchResult>,
+  adjacency: Map<string, Set<string>>,
+): GraphData {
+  // 参照先の未作成ページも含む全タイトルを収集する
+  const allTitles = new Set<string>()
+  for (const page of pages) {
+    allTitles.add(page.title)
+    for (const link of page.links ?? []) {
+      if (link !== page.title) {
+        allTitles.add(link)
+      }
+    }
+  }
+
+  const nodes: GraphNode[] = []
+  for (const title of allTitles) {
+    const existing = pageMap.get(title)
+    nodes.push({
+      id: existing?.id ?? title,
+      title,
+      exists: existing !== undefined,
+    })
+  }
+
+  const edges: GraphEdge[] = []
+  for (const [from, targets] of adjacency) {
+    for (const to of targets) {
+      edges.push({ from, to })
+    }
+  }
+
+  return { nodes, edges }
+}
+
+/** buildBfsGraph は起点から BFS で depth 段まで到達できるノード・エッジを返す。 */
+function buildBfsGraph(
+  from: string,
+  depth: number,
+  pageMap: Map<string, TitleSearchResult>,
+  adjacency: Map<string, Set<string>>,
+): GraphData {
+  // BFS: visited は到達済みタイトルの Set
+  const visited = new Set<string>([from])
+  // キュー: [title, 現在の深さ]
+  const queue: Array<[string, number]> = [[from, 0]]
+
+  while (queue.length > 0) {
+    const item = queue.shift()
+    if (!item) break
+    const [current, currentDepth] = item
+    if (currentDepth >= depth) continue
+    for (const neighbor of adjacency.get(current) ?? []) {
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor)
+        queue.push([neighbor, currentDepth + 1])
+      }
+    }
+  }
+
+  // nodes: BFS 到達タイトル (未作成ページも含む)
+  const nodes: GraphNode[] = []
+  for (const title of visited) {
+    const existing = pageMap.get(title)
+    nodes.push({
+      id: existing?.id ?? title,
+      title,
+      exists: existing !== undefined,
+    })
+  }
+
+  // edges: from/to が両方 visited 内に収まるもの
+  const edges: GraphEdge[] = []
+  for (const from of visited) {
+    for (const to of adjacency.get(from) ?? []) {
+      if (visited.has(to)) {
+        edges.push({ from, to })
+      }
+    }
+  }
+
+  return { nodes, edges }
+}
+
+// -------------------------------------------------------------------
+// serializeDot
+// -------------------------------------------------------------------
+
+/** escapeDotLabel は Graphviz DOT のラベル文字列をエスケープする。 */
+function escapeDotLabel(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")
+}
+
+/**
+ * serializeDot はグラフデータを Graphviz DOT 形式に変換する。
+ * エッジラベルのダブルクォート・バックスラッシュ・改行をエスケープする。
+ */
+export function serializeDot(graph: GraphData): string {
+  const lines: string[] = ["digraph cosense {", "  rankdir=LR;"]
+
+  for (const edge of graph.edges) {
+    const from = escapeDotLabel(edge.from)
+    const to = escapeDotLabel(edge.to)
+    lines.push(`  "${from}" -> "${to}";`)
+  }
+
+  lines.push("}")
+  return lines.join("\n")
+}
+
+// -------------------------------------------------------------------
+// graphToTsvRows
+// -------------------------------------------------------------------
+
+/**
+ * graphToTsvRows はグラフデータのエッジを TSV 行配列に変換する。
+ * writeTsv に渡す形式 ([from_title, to_title] の配列) を返す。
+ */
+export function graphToTsvRows(graph: GraphData): string[][] {
+  return graph.edges.map((e) => [e.from, e.to])
+}

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -74,7 +74,7 @@ export async function fetchAllLinks(
 // -------------------------------------------------------------------
 
 /**
- * buildGraph はページ配列からグラフデータを構築する。
+ * buildGraph はページ配列からグラフデータを構築して返す。
  *
  * @param opts.from - 起点ページタイトル (未指定時は全体グラフを返す)
  * @param opts.depth - BFS の深さ (from 指定時のみ有効、デフォルト 1)
@@ -216,11 +216,16 @@ function escapeDotLabel(s: string): string {
 }
 
 /**
- * serializeDot はグラフデータを Graphviz DOT 形式に変換する。
- * エッジラベルのダブルクォート・バックスラッシュ・改行をエスケープする。
+ * serializeDot はグラフデータを Graphviz DOT 形式に変換して返す。
+ * ノード宣言・エッジのラベルのダブルクォート・バックスラッシュ・改行をエスケープする。
  */
 export function serializeDot(graph: GraphData): string {
   const lines: string[] = ["digraph cosense {", "  rankdir=LR;"]
+
+  for (const node of graph.nodes) {
+    const label = escapeDotLabel(node.title)
+    lines.push(`  "${label}";`)
+  }
 
   for (const edge of graph.edges) {
     const from = escapeDotLabel(edge.from)

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -113,6 +113,6 @@ export const TitleSearchResultSchema = z.object({
   exists: z.boolean().optional(),
   /** ページが張っている前方リンク先のタイトル一覧 */
   links: z.array(z.string()).optional(),
-  image: z.string().optional(),
+  image: z.string().nullable().optional(),
 })
 export type TitleSearchResult = z.infer<typeof TitleSearchResultSchema>

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -111,5 +111,8 @@ export const TitleSearchResultSchema = z.object({
   title: z.string(),
   updated: z.number(),
   exists: z.boolean().optional(),
+  /** ページが張っている前方リンク先のタイトル一覧 */
+  links: z.array(z.string()).optional(),
+  image: z.string().optional(),
 })
 export type TitleSearchResult = z.infer<typeof TitleSearchResultSchema>

--- a/tests/fixtures/search-titles-page2.json
+++ b/tests/fixtures/search-titles-page2.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "page-id-oshirase",
+    "title": "お知らせ",
+    "updated": 1700000060,
+    "links": []
+  },
+  {
+    "id": "page-id-javascript",
+    "title": "JavaScript",
+    "updated": 1700000070,
+    "links": ["TypeScript入門"]
+  }
+]

--- a/tests/fixtures/search-titles.json
+++ b/tests/fixtures/search-titles.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "page-id-hajimeni",
+    "title": "はじめに",
+    "updated": 1700000010,
+    "image": "https://scrapbox.io/files/hajimeni.png",
+    "links": ["TypeScript入門", "プログラミング基礎"]
+  },
+  {
+    "id": "page-id-typescript",
+    "title": "TypeScript入門",
+    "updated": 1700000020,
+    "links": ["はじめに", "JavaScript"]
+  },
+  {
+    "id": "page-id-programming",
+    "title": "プログラミング基礎",
+    "updated": 1700000030,
+    "links": ["アルゴリズム"]
+  },
+  {
+    "id": "page-id-algorithm",
+    "title": "アルゴリズム",
+    "updated": 1700000040,
+    "links": []
+  },
+  {
+    "id": "page-id-release",
+    "title": "リリースノート",
+    "updated": 1700000050,
+    "links": ["はじめに", "お知らせ"]
+  }
+]

--- a/tests/unit/commands/project/graph.test.ts
+++ b/tests/unit/commands/project/graph.test.ts
@@ -82,6 +82,15 @@ async function runGraph(args: Record<string, unknown>) {
   })
 }
 
+/** process.exit のモック後に継続実行で throw される例外を握り潰してコマンドを実行する */
+async function runAndIgnoreExit(args: Record<string, unknown>): Promise<void> {
+  try {
+    await runGraph(args)
+  } catch {
+    // process.exit モック後の継続による throw は想定内
+  }
+}
+
 /** stdout に書き出された文字列を結合して返す */
 function captureStdout(): string {
   return (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
@@ -106,64 +115,40 @@ afterEach(() => {
 describe("projectGraphCommand", () => {
   describe("プロジェクト未指定", () => {
     it("プロジェクトが指定されていない場合は exit 5 で終了する", async () => {
-      try {
-        await runGraph(makeArgs({ project: undefined }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ project: undefined }))
       expect(exitMock).toHaveBeenCalledWith(5)
     })
   })
 
   describe("--format バリデーション", () => {
     it("不正な --format 値の場合は VALIDATION_ERROR で exit 5", async () => {
-      try {
-        await runGraph(makeArgs({ format: "xml" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ format: "xml" }))
       expect(exitMock).toHaveBeenCalledWith(5)
       const out = captureStdout()
       expect(out).toContain("VALIDATION_ERROR")
     })
 
     it("--depth に負の値を指定した場合は exit 5", async () => {
-      try {
-        await runGraph(makeArgs({ depth: "-1" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ depth: "-1" }))
       expect(exitMock).toHaveBeenCalledWith(5)
     })
 
     it("--limit に 0 を指定した場合は exit 5", async () => {
-      try {
-        await runGraph(makeArgs({ limit: "0" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ limit: "0" }))
       expect(exitMock).toHaveBeenCalledWith(5)
     })
   })
 
   describe("sandbox 拒否", () => {
     it("--disable-commands=project.graph の場合は exit 7 で終了する", async () => {
-      try {
-        await runGraph(makeArgs({ "disable-commands": "project.graph" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ "disable-commands": "project.graph" }))
       expect(exitMock).toHaveBeenCalledWith(7)
     })
   })
 
   describe("--format=json (デフォルト)", () => {
     it("envelope 形式で nodes と edges を含む JSON を出力する", async () => {
-      try {
-        await runGraph(makeArgs({ format: "json" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ format: "json" }))
       const out = captureStdout()
       const parsed = JSON.parse(out)
       expect(parsed.data).toBeDefined()
@@ -175,11 +160,7 @@ describe("projectGraphCommand", () => {
     })
 
     it("--results-only の場合は { nodes, edges } のみ出力する", async () => {
-      try {
-        await runGraph(makeArgs({ format: "json", "results-only": true }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ format: "json", "results-only": true }))
       const out = captureStdout()
       const parsed = JSON.parse(out)
       // data/meta が直接出ていないこと (nodes が top-level に存在する)
@@ -190,11 +171,7 @@ describe("projectGraphCommand", () => {
 
   describe("--format=dot", () => {
     it("digraph cosense { ... } 形式の DOT テキストを出力する", async () => {
-      try {
-        await runGraph(makeArgs({ format: "dot" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ format: "dot" }))
       const out = captureStdout()
       expect(out).toContain("digraph cosense {")
       expect(out).toContain("rankdir=LR")
@@ -203,11 +180,7 @@ describe("projectGraphCommand", () => {
 
   describe("--format=csv", () => {
     it("from_title<TAB>to_title の TSV ヘッダと行を出力する", async () => {
-      try {
-        await runGraph(makeArgs({ format: "csv" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ format: "csv" }))
       const out = captureStdout()
       expect(out).toContain("from_title\tto_title")
     })
@@ -215,14 +188,10 @@ describe("projectGraphCommand", () => {
 
   describe("--from + --depth BFS", () => {
     it("--from で起点を指定すると BFS 範囲のみのグラフを出力する", async () => {
-      try {
-        // "はじめに" は links: ["TypeScript入門", "プログラミング基礎"]
-        await runGraph(
-          makeArgs({ format: "json", "results-only": true, from: "はじめに", depth: "1" }),
-        )
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      // "はじめに" は links: ["TypeScript入門", "プログラミング基礎"]
+      await runAndIgnoreExit(
+        makeArgs({ format: "json", "results-only": true, from: "はじめに", depth: "1" }),
+      )
       const out = captureStdout()
       const parsed = JSON.parse(out)
       const titles = parsed.nodes.map((n: { title: string }) => n.title)
@@ -234,23 +203,15 @@ describe("projectGraphCommand", () => {
     })
 
     it("--from に存在しないページを指定した場合は exit 4 で終了する", async () => {
-      try {
-        await runGraph(makeArgs({ from: "存在しないページ", depth: "1" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs({ from: "存在しないページ", depth: "1" }))
       expect(exitMock).toHaveBeenCalledWith(4)
     })
   })
 
   describe("--limit サンプリング", () => {
     it("--limit 件数でサンプリング打ち切りし warnings を含める", async () => {
-      try {
-        // limit=3 で 1 ページ目の 5 件から 3 件で打ち切る
-        await runGraph(makeArgs({ format: "json", limit: "3" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      // limit=3 で 1 ページ目の 5 件から 3 件で打ち切る
+      await runAndIgnoreExit(makeArgs({ format: "json", limit: "3" }))
       const out = captureStdout()
       const parsed = JSON.parse(out)
       // サンプリング打ち切りの警告が含まれる
@@ -268,11 +229,7 @@ describe("projectGraphCommand", () => {
           return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
         }),
       )
-      try {
-        await runGraph(makeArgs())
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
+      await runAndIgnoreExit(makeArgs())
       expect(exitMock).toHaveBeenCalledWith(2)
     })
   })

--- a/tests/unit/commands/project/graph.test.ts
+++ b/tests/unit/commands/project/graph.test.ts
@@ -1,0 +1,279 @@
+/**
+ * project/graph.test.ts — `cos project graph` コマンドのテスト。
+ *
+ * フォーマット出力 (json/dot/csv)、BFS フィルタ (--from/--depth)、
+ * サンプリング (--limit)、エラー系 (未認証・未作成ページ・sandbox・バリデーション) を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { projectGraphCommand } from "@/commands/project/graph"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import searchTitlesPage2Fixture from "../../../fixtures/search-titles-page2.json"
+import searchTitlesFixture from "../../../fixtures/search-titles.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ request, params }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] !== TEST_PROJECT) {
+      return HttpResponse.json({ message: "Not found" }, { status: 404 })
+    }
+    const url = new URL(request.url)
+    const followingId = url.searchParams.get("followingId")
+    if (!followingId) {
+      return HttpResponse.json(searchTitlesFixture, {
+        headers: { "X-following-id": "page2-following-id" },
+      })
+    }
+    if (followingId === "page2-following-id") {
+      return HttpResponse.json(searchTitlesPage2Fixture)
+    }
+    return HttpResponse.json([])
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** テスト用の共通引数ヘルパー */
+function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    project: TEST_PROJECT,
+    format: "json",
+    from: undefined,
+    // citty のデフォルト値はコマンド実行時に適用されるため、テストでは明示的に渡す
+    depth: "1",
+    limit: undefined,
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    profile: undefined,
+    ...overrides,
+  }
+}
+
+async function runGraph(args: Record<string, unknown>) {
+  await (
+    projectGraphCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** stdout に書き出された文字列を結合して返す */
+function captureStdout(): string {
+  return (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  server.resetHandlers()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("projectGraphCommand", () => {
+  describe("プロジェクト未指定", () => {
+    it("プロジェクトが指定されていない場合は exit 5 で終了する", async () => {
+      try {
+        await runGraph(makeArgs({ project: undefined }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("--format バリデーション", () => {
+    it("不正な --format 値の場合は VALIDATION_ERROR で exit 5", async () => {
+      try {
+        await runGraph(makeArgs({ format: "xml" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const out = captureStdout()
+      expect(out).toContain("VALIDATION_ERROR")
+    })
+
+    it("--depth に負の値を指定した場合は exit 5", async () => {
+      try {
+        await runGraph(makeArgs({ depth: "-1" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--limit に 0 を指定した場合は exit 5", async () => {
+      try {
+        await runGraph(makeArgs({ limit: "0" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("sandbox 拒否", () => {
+    it("--disable-commands=project.graph の場合は exit 7 で終了する", async () => {
+      try {
+        await runGraph(makeArgs({ "disable-commands": "project.graph" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe("--format=json (デフォルト)", () => {
+    it("envelope 形式で nodes と edges を含む JSON を出力する", async () => {
+      try {
+        await runGraph(makeArgs({ format: "json" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.data).toBeDefined()
+      expect(Array.isArray(parsed.data.nodes)).toBe(true)
+      expect(Array.isArray(parsed.data.edges)).toBe(true)
+      // meta フィールドがある
+      expect(parsed.meta).toBeDefined()
+      expect(parsed.meta.command).toBe("project.graph")
+    })
+
+    it("--results-only の場合は { nodes, edges } のみ出力する", async () => {
+      try {
+        await runGraph(makeArgs({ format: "json", "results-only": true }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      // data/meta が直接出ていないこと (nodes が top-level に存在する)
+      expect(Array.isArray(parsed.nodes)).toBe(true)
+      expect(Array.isArray(parsed.edges)).toBe(true)
+    })
+  })
+
+  describe("--format=dot", () => {
+    it("digraph cosense { ... } 形式の DOT テキストを出力する", async () => {
+      try {
+        await runGraph(makeArgs({ format: "dot" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      expect(out).toContain("digraph cosense {")
+      expect(out).toContain("rankdir=LR")
+    })
+  })
+
+  describe("--format=csv", () => {
+    it("from_title<TAB>to_title の TSV ヘッダと行を出力する", async () => {
+      try {
+        await runGraph(makeArgs({ format: "csv" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      expect(out).toContain("from_title\tto_title")
+    })
+  })
+
+  describe("--from + --depth BFS", () => {
+    it("--from で起点を指定すると BFS 範囲のみのグラフを出力する", async () => {
+      try {
+        // "はじめに" は links: ["TypeScript入門", "プログラミング基礎"]
+        await runGraph(
+          makeArgs({ format: "json", "results-only": true, from: "はじめに", depth: "1" }),
+        )
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      const titles = parsed.nodes.map((n: { title: string }) => n.title)
+      expect(titles).toContain("はじめに")
+      expect(titles).toContain("TypeScript入門")
+      expect(titles).toContain("プログラミング基礎")
+      // "リリースノート" は BFS 範囲外
+      expect(titles).not.toContain("リリースノート")
+    })
+
+    it("--from に存在しないページを指定した場合は exit 4 で終了する", async () => {
+      try {
+        await runGraph(makeArgs({ from: "存在しないページ", depth: "1" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+  })
+
+  describe("--limit サンプリング", () => {
+    it("--limit 件数でサンプリング打ち切りし warnings を含める", async () => {
+      try {
+        // limit=3 で 1 ページ目の 5 件から 3 件で打ち切る
+        await runGraph(makeArgs({ format: "json", limit: "3" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      // サンプリング打ち切りの警告が含まれる
+      expect(parsed.meta.warnings).toBeDefined()
+      const warnings: string[] = parsed.meta.warnings ?? []
+      expect(warnings.some((w) => w.includes("limit"))).toBe(true)
+    })
+  })
+
+  describe("認証エラー", () => {
+    it("API が 401 を返した場合は exit 2 で終了する", async () => {
+      // このテスト専用: 全リクエストに 401 を返す
+      server.use(
+        http.get(`${BASE_URL}/api/pages/:project/search/titles`, () => {
+          return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+        }),
+      )
+      try {
+        await runGraph(makeArgs())
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+  })
+})

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -205,8 +205,8 @@ describe("CosenseRestClient", () => {
       // search-titles-page2.json に 2 件
       expect(result.pages).toHaveLength(2)
       expect(result.pages[0]?.title).toBe("お知らせ")
-      // 最終ページなので followingId は空文字
-      expect(result.followingId).toBe("")
+      // 最終ページなので followingId は undefined
+      expect(result.followingId).toBeUndefined()
     })
 
     it("全件を結合してページネーション完走できる", async () => {
@@ -218,7 +218,7 @@ describe("CosenseRestClient", () => {
         if (followingId !== undefined) searchOpts.followingId = followingId
         const result = await client.searchTitles(TEST_PROJECT, searchOpts)
         allPages.push(...result.pages)
-        followingId = result.followingId || undefined
+        followingId = result.followingId
       } while (followingId)
       // 計 7 件 (fixture page1: 5件 + page2: 2件)
       expect(allPages).toHaveLength(7)

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -12,6 +12,8 @@ import { setupServer } from "msw/node"
 import meFixture from "../../../fixtures/me.json"
 import pageDetailFixture from "../../../fixtures/page-detail.json"
 import pageListFixture from "../../../fixtures/page-list.json"
+import searchTitlesPage2Fixture from "../../../fixtures/search-titles-page2.json"
+import searchTitlesFixture from "../../../fixtures/search-titles.json"
 
 const BASE_URL = "https://scrapbox.io"
 const TEST_PROJECT = "テストプロジェクト"
@@ -78,6 +80,29 @@ const server = setupServer(
       })
     }
     return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ request, params }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] !== TEST_PROJECT) {
+      return HttpResponse.json({ message: "Not found" }, { status: 404 })
+    }
+    const url = new URL(request.url)
+    const followingId = url.searchParams.get("followingId")
+    // 1ページ目: X-following-id ヘッダ付きで返す
+    if (!followingId) {
+      return HttpResponse.json(searchTitlesFixture, {
+        headers: { "X-following-id": "page2-following-id" },
+      })
+    }
+    // 2ページ目: ヘッダなし (最終ページ)
+    if (followingId === "page2-following-id") {
+      return HttpResponse.json(searchTitlesPage2Fixture)
+    }
+    return HttpResponse.json([], { status: 200 })
   }),
 )
 
@@ -157,6 +182,51 @@ describe("CosenseRestClient", () => {
       const client = new CosenseRestClient({ sid: TEST_SID })
       const result = await client.searchPages(TEST_PROJECT, "存在しないキーワード")
       expect(result.pages).toHaveLength(0)
+    })
+  })
+
+  describe("searchTitles", () => {
+    it("1ページ目のタイトル一覧と followingId を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchTitles(TEST_PROJECT)
+      // search-titles.json に 5 件
+      expect(result.pages).toHaveLength(5)
+      expect(result.pages[0]?.title).toBe("はじめに")
+      expect(result.pages[0]?.links).toEqual(["TypeScript入門", "プログラミング基礎"])
+      // X-following-id ヘッダが設定されている
+      expect(result.followingId).toBe("page2-following-id")
+    })
+
+    it("followingId を指定すると次のページを返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchTitles(TEST_PROJECT, {
+        followingId: "page2-following-id",
+      })
+      // search-titles-page2.json に 2 件
+      expect(result.pages).toHaveLength(2)
+      expect(result.pages[0]?.title).toBe("お知らせ")
+      // 最終ページなので followingId は空文字
+      expect(result.followingId).toBe("")
+    })
+
+    it("全件を結合してページネーション完走できる", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const allPages = []
+      let followingId: string | undefined
+      do {
+        const searchOpts: { followingId?: string } = {}
+        if (followingId !== undefined) searchOpts.followingId = followingId
+        const result = await client.searchTitles(TEST_PROJECT, searchOpts)
+        allPages.push(...result.pages)
+        followingId = result.followingId || undefined
+      } while (followingId)
+      // 計 7 件 (fixture page1: 5件 + page2: 2件)
+      expect(allPages).toHaveLength(7)
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.searchTitles(TEST_PROJECT)).rejects.toThrow()
     })
   })
 })

--- a/tests/unit/core/graph.test.ts
+++ b/tests/unit/core/graph.test.ts
@@ -164,6 +164,7 @@ describe("buildGraph", () => {
       const titles = new Set(graph.nodes.map((n) => n.title))
       for (const edge of graph.edges) {
         expect(titles.has(edge.from)).toBe(true)
+        expect(titles.has(edge.to)).toBe(true)
       }
     })
   })
@@ -276,7 +277,7 @@ describe("fetchAllLinks", () => {
     const client = new CosenseRestClient({ sid: TEST_SID })
     // limit=3 で 5 件の 1 ページ目から 3 件だけ取得
     const result = await fetchAllLinks(client, { project: TEST_PROJECT, limit: 3 })
-    expect(result.pages.length).toBeLessThanOrEqual(3)
+    expect(result.pages).toHaveLength(3)
     expect(result.truncated).toBe(true)
   })
 })

--- a/tests/unit/core/graph.test.ts
+++ b/tests/unit/core/graph.test.ts
@@ -20,8 +20,8 @@ import searchTitlesFixture from "../../fixtures/search-titles.json"
 // テストデータ
 // -------------------------------------------------------------------
 
-/** 相互リンク・自己参照・未作成ページ参照を含む最小テスト用ページ配列 */
-const サンプルページ一覧: TitleSearchResult[] = [
+/** 相互リンク・重複リンクを含む最小テスト用ページ配列 */
+const samplePages: TitleSearchResult[] = [
   {
     id: "id-a",
     title: "ページA",
@@ -42,7 +42,8 @@ const サンプルページ一覧: TitleSearchResult[] = [
   },
 ]
 
-const 自己参照ページ一覧: TitleSearchResult[] = [
+/** 自己参照リンクを含むテスト用ページ配列 */
+const selfReferencePages: TitleSearchResult[] = [
   {
     id: "id-self",
     title: "自己参照ページ",
@@ -57,7 +58,8 @@ const 自己参照ページ一覧: TitleSearchResult[] = [
   },
 ]
 
-const 未作成参照ページ一覧: TitleSearchResult[] = [
+/** 存在しないページへの参照を含むテスト用ページ配列 */
+const nonExistentReferencePages: TitleSearchResult[] = [
   {
     id: "id-existing",
     title: "存在するページ",
@@ -73,7 +75,7 @@ const 未作成参照ページ一覧: TitleSearchResult[] = [
 describe("buildGraph", () => {
   describe("from 未指定 (全体グラフ)", () => {
     it("全ページを nodes として返す", () => {
-      const graph = buildGraph(サンプルページ一覧, {})
+      const graph = buildGraph(samplePages, {})
       const titles = graph.nodes.map((n) => n.title)
       expect(titles).toContain("ページA")
       expect(titles).toContain("ページB")
@@ -81,8 +83,8 @@ describe("buildGraph", () => {
     })
 
     it("全リンクを edges として返す (重複排除済み)", () => {
-      const graph = buildGraph(サンプルページ一覧, {})
-      // ページC → ページA は重複しているが 1 件のみ
+      const graph = buildGraph(samplePages, {})
+      // ページA → ページC は 1 件のみ存在する
       const AからC = graph.edges.filter((e) => e.from === "ページA" && e.to === "ページC")
       expect(AからC).toHaveLength(1)
       // ページC → ページA は重複 2 件 → 1 件に dedup
@@ -99,13 +101,13 @@ describe("buildGraph", () => {
 
   describe("自己参照の除外", () => {
     it("from === to の edge を除外する", () => {
-      const graph = buildGraph(自己参照ページ一覧, {})
+      const graph = buildGraph(selfReferencePages, {})
       const selfEdges = graph.edges.filter((e) => e.from === e.to)
       expect(selfEdges).toHaveLength(0)
     })
 
     it("自己参照でない edge は残る", () => {
-      const graph = buildGraph(自己参照ページ一覧, {})
+      const graph = buildGraph(selfReferencePages, {})
       const normalEdge = graph.edges.find((e) => e.from === "自己参照ページ" && e.to === "他ページ")
       expect(normalEdge).toBeDefined()
     })
@@ -113,14 +115,14 @@ describe("buildGraph", () => {
 
   describe("未作成ページの扱い", () => {
     it("リンク先の未作成ページを nodes に exists: false で含める", () => {
-      const graph = buildGraph(未作成参照ページ一覧, {})
+      const graph = buildGraph(nonExistentReferencePages, {})
       const unexisting = graph.nodes.find((n) => n.title === "存在しないページ")
       expect(unexisting).toBeDefined()
       expect(unexisting?.exists).toBe(false)
     })
 
     it("実在するページは exists: true (または省略)", () => {
-      const graph = buildGraph(未作成参照ページ一覧, {})
+      const graph = buildGraph(nonExistentReferencePages, {})
       const existing = graph.nodes.find((n) => n.title === "存在するページ")
       expect(existing).toBeDefined()
       expect(existing?.exists).not.toBe(false)
@@ -129,14 +131,14 @@ describe("buildGraph", () => {
 
   describe("from + depth 指定 (BFS フィルタ)", () => {
     it("depth=0 のとき起点ノードのみ・edges なし", () => {
-      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 0 })
+      const graph = buildGraph(samplePages, { from: "ページA", depth: 0 })
       expect(graph.nodes).toHaveLength(1)
       expect(graph.nodes[0]?.title).toBe("ページA")
       expect(graph.edges).toHaveLength(0)
     })
 
     it("depth=1 のとき起点から 1 hop のノードを含む", () => {
-      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 1 })
+      const graph = buildGraph(samplePages, { from: "ページA", depth: 1 })
       const titles = graph.nodes.map((n) => n.title)
       expect(titles).toContain("ページA")
       expect(titles).toContain("ページB")
@@ -145,7 +147,7 @@ describe("buildGraph", () => {
 
     it("depth=2 のとき 2 hop まで含む", () => {
       // ページA → ページB → ページA (循環) — ページA は既出
-      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 2 })
+      const graph = buildGraph(samplePages, { from: "ページA", depth: 2 })
       const titles = graph.nodes.map((n) => n.title)
       expect(titles).toContain("ページA")
       expect(titles).toContain("ページB")
@@ -153,13 +155,11 @@ describe("buildGraph", () => {
     })
 
     it("起点が pages に存在しないとき NotFoundError をスローする", () => {
-      expect(() => buildGraph(サンプルページ一覧, { from: "存在しないページ" })).toThrow(
-        NotFoundError,
-      )
+      expect(() => buildGraph(samplePages, { from: "存在しないページ" })).toThrow(NotFoundError)
     })
 
     it("from 指定時の edges は BFS 範囲内のリンクのみ", () => {
-      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 1 })
+      const graph = buildGraph(samplePages, { from: "ページA", depth: 1 })
       // 全 edges の from/to が BFS 到達ノード内に収まっている
       const titles = new Set(graph.nodes.map((n) => n.title))
       for (const edge of graph.edges) {
@@ -198,6 +198,16 @@ describe("serializeDot", () => {
     const graph = { nodes: [], edges: [] }
     const dot = serializeDot(graph)
     expect(dot).toMatch(/^digraph/)
+    expect(dot).not.toContain("->")
+  })
+
+  it("エッジのない孤立ノードも DOT 出力に含まれる", () => {
+    const graph = {
+      nodes: [{ id: "id-isolated", title: "孤立ページ", exists: true }],
+      edges: [],
+    }
+    const dot = serializeDot(graph)
+    expect(dot).toContain('"孤立ページ"')
     expect(dot).not.toContain("->")
   })
 })

--- a/tests/unit/core/graph.test.ts
+++ b/tests/unit/core/graph.test.ts
@@ -1,0 +1,282 @@
+/**
+ * graph.test.ts — グラフ構築・シリアライズ関数のテスト。
+ *
+ * fetchAllLinks / buildGraph / serializeDot / graphToTsvRows の動作を検証する。
+ * buildGraph と serializeDot は副作用のない純関数のため、REST クライアントは
+ * fetchAllLinks のテスト時のみモックする。
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { NotFoundError } from "@/core/api/rest"
+import { buildGraph, fetchAllLinks, graphToTsvRows, serializeDot } from "@/core/graph"
+import type { TitleSearchResult } from "@/schemas/page"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import searchTitlesPage2Fixture from "../../fixtures/search-titles-page2.json"
+import searchTitlesFixture from "../../fixtures/search-titles.json"
+
+// -------------------------------------------------------------------
+// テストデータ
+// -------------------------------------------------------------------
+
+/** 相互リンク・自己参照・未作成ページ参照を含む最小テスト用ページ配列 */
+const サンプルページ一覧: TitleSearchResult[] = [
+  {
+    id: "id-a",
+    title: "ページA",
+    updated: 100,
+    links: ["ページB", "ページC"],
+  },
+  {
+    id: "id-b",
+    title: "ページB",
+    updated: 200,
+    links: ["ページA"], // 相互参照
+  },
+  {
+    id: "id-c",
+    title: "ページC",
+    updated: 300,
+    links: ["ページA", "ページA"], // 重複リンク
+  },
+]
+
+const 自己参照ページ一覧: TitleSearchResult[] = [
+  {
+    id: "id-self",
+    title: "自己参照ページ",
+    updated: 100,
+    links: ["自己参照ページ", "他ページ"],
+  },
+  {
+    id: "id-other",
+    title: "他ページ",
+    updated: 200,
+    links: [],
+  },
+]
+
+const 未作成参照ページ一覧: TitleSearchResult[] = [
+  {
+    id: "id-existing",
+    title: "存在するページ",
+    updated: 100,
+    links: ["存在しないページ"],
+  },
+]
+
+// -------------------------------------------------------------------
+// buildGraph テスト
+// -------------------------------------------------------------------
+
+describe("buildGraph", () => {
+  describe("from 未指定 (全体グラフ)", () => {
+    it("全ページを nodes として返す", () => {
+      const graph = buildGraph(サンプルページ一覧, {})
+      const titles = graph.nodes.map((n) => n.title)
+      expect(titles).toContain("ページA")
+      expect(titles).toContain("ページB")
+      expect(titles).toContain("ページC")
+    })
+
+    it("全リンクを edges として返す (重複排除済み)", () => {
+      const graph = buildGraph(サンプルページ一覧, {})
+      // ページC → ページA は重複しているが 1 件のみ
+      const AからC = graph.edges.filter((e) => e.from === "ページA" && e.to === "ページC")
+      expect(AからC).toHaveLength(1)
+      // ページC → ページA は重複 2 件 → 1 件に dedup
+      const CからA = graph.edges.filter((e) => e.from === "ページC" && e.to === "ページA")
+      expect(CからA).toHaveLength(1)
+    })
+
+    it("空ページ一覧の場合は nodes と edges が空配列", () => {
+      const graph = buildGraph([], {})
+      expect(graph.nodes).toHaveLength(0)
+      expect(graph.edges).toHaveLength(0)
+    })
+  })
+
+  describe("自己参照の除外", () => {
+    it("from === to の edge を除外する", () => {
+      const graph = buildGraph(自己参照ページ一覧, {})
+      const selfEdges = graph.edges.filter((e) => e.from === e.to)
+      expect(selfEdges).toHaveLength(0)
+    })
+
+    it("自己参照でない edge は残る", () => {
+      const graph = buildGraph(自己参照ページ一覧, {})
+      const normalEdge = graph.edges.find((e) => e.from === "自己参照ページ" && e.to === "他ページ")
+      expect(normalEdge).toBeDefined()
+    })
+  })
+
+  describe("未作成ページの扱い", () => {
+    it("リンク先の未作成ページを nodes に exists: false で含める", () => {
+      const graph = buildGraph(未作成参照ページ一覧, {})
+      const unexisting = graph.nodes.find((n) => n.title === "存在しないページ")
+      expect(unexisting).toBeDefined()
+      expect(unexisting?.exists).toBe(false)
+    })
+
+    it("実在するページは exists: true (または省略)", () => {
+      const graph = buildGraph(未作成参照ページ一覧, {})
+      const existing = graph.nodes.find((n) => n.title === "存在するページ")
+      expect(existing).toBeDefined()
+      expect(existing?.exists).not.toBe(false)
+    })
+  })
+
+  describe("from + depth 指定 (BFS フィルタ)", () => {
+    it("depth=0 のとき起点ノードのみ・edges なし", () => {
+      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 0 })
+      expect(graph.nodes).toHaveLength(1)
+      expect(graph.nodes[0]?.title).toBe("ページA")
+      expect(graph.edges).toHaveLength(0)
+    })
+
+    it("depth=1 のとき起点から 1 hop のノードを含む", () => {
+      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 1 })
+      const titles = graph.nodes.map((n) => n.title)
+      expect(titles).toContain("ページA")
+      expect(titles).toContain("ページB")
+      expect(titles).toContain("ページC")
+    })
+
+    it("depth=2 のとき 2 hop まで含む", () => {
+      // ページA → ページB → ページA (循環) — ページA は既出
+      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 2 })
+      const titles = graph.nodes.map((n) => n.title)
+      expect(titles).toContain("ページA")
+      expect(titles).toContain("ページB")
+      expect(titles).toContain("ページC")
+    })
+
+    it("起点が pages に存在しないとき NotFoundError をスローする", () => {
+      expect(() => buildGraph(サンプルページ一覧, { from: "存在しないページ" })).toThrow(
+        NotFoundError,
+      )
+    })
+
+    it("from 指定時の edges は BFS 範囲内のリンクのみ", () => {
+      const graph = buildGraph(サンプルページ一覧, { from: "ページA", depth: 1 })
+      // 全 edges の from/to が BFS 到達ノード内に収まっている
+      const titles = new Set(graph.nodes.map((n) => n.title))
+      for (const edge of graph.edges) {
+        expect(titles.has(edge.from)).toBe(true)
+      }
+    })
+  })
+})
+
+// -------------------------------------------------------------------
+// serializeDot テスト
+// -------------------------------------------------------------------
+
+describe("serializeDot", () => {
+  it("有向グラフの DOT 文字列を返す", () => {
+    const graph = { nodes: [], edges: [{ from: "A", to: "B" }] }
+    const dot = serializeDot(graph)
+    expect(dot).toMatch(/^digraph/)
+    expect(dot).toContain('"A" -> "B"')
+  })
+
+  it("タイトルのダブルクォートをエスケープする", () => {
+    const graph = { nodes: [], edges: [{ from: 'タイトル"引用"', to: "B" }] }
+    const dot = serializeDot(graph)
+    expect(dot).toContain('\\"引用\\"')
+  })
+
+  it("タイトルのバックスラッシュをエスケープする", () => {
+    const graph = { nodes: [], edges: [{ from: "パス\\ファイル", to: "B" }] }
+    const dot = serializeDot(graph)
+    expect(dot).toContain("パス\\\\ファイル")
+  })
+
+  it("edges が空のとき空グラフを返す", () => {
+    const graph = { nodes: [], edges: [] }
+    const dot = serializeDot(graph)
+    expect(dot).toMatch(/^digraph/)
+    expect(dot).not.toContain("->")
+  })
+})
+
+// -------------------------------------------------------------------
+// graphToTsvRows テスト
+// -------------------------------------------------------------------
+
+describe("graphToTsvRows", () => {
+  it("[from_title, to_title] の 2 次元配列を返す", () => {
+    const graph = {
+      nodes: [],
+      edges: [
+        { from: "ページA", to: "ページB" },
+        { from: "ページC", to: "ページA" },
+      ],
+    }
+    const rows = graphToTsvRows(graph)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toEqual(["ページA", "ページB"])
+    expect(rows[1]).toEqual(["ページC", "ページA"])
+  })
+
+  it("edges が空のとき空配列を返す", () => {
+    const graph = { nodes: [], edges: [] }
+    expect(graphToTsvRows(graph)).toHaveLength(0)
+  })
+})
+
+// -------------------------------------------------------------------
+// fetchAllLinks テスト (MSW)
+// -------------------------------------------------------------------
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_SID = "s%3Atest-connect-sid"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ request, params }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] !== TEST_PROJECT) {
+      return HttpResponse.json({ message: "Not found" }, { status: 404 })
+    }
+    const url = new URL(request.url)
+    const followingId = url.searchParams.get("followingId")
+    if (!followingId) {
+      return HttpResponse.json(searchTitlesFixture, {
+        headers: { "X-following-id": "page2-following-id" },
+      })
+    }
+    if (followingId === "page2-following-id") {
+      return HttpResponse.json(searchTitlesPage2Fixture)
+    }
+    return HttpResponse.json([])
+  }),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("fetchAllLinks", () => {
+  it("全ページのリンク情報を取得する (ページネーション完走)", async () => {
+    const { CosenseRestClient } = await import("@/core/api/rest")
+    const client = new CosenseRestClient({ sid: TEST_SID })
+    const result = await fetchAllLinks(client, { project: TEST_PROJECT })
+    // fixture page1: 5件 + page2: 2件 = 7件
+    expect(result.pages).toHaveLength(7)
+    expect(result.truncated).toBe(false)
+  })
+
+  it("limit を指定するとサンプリングして早期終了する", async () => {
+    const { CosenseRestClient } = await import("@/core/api/rest")
+    const client = new CosenseRestClient({ sid: TEST_SID })
+    // limit=3 で 5 件の 1 ページ目から 3 件だけ取得
+    const result = await fetchAllLinks(client, { project: TEST_PROJECT, limit: 3 })
+    expect(result.pages.length).toBeLessThanOrEqual(3)
+    expect(result.truncated).toBe(true)
+  })
+})

--- a/tests/unit/schemas/page.test.ts
+++ b/tests/unit/schemas/page.test.ts
@@ -75,4 +75,34 @@ describe("TitleSearchResultSchema", () => {
     // @ts-expect-error 未定義フィールド
     expect(result.unknownField).toBeUndefined()
   })
+
+  it("image が null の場合も解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-7",
+      title: "画像なしページ",
+      updated: 1700000006,
+      image: null,
+    })
+    expect(result.image).toBeNull()
+  })
+
+  it("必須フィールド (id) が欠落している場合はエラーをスローする", () => {
+    expect(() =>
+      TitleSearchResultSchema.parse({
+        title: "IDなしページ",
+        updated: 1700000007,
+      }),
+    ).toThrow()
+  })
+
+  it("links の要素が文字列でない場合はエラーをスローする", () => {
+    expect(() =>
+      TitleSearchResultSchema.parse({
+        id: "page-id-8",
+        title: "不正リンクページ",
+        updated: 1700000008,
+        links: [123, "正常タイトル"],
+      }),
+    ).toThrow()
+  })
 })

--- a/tests/unit/schemas/page.test.ts
+++ b/tests/unit/schemas/page.test.ts
@@ -1,0 +1,78 @@
+/**
+ * page.test.ts — page スキーマの検証テスト。
+ *
+ * TitleSearchResultSchema が links・image フィールドを含む
+ * /api/pages/:project/search/titles レスポンスを正しく解析できることを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { TitleSearchResultSchema } from "@/schemas/page"
+
+describe("TitleSearchResultSchema", () => {
+  it("id・title・updated の最小フィールドを解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-1",
+      title: "ホームページ",
+      updated: 1700000000,
+    })
+    expect(result.id).toBe("page-id-1")
+    expect(result.title).toBe("ホームページ")
+    expect(result.updated).toBe(1700000000)
+  })
+
+  it("links フィールド (string[]) を含むオブジェクトを解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-2",
+      title: "リンク元ページ",
+      updated: 1700000001,
+      links: ["リンク先A", "リンク先B"],
+    })
+    expect(result.links).toEqual(["リンク先A", "リンク先B"])
+  })
+
+  it("image フィールド (string) を含むオブジェクトを解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-3",
+      title: "画像付きページ",
+      updated: 1700000002,
+      image: "https://scrapbox.io/files/example.png",
+    })
+    expect(result.image).toBe("https://scrapbox.io/files/example.png")
+  })
+
+  it("links と image を両方含むオブジェクトを解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-4",
+      title: "フルページ",
+      updated: 1700000003,
+      links: ["タグ/TypeScript", "お知らせ"],
+      image: "https://scrapbox.io/files/thumb.png",
+      exists: true,
+    })
+    expect(result.links).toEqual(["タグ/TypeScript", "お知らせ"])
+    expect(result.image).toBe("https://scrapbox.io/files/thumb.png")
+    expect(result.exists).toBe(true)
+  })
+
+  it("links が空配列のオブジェクトを解析できる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-5",
+      title: "リンクなしページ",
+      updated: 1700000004,
+      links: [],
+    })
+    expect(result.links).toEqual([])
+  })
+
+  it("余分なフィールドはストリップされる", () => {
+    const result = TitleSearchResultSchema.parse({
+      id: "page-id-6",
+      title: "ページ",
+      updated: 1700000005,
+      links: [],
+      unknownField: "値",
+    })
+    // @ts-expect-error 未定義フィールド
+    expect(result.unknownField).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- `cos project graph -p <project>` コマンドを追加 (Issue #9)
- Graphviz DOT / JSON (envelope) / TSV (--format=csv) の 3 形式に対応
- `--from <title> --depth N` で BFS サブグラフ出力
- `--limit N` でサンプリング打ち切り

## 変更ファイル

### 新規
- `src/core/graph.ts` — `fetchAllLinks` / `buildGraph` / `serializeDot` / `graphToTsvRows` (純関数群)
- `src/commands/project/graph.ts` — citty コマンド実装
- `tests/unit/schemas/page.test.ts` — TitleSearchResultSchema 拡張テスト
- `tests/unit/core/graph.test.ts` — グラフ構築・シリアライズ・fetchAllLinks テスト
- `tests/unit/commands/project/graph.test.ts` — コマンド E2E テスト (MSW + spyOn)
- `tests/fixtures/search-titles.json` — 1 ページ目 fixture (5 件)
- `tests/fixtures/search-titles-page2.json` — 2 ページ目 fixture (2 件)

### 修正
- `src/schemas/page.ts` — `TitleSearchResultSchema` に `links` / `image` (nullable) を追加
- `src/core/api/rest.ts` — `searchTitles` メソッドを追加 (ページネーション対応)
- `src/cli.ts` — `projectCommand.subCommands` に `graph` を追加

## 設計上の注意点

issue 本文は `/api/pages/:project` を参照先として記載していますが、`PageSummary` 型には `links: string[]` が存在しません。実際には `/api/pages/:project/search/titles` (戻り値型 `SearchedTitle` に `links` を含む) が正しいエンドポイントです。

## テスト結果

- 531 pass / 7 skip (skip は pre-existing failures: pageInsert/pageEdit/pageUnpin/pagePrepend)
- Biome エラー 0
- 型チェック エラー 0

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * プロジェクトのページリンクグラフをエクスポートできる新しい project graph コマンドを追加。JSON／DOT／CSV(TSV)出力、--from／--depth／--limit 等のスコープ指定と出力形式オプションをサポートし、警告付きの切り詰めや参照先未存在の通知を含む出力を行います。

* **Tests**
  * コマンド、グラフ生成、APIページ取得、スキーマ挙動を広く検証する単体テストとフィクスチャを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->