### PR TITLE
fix(help): alias を canonical (alias) 形式でグルーピング表示する

### DIFF
--- a/src/infra/help.ts
+++ b/src/infra/help.ts
@@ -5,12 +5,15 @@
  * 1. cmdMeta.name 未設定時に process.argv[1] (バイナリパス) にフォールバックする
  * 2. resolveSubCommand が親を1階層しか伝播しない (3階層目でルート名を失う)
  *
+ * 加えて、subCommands に同一オブジェクト参照を複数キーで登録すると alias が
+ * 重複行として表示されてしまう問題を groupSubCommandsByAlias で解消する。
+ *
  * 本モジュールは rawArgs から完全なコマンドパスを再構築し、
  * 合成 parent を使って citty の公開 renderUsage を正しく呼び出す。
  */
 
 import { type showUsage as cittyShowUsage, renderUsage } from "citty"
-import type { ArgsDef, CommandDef, Resolvable } from "citty"
+import type { ArgsDef, CommandDef, Resolvable, SubCommandsDef } from "citty"
 import consola from "consola"
 
 /** resolveCommandPath の返り値 */
@@ -134,6 +137,62 @@ function ensureMetaName(cmd: CommandDef, name: string): CommandDef {
 }
 
 /**
+ * groupSubCommandsByAlias は同一オブジェクト参照を共有する複数のキーを
+ * `canonical (alias1, alias2)` 形式の単一キーにまとめた新しい subCommands を返す。
+ *
+ * canonical キーの判定優先順位:
+ *   1. resolved meta.name と一致するキー
+ *   2. 最初に出現したキー (フォールバック)
+ *
+ * 元の subCommands は変更しない。並び順は canonical キーの初出位置を保持する。
+ * alias を持たない場合は元のキーをそのまま使用する。
+ */
+async function groupSubCommandsByAlias(
+  subCommands: SubCommandsDef,
+): Promise<Record<string, Resolvable<CommandDef>>> {
+  // 同一参照ごとにキーをまとめる: Map<CommandDef オブジェクト, キー名リスト>
+  const refToKeys = new Map<CommandDef, string[]>()
+  // 各参照の初出順序を保持する配列
+  const refOrder: CommandDef[] = []
+
+  for (const [key, sub] of Object.entries(subCommands)) {
+    const resolved = await resolveValue(sub as Resolvable<CommandDef>)
+    if (!refToKeys.has(resolved)) {
+      refToKeys.set(resolved, [])
+      refOrder.push(resolved)
+    }
+    const keys = refToKeys.get(resolved)
+    if (keys) {
+      keys.push(key)
+    }
+  }
+
+  const result: Record<string, Resolvable<CommandDef>> = {}
+
+  for (const resolved of refOrder) {
+    const keys = refToKeys.get(resolved) ?? []
+    if (keys.length === 0) continue
+
+    const meta = resolved.meta
+      ? await resolveValue(resolved.meta as Resolvable<{ name?: string }>)
+      : null
+    const metaName = meta?.name
+
+    // canonical キーを決定する
+    const canonicalKey = (metaName && keys.includes(metaName) ? metaName : null) ?? keys[0] ?? ""
+    const aliasKeys = keys.filter((k) => k !== canonicalKey)
+
+    // alias がある場合は `canonical (alias1, alias2)` 形式、ない場合はそのまま
+    const displayKey =
+      aliasKeys.length > 0 ? `${canonicalKey} (${aliasKeys.join(", ")})` : canonicalKey
+
+    result[displayKey] = resolved
+  }
+
+  return result
+}
+
+/**
  * renderUsageForArgs は rawArgs を元にヘルプ文字列を生成して返す純関数。
  *
  * citty の公開 renderUsage を使用するが、合成 parent を介してフルパスを注入することで
@@ -155,6 +214,13 @@ export async function renderUsageForArgs(
 
   // citty の renderUsage が process.argv[1] にフォールバックしないよう meta.name を保証する
   const cmdWithName = ensureMetaName(cmd, lastSegment)
+
+  // subCommands の alias を `canonical (alias)` 形式にグルーピングする
+  if (cmdWithName.subCommands) {
+    const originalSubCommands = await resolveValue(cmdWithName.subCommands as SubCommandsDef)
+    const groupedSubCommands = await groupSubCommandsByAlias(originalSubCommands)
+    return renderUsage({ ...cmdWithName, subCommands: groupedSubCommands }, syntheticParent)
+  }
 
   return renderUsage(cmdWithName, syntheticParent)
 }

--- a/tests/unit/infra/help.test.ts
+++ b/tests/unit/infra/help.test.ts
@@ -14,7 +14,8 @@ import consola from "consola"
 
 // テスト用コマンドツリーの構築
 const pageListCmd = defineCommand({
-  meta: { description: "ページ一覧を取得する" },
+  // meta.name を設定し canonical 判定を本番コマンドと同等の状態にする
+  meta: { name: "list", description: "ページ一覧を取得する" },
   args: {
     project: { type: "string", description: "プロジェクト名" },
   },
@@ -36,7 +37,8 @@ const pageCmd = defineCommand({
 })
 
 const searchCmd = defineCommand({
-  meta: { description: "ページを検索する" },
+  // meta.name を設定し canonical 判定を本番コマンドと同等の状態にする
+  meta: { name: "search", description: "ページを検索する" },
   run: () => {},
 })
 
@@ -230,6 +232,38 @@ describe("renderUsageForArgs", () => {
     ])
     expect(result).toContain("cos page list")
     expect(result).not.toContain("/$bunfs/")
+  })
+
+  describe("alias グルーピング", () => {
+    test("cos page --help: 'list (ls)' が表示され、独立した ls 行が消える", async () => {
+      // pageCmd は list と ls を同じコマンドオブジェクトで登録している
+      const result = await renderUsageForArgs(rootCmd, "cos", ["page", "--help"])
+      // canonical とエイリアスがひとつの行にまとまっていること
+      expect(result).toContain("list (ls)")
+      // ls だけの独立行がないこと ("\`ls\`" のようなバックティック形式で出ないこと)
+      expect(result).not.toMatch(/`ls`\s/)
+    })
+
+    test("cos page --help: alias なし get はそのまま表示される", async () => {
+      const result = await renderUsageForArgs(rootCmd, "cos", ["page", "--help"])
+      // alias がない get はグルーピングされずそのまま残ること
+      expect(result).toContain("get")
+      expect(result).not.toContain("get (")
+    })
+
+    test("cos --help (ルート): 'search (find)' が表示され、独立した find 行が消える", async () => {
+      // ルートに search と find が同一コマンドオブジェクトで登録されている
+      const result = await renderUsageForArgs(rootCmd, "cos", ["--help"])
+      expect(result).toContain("search (find)")
+      expect(result).not.toMatch(/`find`\s/)
+    })
+
+    test("cos page ls --help: alias 経由のナビゲーションは引き続き 'cos page ls' を表示する", async () => {
+      // alias でコマンドを指定したとき、ヘッダ行は入力パス ('cos page ls') を保持すること
+      const result = await renderUsageForArgs(rootCmd, "cos", ["page", "ls", "--help"])
+      expect(result).toContain("cos page ls")
+      expect(result).not.toContain("/$bunfs/")
+    })
   })
 })
 


### PR DESCRIPTION
## 問題

`cos page --help` のコマンド一覧で alias が独立行として重複表示されていた。alias 数が多いため、実機能数の約 2 倍の行数になり読みづらかった。

## 解決策

`src/infra/help.ts` の `renderUsageForArgs` 内で、citty の `renderUsage` に渡す前に subCommands を pre-process する `groupSubCommandsByAlias` ヘルパを追加した。

- 同一オブジェクト参照を持つ複数キーを検出し、`list (ls)` 形式の単一キーに統合する
- canonical キーの判定: `meta.name` と一致するキーを優先、未設定の場合は最初のキー
- `src/cli.ts` の alias 二重登録は変更不要 (表示層のみの対応)

## 変更後の表示

```
cos page --help:
  list (ls)    ページ一覧を取得する
  new (create) 新しいページを作成する
  edit (ed)    ページ内容を全置換する
  rename (mv)  ページタイトルを変更する
  delete (rm)  ページを削除する

cos --help:
  search (find) ページをキーワード検索する
```

## テスト

- `groupSubCommandsByAlias` の動作を `renderUsageForArgs` 統合テストで検証
- `cos page --help` 出力に `list (ls)` が含まれ、独立した `ls` 行が消えることを確認
- alias 経由ナビゲーション (`cos page ls --help`) が引き続き正常動作することを確認

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * ヘルプ出力でコマンドエイリアスが正規形式でグループ化されて表示されるようになりました（例："list (ls)"）。

* **テスト**
  * エイリアスグループ化の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->