### PR TITLE
fix(help): citty USAGE にバイナリパスが表示される問題を修正

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@progfay/scrapbox-parser": "^10.1.1",
         "citty": "^0.1.6",
         "cli-table3": "^0.6.5",
+        "consola": "^3.4.2",
         "json5": "^2.2.3",
         "picocolors": "^1.1.1",
         "zod": "^3.25.17",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@cosense/types": "npm:@jsr/cosense__types",
     "@progfay/scrapbox-parser": "^10.1.1",
     "citty": "^0.1.6",
+    "consola": "^3.4.2",
     "cli-table3": "^0.6.5",
     "json5": "^2.2.3",
     "picocolors": "^1.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { initColor } from "@/infra/color"
+import { createCustomShowUsage } from "@/infra/help"
 import { defineCommand, runMain } from "citty"
 
 // bun build --define 'VERSION="x.y.z"' でビルド時に注入される
@@ -61,7 +62,7 @@ import { serveCommand } from "@/commands/serve"
 
 /** page サブコマンドグループ */
 const pageCommand = defineCommand({
-  meta: { description: "ページ操作コマンド" },
+  meta: { name: "page", description: "ページ操作コマンド" },
   subCommands: {
     list: pageListCommand,
     ls: pageListCommand,
@@ -89,7 +90,7 @@ const pageCommand = defineCommand({
 
 /** project サブコマンドグループ */
 const projectCommand = defineCommand({
-  meta: { description: "プロジェクト操作コマンド" },
+  meta: { name: "project", description: "プロジェクト操作コマンド" },
   subCommands: {
     list: projectListCommand,
     ls: projectListCommand,
@@ -100,7 +101,7 @@ const projectCommand = defineCommand({
 
 /** auth サブコマンドグループ */
 const authCommand = defineCommand({
-  meta: { description: "認証コマンド" },
+  meta: { name: "auth", description: "認証コマンド" },
   subCommands: {
     login: authLoginCommand,
     logout: authLogoutCommand,
@@ -111,7 +112,7 @@ const authCommand = defineCommand({
 
 /** config サブコマンドグループ */
 const configCommand = defineCommand({
-  meta: { description: "設定コマンド" },
+  meta: { name: "config", description: "設定コマンド" },
   subCommands: {
     get: configGetCommand,
     set: configSetCommand,
@@ -121,7 +122,7 @@ const configCommand = defineCommand({
 
 /** sync サブコマンドグループ */
 const syncCommand = defineCommand({
-  meta: { description: "ローカルファイルと Cosense の同期コマンド" },
+  meta: { name: "sync", description: "ローカルファイルと Cosense の同期コマンド" },
   subCommands: {
     pull: syncPullCommand,
     push: syncPushCommand,
@@ -180,4 +181,7 @@ const main = defineCommand({
   },
 })
 
-runMain(main)
+// main の具体的な args 型を CommandDef に広げて createCustomShowUsage に渡す
+runMain(main, {
+  showUsage: createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos"),
+})

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -65,7 +65,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
   const storeFactory = deps.createStore ?? createTokenStore
 
   return defineCommand({
-    meta: { description: "Cosense に認証ログインする" },
+    meta: { name: "login", description: "Cosense に認証ログインする" },
     args: {
       ...commonArgs,
       sid: {

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -17,7 +17,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const authLogoutCommand = defineCommand({
-  meta: { description: "認証情報を削除する" },
+  meta: { name: "logout", description: "認証情報を削除する" },
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -20,7 +20,7 @@ import { writePlainTable } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 export const authWhoamiCommand = defineCommand({
-  meta: { description: "現在の認証ユーザー情報を取得する" },
+  meta: { name: "whoami", description: "現在の認証ユーザー情報を取得する" },
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -17,7 +17,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const configGetCommand = defineCommand({
-  meta: { description: "設定値を取得する" },
+  meta: { name: "get", description: "設定値を取得する" },
   args: {
     ...commonArgs,
     key: {

--- a/src/commands/config/path.ts
+++ b/src/commands/config/path.ts
@@ -17,7 +17,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const configPathCommand = defineCommand({
-  meta: { description: "設定ファイルのパスを表示する" },
+  meta: { name: "path", description: "設定ファイルのパスを表示する" },
   args: { ...commonArgs },
   run({ args }) {
     const a = args as CommonArgs

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -18,7 +18,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const configSetCommand = defineCommand({
-  meta: { description: "設定値を保存する" },
+  meta: { name: "set", description: "設定値を保存する" },
   args: {
     ...commonArgs,
     key: {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -16,7 +16,7 @@ const VALID_FORMATS = ["scrapbox", "md"] as const
 const VALID_BOLD_STYLES = ["auto", "heading", "emphasis"] as const
 
 export const convertCommand = defineCommand({
-  meta: { description: "Scrapbox 記法と Markdown を相互変換する" },
+  meta: { name: "convert", description: "Scrapbox 記法と Markdown を相互変換する" },
   args: {
     ...commonArgs,
     from: {

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -20,7 +20,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageAppendCommand = defineCommand({
-  meta: { description: "ページ末尾に行を追加する" },
+  meta: { name: "append", description: "ページ末尾に行を追加する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/code.ts
+++ b/src/commands/page/code.ts
@@ -18,7 +18,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageCodeCommand = defineCommand({
-  meta: { description: "ページ内のコードブロックを取得する" },
+  meta: { name: "code", description: "ページ内のコードブロックを取得する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -19,7 +19,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageDeleteCommand = defineCommand({
-  meta: { description: "ページを削除する" },
+  meta: { name: "delete", description: "ページを削除する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -25,7 +25,7 @@ import { defineCommand } from "citty"
 const VALID_INPUT_FORMATS = ["txt", "md"] as const
 
 export const pageEditCommand = defineCommand({
-  meta: { description: "ページ内容を全置換する" },
+  meta: { name: "edit", description: "ページ内容を全置換する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -18,7 +18,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageGetCommand = defineCommand({
-  meta: { description: "ページ詳細を取得する" },
+  meta: { name: "get", description: "ページ詳細を取得する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/icon.ts
+++ b/src/commands/page/icon.ts
@@ -18,7 +18,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageIconCommand = defineCommand({
-  meta: { description: "ページアイコン取得 URL を生成する (API 呼び出しなし)" },
+  meta: { name: "icon", description: "ページアイコン取得 URL を生成する (API 呼び出しなし)" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -21,7 +21,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageInsertCommand = defineCommand({
-  meta: { description: "指定行 (1-indexed) の後ろに行を挿入する" },
+  meta: { name: "insert", description: "指定行 (1-indexed) の後ろに行を挿入する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -20,7 +20,7 @@ import { writePlainTable, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 export const pageListCommand = defineCommand({
-  meta: { description: "ページ一覧を取得する" },
+  meta: { name: "list", description: "ページ一覧を取得する" },
   args: {
     ...commonArgs,
     limit: {

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -20,7 +20,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageNewCommand = defineCommand({
-  meta: { description: "新しいページを作成する" },
+  meta: { name: "new", description: "新しいページを作成する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/pin.ts
+++ b/src/commands/page/pin.ts
@@ -20,7 +20,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pagePinCommand = defineCommand({
-  meta: { description: "ページをピン留めする" },
+  meta: { name: "pin", description: "ページをピン留めする" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -20,7 +20,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pagePrependCommand = defineCommand({
-  meta: { description: "ページ先頭 (タイトル直後) に行を挿入する" },
+  meta: { name: "prepend", description: "ページ先頭 (タイトル直後) に行を挿入する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -23,7 +23,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageRenameCommand = defineCommand({
-  meta: { description: "ページタイトルを変更する" },
+  meta: { name: "rename", description: "ページタイトルを変更する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/text.ts
+++ b/src/commands/page/text.ts
@@ -24,7 +24,7 @@ const VALID_FORMATS = ["txt", "md"] as const
 const VALID_BOLD_STYLES = ["auto", "heading", "emphasis"] as const
 
 export const pageTextCommand = defineCommand({
-  meta: { description: "ページのテキスト本文を取得する" },
+  meta: { name: "text", description: "ページのテキスト本文を取得する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/unpin.ts
+++ b/src/commands/page/unpin.ts
@@ -18,7 +18,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageUnpinCommand = defineCommand({
-  meta: { description: "ページのピン留めを解除する" },
+  meta: { name: "unpin", description: "ページのピン留めを解除する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/url.ts
+++ b/src/commands/page/url.ts
@@ -18,7 +18,7 @@ import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageUrlCommand = defineCommand({
-  meta: { description: "ページの URL を生成する (API 呼び出しなし)" },
+  meta: { name: "url", description: "ページの URL を生成する (API 呼び出しなし)" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/page/watch.ts
+++ b/src/commands/page/watch.ts
@@ -53,7 +53,7 @@ export interface WatchDeps {
  */
 export function makePageWatchCommand(deps: WatchDeps = {}) {
   return defineCommand({
-    meta: { description: "ページ更新をリアルタイム監視する (tail -f 風)" },
+    meta: { name: "watch", description: "ページ更新をリアルタイム監視する (tail -f 風)" },
     args: {
       ...commonArgs,
       title: {

--- a/src/commands/project/graph.ts
+++ b/src/commands/project/graph.ts
@@ -35,7 +35,7 @@ const VALID_FORMATS = ["json", "dot", "csv"] as const
 type GraphFormat = (typeof VALID_FORMATS)[number]
 
 export const projectGraphCommand = defineCommand({
-  meta: { description: "プロジェクトのページ間リンクをグラフとして export する" },
+  meta: { name: "graph", description: "プロジェクトのページ間リンクをグラフとして export する" },
   args: {
     ...commonArgs,
     format: {

--- a/src/commands/project/info.ts
+++ b/src/commands/project/info.ts
@@ -19,7 +19,7 @@ import { writePlainTable } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 export const projectInfoCommand = defineCommand({
-  meta: { description: "プロジェクト詳細情報を取得する" },
+  meta: { name: "info", description: "プロジェクト詳細情報を取得する" },
   args: {
     ...commonArgs,
     name: {

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -17,7 +17,7 @@ import { writePlainTable, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 export const projectListCommand = defineCommand({
-  meta: { description: "参加中のプロジェクト一覧を取得する" },
+  meta: { name: "list", description: "参加中のプロジェクト一覧を取得する" },
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,7 +18,7 @@ import { writePlainList, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 export const searchCommand = defineCommand({
-  meta: { description: "ページをキーワード検索する" },
+  meta: { name: "search", description: "ページをキーワード検索する" },
   args: {
     ...commonArgs,
     query: {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -62,7 +62,7 @@ export function makeServeCommand(deps: ServeDeps = {}) {
   const startServerFn = deps.startServer ?? startBunServer
 
   return defineCommand({
-    meta: { description: "ローカル REST プロキシサーバーを起動する" },
+    meta: { name: "serve", description: "ローカル REST プロキシサーバーを起動する" },
     args: {
       ...commonArgs,
       rest: {

--- a/src/commands/sync/diff.ts
+++ b/src/commands/sync/diff.ts
@@ -21,7 +21,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const syncDiffCommand = defineCommand({
-  meta: { description: "ローカルと Cosense の差分を表示する" },
+  meta: { name: "diff", description: "ローカルと Cosense の差分を表示する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -21,7 +21,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const syncPullCommand = defineCommand({
-  meta: { description: "Cosense → ローカルへ pull する" },
+  meta: { name: "pull", description: "Cosense → ローカルへ pull する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -22,7 +22,7 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const syncPushCommand = defineCommand({
-  meta: { description: "ローカル → Cosense へ push する" },
+  meta: { name: "push", description: "ローカル → Cosense へ push する" },
   args: {
     ...commonArgs,
     title: {

--- a/src/infra/help.ts
+++ b/src/infra/help.ts
@@ -1,0 +1,139 @@
+/**
+ * help.ts — citty のヘルプ表示における USAGE バイナリパス露出問題のワークアラウンド。
+ *
+ * citty 0.1.6 の renderUsage は以下の2問題を持つ:
+ * 1. cmdMeta.name 未設定時に process.argv[1] (バイナリパス) にフォールバックする
+ * 2. resolveSubCommand が親を1階層しか伝播しない (3階層目でルート名を失う)
+ *
+ * 本モジュールは rawArgs から完全なコマンドパスを再構築し、
+ * 合成 parent を使って citty の公開 renderUsage を正しく呼び出す。
+ */
+
+import { type showUsage as cittyShowUsage, renderUsage } from "citty"
+import type { CommandDef, Resolvable } from "citty"
+import consola from "consola"
+
+/** resolveCommandPath の返り値 */
+export type ResolvedCommand = {
+  /** 末端の解決済みコマンド */
+  cmd: CommandDef
+  /** ルートから末端までのコマンドパス。例: ["cos", "page", "list"] */
+  pathSegments: string[]
+}
+
+/**
+ * resolveValue は Resolvable<T> を解決する。
+ * citty の Resolvable<T> = T | Promise<T> | (() => T) | (() => Promise<T>) に対応する。
+ */
+async function resolveValue<T>(value: Resolvable<T>): Promise<T> {
+  if (typeof value === "function") {
+    return (value as (() => T) | (() => Promise<T>))()
+  }
+  return value
+}
+
+/**
+ * resolveCommandPath は rawArgs を辿り、どのコマンドが対象かを解決する。
+ *
+ * citty の resolveSubCommand と異なり、ルートからのフルパスを pathSegments に保持する。
+ * 未知のサブコマンドが現れた場合は graceful にその手前で停止し、親コマンドを返す。
+ */
+export async function resolveCommandPath(
+  rootCmd: CommandDef,
+  rootName: string,
+  rawArgs: string[],
+): Promise<ResolvedCommand> {
+  const pathSegments: string[] = [rootName]
+  let currentCmd: CommandDef = rootCmd
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i]
+    // フラグ (--, -x 形式) はスキップ
+    if (arg === undefined || arg.startsWith("-")) {
+      continue
+    }
+
+    if (!currentCmd.subCommands) {
+      // リーフコマンドに到達済み: positional arg はコマンドキーではない
+      break
+    }
+    const subCommands = await resolveValue(currentCmd.subCommands)
+    if (!subCommands || Object.keys(subCommands).length === 0) {
+      break
+    }
+
+    const subCmd = subCommands[arg]
+    if (subCmd === undefined) {
+      // 未知のサブコマンド: graceful fallback
+      break
+    }
+
+    const resolvedSubCmd = await resolveValue(subCmd)
+
+    currentCmd = resolvedSubCmd
+    pathSegments.push(arg)
+  }
+
+  return { cmd: currentCmd, pathSegments }
+}
+
+/**
+ * ensureMetaName は CommandDef の meta.name を強制的に設定したクローンを返す。
+ *
+ * exactOptionalPropertyTypes 対策として、meta オブジェクトを spread でクローンし
+ * name を追加する。元の CommandDef は変更しない。
+ */
+function ensureMetaName(cmd: CommandDef, name: string): CommandDef {
+  return {
+    ...cmd,
+    meta: { ...(cmd.meta as object), name },
+  }
+}
+
+/**
+ * renderUsageForArgs は rawArgs を元にヘルプ文字列を生成して返す純関数。
+ *
+ * citty の公開 renderUsage を使用するが、合成 parent を介してフルパスを注入することで
+ * process.argv[1] フォールバックを回避する。
+ */
+export async function renderUsageForArgs(
+  rootCmd: CommandDef,
+  rootName: string,
+  rawArgs: string[],
+): Promise<string> {
+  const { cmd, pathSegments } = await resolveCommandPath(rootCmd, rootName, rawArgs)
+  const lastSegment = pathSegments.at(-1) ?? rootName
+  const parentSegments = pathSegments.slice(0, -1)
+
+  // 合成 parent: meta.name に "cos page" のような接頭辞を設定する
+  // citty の renderUsage は `${parentMeta.name} ` + cmdMeta.name で commandName を構築するため
+  const syntheticParent: CommandDef =
+    parentSegments.length > 0 ? { meta: { name: parentSegments.join(" ") } } : { meta: {} }
+
+  // citty の renderUsage が process.argv[1] にフォールバックしないよう meta.name を保証する
+  const cmdWithName = ensureMetaName(cmd, lastSegment)
+
+  return renderUsage(cmdWithName, syntheticParent)
+}
+
+/**
+ * createCustomShowUsage は runMain の showUsage オプションに渡せるクロージャを生成する。
+ *
+ * citty の showUsage と同じシグネチャ (cmd, parent) を受け取るが、引数は無視し、
+ * process.argv.slice(2) から自前でコマンドパスを再構築して正確な USAGE を表示する。
+ *
+ * 戻り値の型は citty の showUsage と同一 (typeof cittyShowUsage) にして
+ * runMain の showUsage オプションとして直接渡せるようにする。
+ */
+export function createCustomShowUsage(
+  rootCmd: CommandDef,
+  rootName: string,
+): typeof cittyShowUsage {
+  const fn = async () => {
+    const rawArgs = process.argv.slice(2)
+    const out = await renderUsageForArgs(rootCmd, rootName, rawArgs)
+    consola.log(`${out}\n`)
+  }
+  // citty の showUsage は generic 関数だが、引数を使わない実装のため安全にキャストする
+  return fn as typeof cittyShowUsage
+}

--- a/src/infra/help.ts
+++ b/src/infra/help.ts
@@ -10,7 +10,7 @@
  */
 
 import { type showUsage as cittyShowUsage, renderUsage } from "citty"
-import type { CommandDef, Resolvable } from "citty"
+import type { ArgsDef, CommandDef, Resolvable } from "citty"
 import consola from "consola"
 
 /** resolveCommandPath の返り値 */
@@ -33,9 +33,34 @@ async function resolveValue<T>(value: Resolvable<T>): Promise<T> {
 }
 
 /**
- * resolveCommandPath は rawArgs を辿り、どのコマンドが対象かを解決する。
+ * getStringFlagNames はコマンドの args から文字列型フラグ名のセットを返す。
+ *
+ * boolean 型と positional 型以外のフラグは値を必要とするため、セットに含める。
+ * エイリアスも含む。
+ */
+async function getStringFlagNames(cmd: CommandDef): Promise<Set<string>> {
+  if (!cmd.args) return new Set()
+  const args = await resolveValue(cmd.args as Resolvable<ArgsDef>)
+  const result = new Set<string>()
+  for (const [name, def] of Object.entries(args ?? {})) {
+    const resolved = await resolveValue(def as Resolvable<{ type?: string; alias?: string[] }>)
+    const type = resolved?.type
+    // boolean 型と positional 型以外はフラグ値を次トークンとして必要とする
+    if (type !== "boolean" && type !== "positional") {
+      result.add(name)
+      if (resolved?.alias) {
+        for (const a of resolved.alias) result.add(a)
+      }
+    }
+  }
+  return result
+}
+
+/**
+ * resolveCommandPath は rawArgs を辿りコマンドパスを解決した ResolvedCommand を返す。
  *
  * citty の resolveSubCommand と異なり、ルートからのフルパスを pathSegments に保持する。
+ * 文字列型フラグの値トークンをスキップすることで、`--flag value subcommand` 形式にも対応する。
  * 未知のサブコマンドが現れた場合は graceful にその手前で停止し、親コマンドを返す。
  */
 export async function resolveCommandPath(
@@ -45,11 +70,27 @@ export async function resolveCommandPath(
 ): Promise<ResolvedCommand> {
   const pathSegments: string[] = [rootName]
   let currentCmd: CommandDef = rootCmd
+  let stringFlagNames = await getStringFlagNames(currentCmd)
 
-  for (let i = 0; i < rawArgs.length; i++) {
+  let i = 0
+  while (i < rawArgs.length) {
     const arg = rawArgs[i]
-    // フラグ (--, -x 形式) はスキップ
-    if (arg === undefined || arg.startsWith("-")) {
+    if (arg === undefined) {
+      i++
+      continue
+    }
+
+    if (arg.startsWith("-")) {
+      // --flag=value 形式はそのまま 1 トークンでスキップ
+      if (!arg.includes("=")) {
+        const flagName = arg.replace(/^-+/, "")
+        // 文字列型フラグなら次のトークン (値) もスキップ
+        if (stringFlagNames.has(flagName)) {
+          i += 2
+          continue
+        }
+      }
+      i++
       continue
     }
 
@@ -69,9 +110,11 @@ export async function resolveCommandPath(
     }
 
     const resolvedSubCmd = await resolveValue(subCmd)
-
     currentCmd = resolvedSubCmd
     pathSegments.push(arg)
+    // サブコマンドに進んだら、新しいコマンドのフラグセットに更新
+    stringFlagNames = await getStringFlagNames(currentCmd)
+    i++
   }
 
   return { cmd: currentCmd, pathSegments }
@@ -117,7 +160,7 @@ export async function renderUsageForArgs(
 }
 
 /**
- * createCustomShowUsage は runMain の showUsage オプションに渡せるクロージャを生成する。
+ * createCustomShowUsage は runMain の showUsage オプションに渡すクロージャを返す。
  *
  * citty の showUsage と同じシグネチャ (cmd, parent) を受け取るが、引数は無視し、
  * process.argv.slice(2) から自前でコマンドパスを再構築して正確な USAGE を表示する。

--- a/tests/unit/infra/help.test.ts
+++ b/tests/unit/infra/help.test.ts
@@ -3,11 +3,14 @@
  *
  * resolveCommandPath: rawArgs からコマンドパスを再構築する関数
  * renderUsageForArgs: rawArgs からヘルプ文字列を生成する純関数
+ * createCustomShowUsage: runMain の showUsage オプション用クロージャを返す関数
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { renderUsageForArgs, resolveCommandPath } from "@/infra/help"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { createCustomShowUsage, renderUsageForArgs, resolveCommandPath } from "@/infra/help"
 import { defineCommand } from "citty"
+import type { CommandDef } from "citty"
+import consola from "consola"
 
 // テスト用コマンドツリーの構築
 const pageListCmd = defineCommand({
@@ -43,6 +46,17 @@ const rootCmd = defineCommand({
     page: pageCmd,
     search: searchCmd,
     find: searchCmd,
+  },
+})
+
+// --color のような文字列型ルートフラグを持つコマンドツリー (Copilot 指摘の回帰テスト用)
+const rootCmdWithStringFlag = defineCommand({
+  meta: { name: "cos", description: "Cosense CLI" },
+  args: {
+    color: { type: "string", description: "色設定" },
+  },
+  subCommands: {
+    page: pageCmd,
   },
 })
 
@@ -124,6 +138,30 @@ describe("resolveCommandPath", () => {
     expect(result.pathSegments).toEqual(["cos", "find"])
     expect(Object.is(result.cmd, searchCmd)).toBe(true)
   })
+
+  test("値付きルートフラグが先頭にある場合: フラグ値をスキップして page list を解決する", async () => {
+    // --color never のような string 型フラグの値 "never" を未知サブコマンドとして誤認しないことを確認
+    const result = await resolveCommandPath(rootCmdWithStringFlag as unknown as CommandDef, "cos", [
+      "--color",
+      "never",
+      "page",
+      "list",
+      "--help",
+    ])
+    expect(result.pathSegments).toEqual(["cos", "page", "list"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
+
+  test("--flag=value 形式: = 以降を値として 1 トークンでスキップする", async () => {
+    const result = await resolveCommandPath(rootCmdWithStringFlag as unknown as CommandDef, "cos", [
+      "--color=never",
+      "page",
+      "list",
+      "--help",
+    ])
+    expect(result.pathSegments).toEqual(["cos", "page", "list"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
 })
 
 describe("renderUsageForArgs", () => {
@@ -179,5 +217,53 @@ describe("renderUsageForArgs", () => {
     expect(result).toContain("cos page list")
     expect(result).not.toContain("/$bunfs/")
     expect(result).not.toContain("cos-darwin-arm64")
+  })
+
+  test("値付きルートフラグが先頭にある場合: 'cos page list' を含む", async () => {
+    // --color never の値 "never" を未知サブコマンドとして誤認しないことを確認 (回帰テスト)
+    const result = await renderUsageForArgs(rootCmdWithStringFlag as unknown as CommandDef, "cos", [
+      "--color",
+      "never",
+      "page",
+      "list",
+      "--help",
+    ])
+    expect(result).toContain("cos page list")
+    expect(result).not.toContain("/$bunfs/")
+  })
+})
+
+describe("createCustomShowUsage", () => {
+  let originalArgv: string[]
+  let logOutput: unknown
+
+  beforeEach(() => {
+    originalArgv = process.argv.slice()
+    logOutput = undefined
+    // consola の LogFn は .raw プロパティを持つ関数型のため、as でキャストする
+    spyOn(consola, "log").mockImplementation(((...args: unknown[]) => {
+      logOutput = args[0]
+    }) as unknown as typeof consola.log)
+  })
+
+  afterEach(() => {
+    process.argv.splice(0, process.argv.length, ...originalArgv)
+  })
+
+  test("process.argv から 'cos page list' を含む USAGE を出力する", async () => {
+    process.argv = ["bun", "/$bunfs/root/cos-darwin-arm64", "page", "list", "--help"]
+    const showUsageFn = createCustomShowUsage(rootCmd, "cos")
+    // citty の showUsage シグネチャに合わせて呼び出す (引数は内部で無視される)
+    await (showUsageFn as () => Promise<void>)()
+    expect(String(logOutput)).toContain("cos page list")
+    expect(String(logOutput)).not.toContain("/$bunfs/")
+  })
+
+  test("バイナリパスが露出しない: process.argv[1] が SFE パスでも安全", async () => {
+    process.argv = ["bun", "/$bunfs/root/cos-darwin-arm64", "page", "--help"]
+    const showUsageFn = createCustomShowUsage(rootCmd, "cos")
+    await (showUsageFn as () => Promise<void>)()
+    expect(String(logOutput)).toContain("cos page")
+    expect(String(logOutput)).not.toContain("/$bunfs/")
   })
 })

--- a/tests/unit/infra/help.test.ts
+++ b/tests/unit/infra/help.test.ts
@@ -1,0 +1,183 @@
+/**
+ * src/infra/help.ts のユニットテスト。
+ *
+ * resolveCommandPath: rawArgs からコマンドパスを再構築する関数
+ * renderUsageForArgs: rawArgs からヘルプ文字列を生成する純関数
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { renderUsageForArgs, resolveCommandPath } from "@/infra/help"
+import { defineCommand } from "citty"
+
+// テスト用コマンドツリーの構築
+const pageListCmd = defineCommand({
+  meta: { description: "ページ一覧を取得する" },
+  args: {
+    project: { type: "string", description: "プロジェクト名" },
+  },
+  run: () => {},
+})
+
+const pageGetCmd = defineCommand({
+  meta: { description: "ページを取得する" },
+  run: () => {},
+})
+
+const pageCmd = defineCommand({
+  meta: { description: "ページ操作コマンド" },
+  subCommands: {
+    list: pageListCmd,
+    ls: pageListCmd,
+    get: pageGetCmd,
+  },
+})
+
+const searchCmd = defineCommand({
+  meta: { description: "ページを検索する" },
+  run: () => {},
+})
+
+const rootCmd = defineCommand({
+  meta: { name: "cos", description: "Cosense CLI" },
+  subCommands: {
+    page: pageCmd,
+    search: searchCmd,
+    find: searchCmd,
+  },
+})
+
+describe("resolveCommandPath", () => {
+  test("引数なし: ルートコマンドを返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", [])
+    expect(result.pathSegments).toEqual(["cos"])
+    expect(Object.is(result.cmd, rootCmd)).toBe(true)
+  })
+
+  test("--help のみ: ルートコマンドを返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["--help"])
+    expect(result.pathSegments).toEqual(["cos"])
+    expect(Object.is(result.cmd, rootCmd)).toBe(true)
+  })
+
+  test("グループコマンド: pageCmd を返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page"])
+    expect(result.pathSegments).toEqual(["cos", "page"])
+    expect(Object.is(result.cmd, pageCmd)).toBe(true)
+  })
+
+  test("グループコマンド + --help: pageCmd を返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page", "--help"])
+    expect(result.pathSegments).toEqual(["cos", "page"])
+    expect(Object.is(result.cmd, pageCmd)).toBe(true)
+  })
+
+  test("3階層: pageListCmd を返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page", "list"])
+    expect(result.pathSegments).toEqual(["cos", "page", "list"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
+
+  test("3階層 + --help: pageListCmd を返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page", "list", "--help"])
+    expect(result.pathSegments).toEqual(["cos", "page", "list"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
+
+  test("フラグ混じり: フラグをスキップして pageListCmd を返す", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", [
+      "page",
+      "list",
+      "--project",
+      "foo",
+      "--help",
+    ])
+    expect(result.pathSegments).toEqual(["cos", "page", "list"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
+
+  test("--help が先頭: page を後方から解決する", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["--help", "page"])
+    expect(result.pathSegments).toEqual(["cos", "page"])
+    expect(Object.is(result.cmd, pageCmd)).toBe(true)
+  })
+
+  test("alias: ls で pageListCmd を返し、パスにも ls が入る", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page", "ls", "--help"])
+    expect(result.pathSegments).toEqual(["cos", "page", "ls"])
+    expect(Object.is(result.cmd, pageListCmd)).toBe(true)
+  })
+
+  test("未知のサブコマンド: ルートに graceful fallback", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["foobar"])
+    expect(result.pathSegments).toEqual(["cos"])
+    expect(Object.is(result.cmd, rootCmd)).toBe(true)
+  })
+
+  test("グループ直下の未知コマンド: pageCmd に graceful fallback", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["page", "foobar"])
+    expect(result.pathSegments).toEqual(["cos", "page"])
+    expect(Object.is(result.cmd, pageCmd)).toBe(true)
+  })
+
+  test("二重登録された alias (find=search): 入力キーをパスに使う", async () => {
+    const result = await resolveCommandPath(rootCmd, "cos", ["find", "--help"])
+    expect(result.pathSegments).toEqual(["cos", "find"])
+    expect(Object.is(result.cmd, searchCmd)).toBe(true)
+  })
+})
+
+describe("renderUsageForArgs", () => {
+  let originalArgv: string[]
+
+  beforeEach(() => {
+    originalArgv = process.argv.slice()
+  })
+
+  afterEach(() => {
+    process.argv.splice(0, process.argv.length, ...originalArgv)
+  })
+
+  test("ルートヘルプ: 'cos' を含み バイナリパスを含まない", async () => {
+    const result = await renderUsageForArgs(rootCmd, "cos", ["--help"])
+    expect(result).toContain("cos")
+    expect(result).not.toContain("/$bunfs/")
+  })
+
+  test("グループヘルプ: 'cos page' を含む", async () => {
+    const result = await renderUsageForArgs(rootCmd, "cos", ["page", "--help"])
+    expect(result).toContain("cos page")
+    expect(result).not.toContain("/$bunfs/")
+  })
+
+  test("3階層ヘルプ: 'cos page list' を含む", async () => {
+    const result = await renderUsageForArgs(rootCmd, "cos", ["page", "list", "--help"])
+    expect(result).toContain("cos page list")
+    expect(result).not.toContain("/$bunfs/")
+  })
+
+  test("フラグ混じり3階層: 'cos page list' を含む", async () => {
+    const result = await renderUsageForArgs(rootCmd, "cos", [
+      "page",
+      "list",
+      "--project",
+      "foo",
+      "--help",
+    ])
+    expect(result).toContain("cos page list")
+    expect(result).not.toContain("/$bunfs/")
+  })
+
+  test("alias 経由: 'cos page ls' を含む", async () => {
+    const result = await renderUsageForArgs(rootCmd, "cos", ["page", "ls", "--help"])
+    expect(result).toContain("cos page ls")
+    expect(result).not.toContain("/$bunfs/")
+  })
+
+  test("bun SFE バイナリパス偽装: process.argv[1] をバイナリパスにしても露出しない", async () => {
+    process.argv[1] = "/$bunfs/root/cos-darwin-arm64"
+    const result = await renderUsageForArgs(rootCmd, "cos", ["page", "list", "--help"])
+    expect(result).toContain("cos page list")
+    expect(result).not.toContain("/$bunfs/")
+    expect(result).not.toContain("cos-darwin-arm64")
+  })
+})


### PR DESCRIPTION
## Summary

- `cos page --help` や `cos page list --help` などのヘルプ表示で USAGE 行にバイナリパス (`/$bunfs/root/cos-darwin-arm64`) が露出する問題を修正
- citty 0.1.6 の `renderUsage` における2つのバグ (process.argv[1] フォールバック・親1階層のみ伝播) をワークアラウンドで解決

**修正前:**
```
USAGE cos /$bunfs/root/cos-darwin-arm64 list|ls|get|...
ページ一覧を取得する (/$bunfs/root/cos-darwin-arm64)
```

**修正後:**
```
ページ一覧を取得する (cos page list)
USAGE cos page list [OPTIONS]
```

## Changes

- `src/infra/help.ts` (新規): `resolveCommandPath`・`renderUsageForArgs`・`createCustomShowUsage` を実装
  - rawArgs からコマンドツリーをフルパスで再構築
  - 合成 parent (`{ meta: { name: "cos page" } }`) を使って citty の公開 `renderUsage` を正しく呼び出す
- 全コマンド・グループに `meta.name` を設定 (`process.argv[1]` フォールバックを防止)
- `runMain` の `showUsage` オプションに `createCustomShowUsage` を渡す
- `tests/unit/infra/help.test.ts` (新規): 18テストケース (resolveCommandPath・renderUsageForArgs の正常系・異常系・回帰テスト)

## Test plan

- [ ] `bun run dev page --help` → `USAGE cos page ...` (バイナリパスなし)
- [ ] `bun run dev page list --help` → `USAGE cos page list [OPTIONS]`
- [ ] `bun run dev page ls --help` → `USAGE cos page ls ...` (alias 表示)
- [ ] `bun run dev foobar --help` → ルートヘルプに graceful fallback
- [ ] `./dist/cos-darwin-arm64 page list --help` → `USAGE cos page list [OPTIONS]` (SFE でも露出なし)
- [ ] `bun test` → 573 pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI のヘルプ表示（USAGE）レンダリングを改善し、正しいコマンドパスを表示するようになりました
  * 多数のサブコマンドに表示用メタ情報（コマンド名）を明示的に追加し、CLI 表示の一貫性を向上しました
* **Tests**
  * ヘルプ表示解決ロジックのユニットテストを追加しました
* **Chores**
  * ロギング用依存パッケージを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->