### PR TITLE
fix: process.exit モック時のテストタイムアウトを修正

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -174,6 +174,8 @@ export function requireProject(args: CommonArgs): string {
       "--project (-p) フラグか COS_PROJECT 環境変数でプロジェクトを指定してください",
     )
     process.exit(5)
+    // process.exit がモックされた場合でも後続処理を止める（テスト環境向け）
+    throw new Error("PROJECT_REQUIRED")
   }
   return project
 }

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -15,6 +15,15 @@ import { Logger } from "@/infra/logger"
 import { writeErrorJson } from "@/presenter/json"
 import type { JsonOutputOptions } from "@/presenter/json"
 
+/**
+ * exitWithError は指定コードでプロセスを終了する。
+ * process.exit がモックされたテスト環境でも後続処理を止めるため throw を続ける。
+ */
+function exitWithError(code: number, message: string): never {
+  process.exit(code)
+  throw new Error(message)
+}
+
 /** commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義。 */
 export const commonArgs = {
   project: {
@@ -129,7 +138,7 @@ export function checkSandbox(commandName: string, args: CommonArgs): void {
       `[denied] ${commandName} is disabled by policy`,
       "--enable-commands フラグで明示的に許可してください",
     )
-    process.exit(7)
+    exitWithError(7, "POLICY_DENIED")
   }
 }
 
@@ -159,7 +168,7 @@ export async function requireSid(profile?: string): Promise<string> {
       "認証情報が見つかりません",
       "`cos auth login` を実行してログインしてください",
     )
-    process.exit(2)
+    exitWithError(2, "AUTH_REQUIRED")
   }
   return sid
 }
@@ -173,9 +182,7 @@ export function requireProject(args: CommonArgs): string {
       "プロジェクト名が指定されていません",
       "--project (-p) フラグか COS_PROJECT 環境変数でプロジェクトを指定してください",
     )
-    process.exit(5)
-    // process.exit がモックされた場合でも後続処理を止める（テスト環境向け）
-    throw new Error("PROJECT_REQUIRED")
+    exitWithError(5, "PROJECT_REQUIRED")
   }
   return project
 }

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -63,6 +63,7 @@ export const pageEditCommand = defineCommand({
         `有効な値: ${VALID_INPUT_FORMATS.join(", ")}`,
       )
       process.exit(5)
+      return
     }
 
     let content: string

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -84,6 +84,7 @@ export const pageEditCommand = defineCommand({
     if (lines.length === 0) {
       writeErrorJson("CONTENT_REQUIRED", "新しい本文が空です")
       process.exit(5)
+      return
     }
 
     logger.info(`"${a.title}" を編集中...`)

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -93,6 +93,7 @@ export const pageInsertCommand = defineCommand({
         "--line または --from-file でコンテンツを指定してください",
       )
       process.exit(5)
+      return
     }
 
     logger.info(`"${a.title}" の ${afterN} 行目の後ろに挿入中...`)

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -29,11 +29,14 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
+  process.env["COS_SID"] = "ダミーセッションID-テスト用"
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
 })
 
 describe("pageEditCommand", () => {
@@ -85,22 +88,19 @@ describe("pageEditCommand", () => {
     // MD ファイルを作成
     const tmpFile = join(tmpdir(), `cos-test-edit-${Date.now()}.md`)
     writeFileSync(tmpFile, "## テスト見出し\n本文テキスト\n")
-    // --dry-run=true で実際の WebSocket 接続を発生させずに実行する
-    try {
-      await runEdit({
-        title: "テストページ",
-        "from-file": tmpFile,
-        "input-format": "md",
-        project: "テストプロジェクト",
-        json: false,
-        plain: false,
-        "results-only": false,
-        "dry-run": true,
-        quiet: false,
-      })
-    } catch {
-      // process.exit モック後の継続による throw は想定内
-    }
+    // COS_SID は beforeEach でダミー値が設定済み。
+    // --dry-run=true によって DryRunWriter が使われ WS 接続なしで最後まで完走する
+    await runEdit({
+      title: "テストページ",
+      "from-file": tmpFile,
+      "input-format": "md",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": true,
+      quiet: false,
+    })
     // VALIDATION_ERROR が出ていないこと (MD フォーマットは有効)
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).not.toContain("VALIDATION_ERROR")

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -85,25 +85,22 @@ describe("pageEditCommand", () => {
     // MD ファイルを作成
     const tmpFile = join(tmpdir(), `cos-test-edit-${Date.now()}.md`)
     writeFileSync(tmpFile, "## テスト見出し\n本文テキスト\n")
-    try {
-      await runEdit({
-        title: "テストページ",
-        "from-file": tmpFile,
-        "input-format": "md",
-        project: "テストプロジェクト",
-        json: false,
-        plain: false,
-        "results-only": false,
-        "dry-run": false,
-        quiet: false,
-      })
-    } catch {
-      // buildWriter が認証を要求するため throw される。バリデーションは通過している
-    }
+    // --dry-run=true で実際の WebSocket 接続を発生させずに実行する
+    await runEdit({
+      title: "テストページ",
+      "from-file": tmpFile,
+      "input-format": "md",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": true,
+      quiet: false,
+    })
     // VALIDATION_ERROR が出ていないこと (MD フォーマットは有効)
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).not.toContain("VALIDATION_ERROR")
-    // exit 5 が VALIDATION_ERROR 由来でないこと (認証エラーの exit 2 などはあり得る)
+    // exit 5 が VALIDATION_ERROR 由来でないこと
     expect(exitMock).not.toHaveBeenCalledWith(5)
   })
 })

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -86,21 +86,25 @@ describe("pageEditCommand", () => {
     const tmpFile = join(tmpdir(), `cos-test-edit-${Date.now()}.md`)
     writeFileSync(tmpFile, "## テスト見出し\n本文テキスト\n")
     // --dry-run=true で実際の WebSocket 接続を発生させずに実行する
-    await runEdit({
-      title: "テストページ",
-      "from-file": tmpFile,
-      "input-format": "md",
-      project: "テストプロジェクト",
-      json: false,
-      plain: false,
-      "results-only": false,
-      "dry-run": true,
-      quiet: false,
-    })
+    try {
+      await runEdit({
+        title: "テストページ",
+        "from-file": tmpFile,
+        "input-format": "md",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": true,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
     // VALIDATION_ERROR が出ていないこと (MD フォーマットは有効)
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).not.toContain("VALIDATION_ERROR")
-    // exit 5 が VALIDATION_ERROR 由来でないこと
+    // exit 5 が呼ばれていないこと (MD フォーマットはバリデーションを通過する)
     expect(exitMock).not.toHaveBeenCalledWith(5)
   })
 })


### PR DESCRIPTION
## Summary

- `process.exit` をテストでモックすると後続の `buildWriter` が WebSocket 接続待ちで 5 秒タイムアウトしていた問題を修正
- `requireProject` / `requireSid` / `checkSandbox` の `process.exit` 呼び出しを `exitWithError()` ヘルパーに一元化し、モック環境でも `throw` で確実に早期終了するよう統一
- `insert.ts` / `edit.ts` のバリデーション失敗後の `return` 漏れを修正
- `edit.test.ts` の md フォーマットテストを `--dry-run: true` に変更して WS 接続を回避

## 修正したテスト (7件 → 0件)

- `pageUnpinCommand > プロジェクト未指定の場合は exit 5 で終了する`
- `pageInsertCommand > プロジェクト未指定の場合は exit 5 で終了する`
- `pageInsertCommand > --line も --from-file も指定しない場合は CONTENT_REQUIRED で exit 5`
- `pageEditCommand > プロジェクト未指定の場合は exit 5 で終了する`
- `pageEditCommand > --input-format に未知の値を指定した場合は VALIDATION_ERROR で exit 5`
- `pageEditCommand > --input-format=md の場合、MD ファイルを読み込んでバリデーションを通過し先へ進む`
- `pagePrependCommand > プロジェクト未指定の場合は exit 5 で終了する`

## Test plan

- [x] `bun test` — 539 pass / 0 fail (修正前: 532 pass / 7 fail)
- [x] `bunx biome check src tests` — エラー・警告ゼロ
- [x] `bun run typecheck` — エラーゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ページ編集コマンドの入力形式バリデーション失敗時にコマンド実行が適切に終了するように改善
  * ページ挿入コマンドでコンテンツが未入力の場合にコマンド実行が適切に終了するように改善
  * エラーハンドリングロジックを統一し、コマンド実行の制御フローを堅牢化

* **テスト**
  * ページ編集コマンドのテスト条件を改善し、テストの信頼性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->