### PR TITLE
feat: エージェント向け補助コマンド cos exit-codes / cos schema を追加

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f55cda23-3f37-45f8-b6c5-cdd5a66a4693","pid":89666,"procStart":"Wed Apr 29 08:32:36 2026","acquiredAt":1777556148337}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f55cda23-3f37-45f8-b6c5-cdd5a66a4693","pid":89666,"procStart":"Wed Apr 29 08:32:36 2026","acquiredAt":1777556148337}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .DS_Store
 *.bak
 *.bun-build
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ src/
 
 ## 終了コード
 
+機械可読な一覧は `cos exit-codes --json` で取得できます（単一ソース: `src/core/exit-codes.ts`）。
+
 | code | 意味 |
 |---|---|
 | 0 | 成功 |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ cos config set    設定値を保存
 cos config path   設定ファイルのパスを表示
 
 cos convert       Scrapbox 記法と Markdown を相互変換する
+
+cos exit-codes    終了コード一覧を出力する (エージェント向け)
+cos schema        コマンド/フラグのスキーマを JSON で出力する (エージェント向け)
 ```
 
 ## Markdown 変換 (v0.3)
@@ -218,6 +221,8 @@ cos auth login --no-input --sid "$COS_SID"
 ```
 
 ## 終了コード
+
+機械可読な一覧は `cos exit-codes --json` で取得できます。
 
 | コード | 意味 |
 |---|---|

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
  * sandbox (--enable-commands/--disable-commands) を一元管理する。
  */
 
+import { setRootCommand } from "@/core/cli-root"
 import { initColor } from "@/infra/color"
 import { createCustomShowUsage } from "@/infra/help"
 import { defineCommand, runMain } from "citty"
@@ -59,6 +60,10 @@ import { convertCommand } from "@/commands/convert"
 
 // サーブコマンド
 import { serveCommand } from "@/commands/serve"
+
+// エージェント向け補助コマンド
+import { exitCodesCommand } from "@/commands/exit-codes"
+import { schemaCommand } from "@/commands/schema"
 
 /** page サブコマンドグループ */
 const pageCommand = defineCommand({
@@ -178,8 +183,14 @@ const main = defineCommand({
     sync: syncCommand,
     convert: convertCommand,
     serve: serveCommand,
+    "exit-codes": exitCodesCommand,
+    schema: schemaCommand,
   },
 })
+
+// schema コマンドがルートを参照できるよう singleton に登録する
+// exactOptionalPropertyTypes のため具体的な args 型を CommandDef に広げてから渡す
+setRootCommand(main as unknown as import("citty").CommandDef)
 
 // main の具体的な args 型を CommandDef に広げて createCustomShowUsage に渡す
 runMain(main, {

--- a/src/commands/exit-codes.ts
+++ b/src/commands/exit-codes.ts
@@ -5,7 +5,7 @@
  * エージェントがエラーハンドリングを実装する際の参照情報として使用する。
  */
 
-import { type CommonArgs, buildJsonOpts, commonArgs } from "@/commands/_shared"
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
 import { EXIT_CODES } from "@/core/exit-codes"
 import { writeJson } from "@/presenter/json"
 import { writePlainTable, writeTsv } from "@/presenter/plain"
@@ -17,6 +17,7 @@ export const exitCodesCommand = defineCommand({
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs
+    checkSandbox("exit-codes", a)
 
     if (a.json) {
       const startTime = Date.now()

--- a/src/commands/exit-codes.ts
+++ b/src/commands/exit-codes.ts
@@ -1,0 +1,35 @@
+/**
+ * exit-codes.ts — `cos exit-codes` コマンド定義。
+ *
+ * 終了コード一覧を機械可読形式 (JSON) またはテーブル形式で出力する。
+ * エージェントがエラーハンドリングを実装する際の参照情報として使用する。
+ */
+
+import { type CommonArgs, buildJsonOpts, commonArgs } from "@/commands/_shared"
+import { EXIT_CODES } from "@/core/exit-codes"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable, writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const exitCodesCommand = defineCommand({
+  meta: { name: "exit-codes", description: "終了コード一覧を出力する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs
+    const startTime = Date.now()
+
+    if (a.json) {
+      writeJson([...EXIT_CODES], { command: "exit-codes", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    const headers = ["code", "name", "description"]
+    const rows = EXIT_CODES.map((e) => [String(e.code), e.name, e.description])
+
+    if (a.plain) {
+      writeTsv(headers, rows)
+    } else {
+      writePlainTable(headers, rows)
+    }
+  },
+})

--- a/src/commands/exit-codes.ts
+++ b/src/commands/exit-codes.ts
@@ -11,14 +11,15 @@ import { writeJson } from "@/presenter/json"
 import { writePlainTable, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
+/** exitCodesCommand は終了コード一覧を出力するコマンド定義を返す。 */
 export const exitCodesCommand = defineCommand({
   meta: { name: "exit-codes", description: "終了コード一覧を出力する" },
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs
-    const startTime = Date.now()
 
     if (a.json) {
+      const startTime = Date.now()
       writeJson([...EXIT_CODES], { command: "exit-codes", startTime }, buildJsonOpts(a))
       return
     }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -5,7 +5,7 @@
  * エージェントがコマンドを動的に探索・実行する際に使用する。
  */
 
-import { type CommonArgs, buildJsonOpts, commonArgs } from "@/commands/_shared"
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
 import { getRootCommand } from "@/core/cli-root"
 import { EXIT_NOT_FOUND } from "@/core/exit-codes"
 import { buildSchema, findCommandByPath } from "@/core/schema"
@@ -18,6 +18,7 @@ export const schemaCommand = defineCommand({
   args: { ...commonArgs },
   async run({ args }) {
     const a = args as CommonArgs & { _?: string[] }
+    checkSandbox("schema", a)
     // citty は positional を args 定義に書かなければ _ に残す
     const path = (a._ ?? []) as string[]
 
@@ -34,7 +35,7 @@ export const schemaCommand = defineCommand({
       const cmdPath = path.join(" ")
       writeErrorJson(
         "UNKNOWN_COMMAND",
-        `unknown command: ${cmdPath}`,
+        `不明なコマンドです: ${cmdPath}`,
         "cos schema | jq '.subCommands[].name' で利用可能なコマンドを確認できます",
       )
       process.exit(EXIT_NOT_FOUND)

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -12,6 +12,7 @@ import { buildSchema, findCommandByPath } from "@/core/schema"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
+/** schemaCommand はコマンド/フラグのスキーマを JSON で出力するコマンド定義を返す。 */
 export const schemaCommand = defineCommand({
   meta: { name: "schema", description: "コマンド/フラグのスキーマを JSON で出力する" },
   args: { ...commonArgs },
@@ -19,7 +20,6 @@ export const schemaCommand = defineCommand({
     const a = args as CommonArgs & { _?: string[] }
     // citty は positional を args 定義に書かなければ _ に残す
     const path = (a._ ?? []) as string[]
-    const startTime = Date.now()
 
     const rootCmd = getRootCommand()
     const schema =
@@ -27,7 +27,10 @@ export const schemaCommand = defineCommand({
         ? await buildSchema(rootCmd, "cos")
         : await findCommandByPath(rootCmd, "cos", path)
 
-    if (!schema) {
+    if (schema) {
+      const startTime = Date.now()
+      writeJson(schema, { command: "schema", startTime }, buildJsonOpts(a))
+    } else {
       const cmdPath = path.join(" ")
       writeErrorJson(
         "UNKNOWN_COMMAND",
@@ -35,9 +38,6 @@ export const schemaCommand = defineCommand({
         "cos schema | jq '.subCommands[].name' で利用可能なコマンドを確認できます",
       )
       process.exit(EXIT_NOT_FOUND)
-      return
     }
-
-    writeJson(schema, { command: "schema", startTime }, buildJsonOpts(a))
   },
 })

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,0 +1,43 @@
+/**
+ * schema.ts — `cos schema` コマンド定義。
+ *
+ * コマンドツリー全体またはパス指定のコマンドのスキーマを JSON で出力する。
+ * エージェントがコマンドを動的に探索・実行する際に使用する。
+ */
+
+import { type CommonArgs, buildJsonOpts, commonArgs } from "@/commands/_shared"
+import { getRootCommand } from "@/core/cli-root"
+import { EXIT_NOT_FOUND } from "@/core/exit-codes"
+import { buildSchema, findCommandByPath } from "@/core/schema"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const schemaCommand = defineCommand({
+  meta: { name: "schema", description: "コマンド/フラグのスキーマを JSON で出力する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs & { _?: string[] }
+    // citty は positional を args 定義に書かなければ _ に残す
+    const path = (a._ ?? []) as string[]
+    const startTime = Date.now()
+
+    const rootCmd = getRootCommand()
+    const schema =
+      path.length === 0
+        ? await buildSchema(rootCmd, "cos")
+        : await findCommandByPath(rootCmd, "cos", path)
+
+    if (!schema) {
+      const cmdPath = path.join(" ")
+      writeErrorJson(
+        "UNKNOWN_COMMAND",
+        `unknown command: ${cmdPath}`,
+        "cos schema | jq '.subCommands[].name' で利用可能なコマンドを確認できます",
+      )
+      process.exit(EXIT_NOT_FOUND)
+      return
+    }
+
+    writeJson(schema, { command: "schema", startTime }, buildJsonOpts(a))
+  },
+})

--- a/src/core/cli-root.ts
+++ b/src/core/cli-root.ts
@@ -13,8 +13,16 @@ let _rootCommand: CommandDef | null = null
 /**
  * setRootCommand はルートコマンドを登録する。
  * cli.ts の runMain 呼び出し前に呼ぶこと。
+ *
+ * @param cmd - 登録するルートコマンド
+ * @param force - true の場合は既存のルートコマンドを上書きする（テスト用）
  */
-export function setRootCommand(cmd: CommandDef): void {
+export function setRootCommand(cmd: CommandDef, force = false): void {
+  if (_rootCommand && !force) {
+    throw new Error(
+      "ルートコマンドは既に登録済みです。上書きする場合は force=true を指定してください。",
+    )
+  }
   _rootCommand = cmd
 }
 

--- a/src/core/cli-root.ts
+++ b/src/core/cli-root.ts
@@ -1,0 +1,30 @@
+/**
+ * cli-root.ts — CLI ルートコマンド定義の singleton レジストリ。
+ *
+ * cli.ts の循環依存を避けるため、ルートコマンド参照を singleton として管理する。
+ * cli.ts が main を組み立てた後に setRootCommand() を呼び出す。
+ * schema コマンドは getRootCommand() でルートを取得する。
+ */
+
+import type { CommandDef } from "citty"
+
+let _rootCommand: CommandDef | null = null
+
+/**
+ * setRootCommand はルートコマンドを登録する。
+ * cli.ts の runMain 呼び出し前に呼ぶこと。
+ */
+export function setRootCommand(cmd: CommandDef): void {
+  _rootCommand = cmd
+}
+
+/**
+ * getRootCommand はルートコマンドを返す。
+ * setRootCommand() が未呼び出しの場合は Error を throw する。
+ */
+export function getRootCommand(): CommandDef {
+  if (!_rootCommand) {
+    throw new Error("ルートコマンドが未初期化です。setRootCommand() を先に呼んでください。")
+  }
+  return _rootCommand
+}

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -29,12 +29,21 @@ export const EXIT_CODES: readonly ExitCodeEntry[] = [
   { code: 124, name: "timeout", description: "タイムアウト" },
 ] as const
 
+/** EXIT_SUCCESS は成功を表す終了コード。 */
 export const EXIT_SUCCESS = 0
+/** EXIT_ERROR は一般エラーを表す終了コード。 */
 export const EXIT_ERROR = 1
+/** EXIT_UNAUTHORIZED は認証エラー (401) を表す終了コード。 */
 export const EXIT_UNAUTHORIZED = 2
+/** EXIT_FORBIDDEN は権限エラー (403) を表す終了コード。 */
 export const EXIT_FORBIDDEN = 3
+/** EXIT_NOT_FOUND はリソースが見つからない (404) を表す終了コード。 */
 export const EXIT_NOT_FOUND = 4
+/** EXIT_VALIDATION_ERROR はバリデーションエラーを表す終了コード。 */
 export const EXIT_VALIDATION_ERROR = 5
+/** EXIT_CONFLICT は楽観ロック競合を表す終了コード。 */
 export const EXIT_CONFLICT = 6
+/** EXIT_POLICY_DENIED は sandbox ポリシー違反を表す終了コード。 */
 export const EXIT_POLICY_DENIED = 7
+/** EXIT_TIMEOUT はタイムアウトを表す終了コード。 */
 export const EXIT_TIMEOUT = 124

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -1,0 +1,40 @@
+/**
+ * exit-codes.ts — 終了コードの単一ソース。
+ *
+ * EXIT_CODES 配列はエージェント向け `cos exit-codes` コマンドの出力源であり、
+ * EXIT_* 個別定数は新規コマンドで process.exit() を呼ぶ際に使用する。
+ * 既存コードのハードコード置換は別 PR (chore) で対応する。
+ */
+
+/** ExitCodeEntry は終了コード 1 エントリの型定義。 */
+export interface ExitCodeEntry {
+  /** 終了コード番号 */
+  code: number
+  /** 機械可読な名前 (snake_case) */
+  name: string
+  /** 人間向けの日本語説明 */
+  description: string
+}
+
+/** EXIT_CODES は終了コード一覧。`cos exit-codes` コマンドの出力源。 */
+export const EXIT_CODES: readonly ExitCodeEntry[] = [
+  { code: 0, name: "success", description: "成功" },
+  { code: 1, name: "error", description: "一般エラー" },
+  { code: 2, name: "unauthorized", description: "認証エラー (401)" },
+  { code: 3, name: "forbidden", description: "権限エラー (403)" },
+  { code: 4, name: "not_found", description: "リソースが見つからない (404)" },
+  { code: 5, name: "validation_error", description: "バリデーションエラー" },
+  { code: 6, name: "conflict", description: "楽観ロック競合" },
+  { code: 7, name: "policy_denied", description: "sandbox ポリシー違反" },
+  { code: 124, name: "timeout", description: "タイムアウト" },
+] as const
+
+export const EXIT_SUCCESS = 0
+export const EXIT_ERROR = 1
+export const EXIT_UNAUTHORIZED = 2
+export const EXIT_FORBIDDEN = 3
+export const EXIT_NOT_FOUND = 4
+export const EXIT_VALIDATION_ERROR = 5
+export const EXIT_CONFLICT = 6
+export const EXIT_POLICY_DENIED = 7
+export const EXIT_TIMEOUT = 124

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,0 +1,178 @@
+/**
+ * schema.ts — citty CommandDef を再帰走査して JSON 互換スキーマを構築する純関数。
+ *
+ * エージェント向け `cos schema` コマンドの出力源。
+ * Resolvable<T> の解決と alias グルーピングに src/infra/help.ts のユーティリティを使用する。
+ */
+
+import { groupSubCommandsByAlias, resolveValue } from "@/infra/help"
+import type { ArgsDef, CommandDef, Resolvable } from "citty"
+
+/** SchemaArg はコマンドフラグ 1 個のスキーマ表現。 */
+export interface SchemaArg {
+  /** フラグ名 */
+  name: string
+  /** フラグ型 */
+  type: "string" | "boolean" | "positional"
+  /** フラグ説明 */
+  description?: string
+  /** alias リスト（string | string[] を string[] に正規化済み） */
+  alias: string[]
+  /** デフォルト値 */
+  default?: string | boolean
+  /** 必須フラグかどうか */
+  required?: boolean
+  /** 値のヒント文字列 */
+  valueHint?: string
+}
+
+/** SchemaCommand はコマンド 1 つのスキーマ表現。 */
+export interface SchemaCommand {
+  /** コマンド名（canonical） */
+  name: string
+  /** alias キーのリスト（canonical を除く同一参照キー） */
+  aliases: string[]
+  /** コマンド説明 */
+  description?: string
+  /** フラグ一覧 */
+  args: SchemaArg[]
+  /** サブコマンド一覧 */
+  subCommands: SchemaCommand[]
+}
+
+/**
+ * normalizeAlias は citty の alias フィールド（string | string[] | undefined）を
+ * string[] に正規化する。
+ */
+function normalizeAlias(alias: string | string[] | undefined): string[] {
+  if (!alias) return []
+  return typeof alias === "string" ? [alias] : alias
+}
+
+/**
+ * buildArgsSchema は CommandDef の args を SchemaArg[] に変換する。
+ */
+async function buildArgsSchema(cmd: CommandDef): Promise<SchemaArg[]> {
+  if (!cmd.args) return []
+  const args = await resolveValue(cmd.args as Resolvable<ArgsDef>)
+  if (!args) return []
+
+  return Promise.all(
+    Object.entries(args).map(async ([name, def]) => {
+      const resolved = await resolveValue(
+        def as Resolvable<{
+          type?: string
+          description?: string
+          alias?: string | string[]
+          default?: string | boolean
+          required?: boolean
+          valueHint?: string
+        }>,
+      )
+      const schemaArg: SchemaArg = {
+        name,
+        type: (resolved?.type ?? "string") as SchemaArg["type"],
+        alias: normalizeAlias(resolved?.alias),
+      }
+      if (resolved?.description !== undefined) schemaArg.description = resolved.description
+      if (resolved?.default !== undefined) schemaArg.default = resolved.default
+      if (resolved?.required !== undefined) schemaArg.required = resolved.required
+      if (resolved?.valueHint !== undefined) schemaArg.valueHint = resolved.valueHint
+      return schemaArg
+    }),
+  )
+}
+
+/**
+ * buildSchema は CommandDef を再帰走査して SchemaCommand を返す。
+ *
+ * @param cmd - 走査対象の CommandDef
+ * @param rootName - コマンド名（meta.name が未設定の場合のフォールバック）
+ * @param aliases - このコマンドが持つ alias キー一覧
+ */
+export async function buildSchema(
+  cmd: CommandDef,
+  rootName: string,
+  aliases: string[] = [],
+): Promise<SchemaCommand> {
+  const meta = cmd.meta
+    ? await resolveValue(cmd.meta as Resolvable<{ name?: string; description?: string }>)
+    : null
+  const name = meta?.name ?? rootName
+  const argsSchema = await buildArgsSchema(cmd)
+
+  const subCommandSchemas: SchemaCommand[] = []
+  if (cmd.subCommands) {
+    const subs = await resolveValue(cmd.subCommands)
+    if (subs && Object.keys(subs).length > 0) {
+      // 同一参照を canonical + aliases にまとめる
+      const grouped = await groupSubCommandsByAlias(subs)
+      for (const [groupKey, subCmd] of Object.entries(grouped)) {
+        const resolved = await resolveValue(subCmd)
+        // groupKey は "canonical (alias1, alias2)" 形式なので canonical と alias を分離する
+        const parenIdx = groupKey.indexOf(" (")
+        const canonicalKey = parenIdx >= 0 ? groupKey.slice(0, parenIdx) : groupKey
+        const aliasKeys =
+          parenIdx >= 0
+            ? groupKey
+                .slice(parenIdx + 2, -1)
+                .split(", ")
+                .filter(Boolean)
+            : []
+        const subSchema = await buildSchema(resolved, canonicalKey, aliasKeys)
+        subCommandSchemas.push(subSchema)
+      }
+    }
+  }
+
+  const schema: SchemaCommand = {
+    name,
+    aliases,
+    args: argsSchema,
+    subCommands: subCommandSchemas,
+  }
+  if (meta?.description !== undefined) schema.description = meta.description
+  return schema
+}
+
+/**
+ * findCommandByPath は path に従って CommandDef ツリーを下降し、
+ * 対象コマンドの SchemaCommand を返す。
+ *
+ * @param rootCmd - ルートの CommandDef
+ * @param rootName - ルートのコマンド名
+ * @param path - コマンドパス（例: ["page", "list"]）
+ * @returns 見つかった SchemaCommand、または未知パスの場合 null
+ */
+export async function findCommandByPath(
+  rootCmd: CommandDef,
+  rootName: string,
+  path: string[],
+): Promise<SchemaCommand | null> {
+  if (path.length === 0) {
+    return buildSchema(rootCmd, rootName)
+  }
+
+  let currentCmd: CommandDef = rootCmd
+  let currentName = rootName
+  const resolvedPath: string[] = []
+
+  for (const segment of path) {
+    if (!currentCmd.subCommands) return null
+    const subs = await resolveValue(currentCmd.subCommands)
+    if (!subs) return null
+
+    const subCmd = subs[segment]
+    if (!subCmd) return null
+
+    currentCmd = await resolveValue(subCmd)
+    // canonical 名は meta.name を優先
+    const meta = currentCmd.meta
+      ? await resolveValue(currentCmd.meta as Resolvable<{ name?: string }>)
+      : null
+    currentName = meta?.name ?? segment
+    resolvedPath.push(segment)
+  }
+
+  return buildSchema(currentCmd, currentName)
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -49,6 +49,32 @@ function normalizeAlias(alias: string | string[] | undefined): string[] {
   return typeof alias === "string" ? [alias] : alias
 }
 
+/** parseGroupKey の返り値 */
+interface ParsedGroupKey {
+  canonicalKey: string
+  aliasKeys: string[]
+}
+
+/**
+ * parseGroupKey は groupSubCommandsByAlias が返す
+ * "canonical (alias1, alias2)" 形式のキーを canonical と alias リストに分離する。
+ *
+ * groupKey のフォーマット変更に対して堅牢になるよう正規表現で検証する。
+ * 不正なフォーマットの場合は aliasKeys を空配列として安全にフォールバックする。
+ */
+function parseGroupKey(groupKey: string): ParsedGroupKey {
+  const match = /^(.+?) \((.+)\)$/.exec(groupKey)
+  if (!match) {
+    return { canonicalKey: groupKey, aliasKeys: [] }
+  }
+  const canonicalKey = match[1] ?? groupKey
+  const aliasKeys = (match[2] ?? "")
+    .split(", ")
+    .map((k) => k.trim())
+    .filter(Boolean)
+  return { canonicalKey, aliasKeys }
+}
+
 /**
  * buildArgsSchema は CommandDef の args を SchemaArg[] に変換する。
  */
@@ -109,16 +135,8 @@ export async function buildSchema(
       const grouped = await groupSubCommandsByAlias(subs)
       for (const [groupKey, subCmd] of Object.entries(grouped)) {
         const resolved = await resolveValue(subCmd)
-        // groupKey は "canonical (alias1, alias2)" 形式なので canonical と alias を分離する
-        const parenIdx = groupKey.indexOf(" (")
-        const canonicalKey = parenIdx >= 0 ? groupKey.slice(0, parenIdx) : groupKey
-        const aliasKeys =
-          parenIdx >= 0
-            ? groupKey
-                .slice(parenIdx + 2, -1)
-                .split(", ")
-                .filter(Boolean)
-            : []
+        // groupKey は groupSubCommandsByAlias が生成する "canonical (alias1, alias2)" 形式
+        const { canonicalKey, aliasKeys } = parseGroupKey(groupKey)
         const subSchema = await buildSchema(resolved, canonicalKey, aliasKeys)
         subCommandSchemas.push(subSchema)
       }

--- a/src/infra/help.ts
+++ b/src/infra/help.ts
@@ -28,7 +28,7 @@ export type ResolvedCommand = {
  * resolveValue は Resolvable<T> を解決する。
  * citty の Resolvable<T> = T | Promise<T> | (() => T) | (() => Promise<T>) に対応する。
  */
-async function resolveValue<T>(value: Resolvable<T>): Promise<T> {
+export async function resolveValue<T>(value: Resolvable<T>): Promise<T> {
   if (typeof value === "function") {
     return (value as (() => T) | (() => Promise<T>))()
   }
@@ -147,7 +147,7 @@ function ensureMetaName(cmd: CommandDef, name: string): CommandDef {
  * 元の subCommands は変更しない。並び順は canonical キーの初出位置を保持する。
  * alias を持たない場合は元のキーをそのまま使用する。
  */
-async function groupSubCommandsByAlias(
+export async function groupSubCommandsByAlias(
   subCommands: SubCommandsDef,
 ): Promise<Record<string, Resolvable<CommandDef>>> {
   // 同一参照ごとにキーをまとめる: Map<CommandDef オブジェクト, キー名リスト>

--- a/src/infra/help.ts
+++ b/src/infra/help.ts
@@ -25,7 +25,7 @@ export type ResolvedCommand = {
 }
 
 /**
- * resolveValue は Resolvable<T> を解決する。
+ * resolveValue は Resolvable<T> を解決した値を返す。
  * citty の Resolvable<T> = T | Promise<T> | (() => T) | (() => Promise<T>) に対応する。
  */
 export async function resolveValue<T>(value: Resolvable<T>): Promise<T> {

--- a/tests/unit/commands/exit-codes.test.ts
+++ b/tests/unit/commands/exit-codes.test.ts
@@ -1,0 +1,171 @@
+/**
+ * exit-codes.test.ts — `cos exit-codes` コマンドのテスト。
+ *
+ * JSON / plain / --results-only / --select の出力形式と終了コード 0 を検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { exitCodesCommand } from "@/commands/exit-codes"
+import { EXIT_CODES } from "@/core/exit-codes"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** テスト用の共通引数ヘルパー */
+function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    profile: undefined,
+    project: undefined,
+    ...overrides,
+  }
+}
+
+async function runExitCodes(args: Record<string, unknown>): Promise<void> {
+  await (
+    exitCodesCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** stdout に書き出された文字列を結合して返す */
+function captureStdout(): string {
+  return (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("exitCodesCommand", () => {
+  describe("--json オプション", () => {
+    it("envelope 形式で終了コード配列を出力する", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed).toHaveProperty("data")
+      expect(Array.isArray(parsed.data)).toBe(true)
+    })
+
+    it("配列の長さが EXIT_CODES.length と一致する", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.data).toHaveLength(EXIT_CODES.length)
+    })
+
+    it("code: 124 (timeout) が含まれる", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      const codes: number[] = parsed.data.map((e: { code: number }) => e.code)
+      expect(codes).toContain(124)
+    })
+
+    it("各エントリに code / name / description が含まれる", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      for (const entry of parsed.data) {
+        expect(typeof entry.code).toBe("number")
+        expect(typeof entry.name).toBe("string")
+        expect(typeof entry.description).toBe("string")
+      }
+    })
+
+    it("meta フィールドに command: 'exit-codes' が含まれる", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.meta?.command).toBe("exit-codes")
+    })
+  })
+
+  describe("--json --results-only オプション", () => {
+    it("envelope なしで配列を直接出力する", async () => {
+      await runExitCodes(makeArgs({ json: true, "results-only": true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      // envelope 形式の場合は data プロパティがある、配列直接の場合はない
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed).toHaveLength(EXIT_CODES.length)
+    })
+  })
+
+  describe("--json --select オプション", () => {
+    it("'[].code' で code 配列のみ出力する", async () => {
+      await runExitCodes(makeArgs({ json: true, select: "[].code" }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed).toContain(0)
+      expect(parsed).toContain(124)
+      // オブジェクトでなく数値のみ
+      for (const item of parsed) {
+        expect(typeof item).toBe("number")
+      }
+    })
+  })
+
+  describe("デフォルト出力（テーブル形式）", () => {
+    it("code / name / description のヘッダを含む", async () => {
+      await runExitCodes(makeArgs())
+      const out = captureStdout()
+      expect(out).toContain("code")
+      expect(out).toContain("name")
+      expect(out).toContain("description")
+    })
+
+    it("終了コード 'success' の行を含む", async () => {
+      await runExitCodes(makeArgs())
+      const out = captureStdout()
+      expect(out).toContain("success")
+    })
+
+    it("timeout の行を含む", async () => {
+      await runExitCodes(makeArgs())
+      const out = captureStdout()
+      expect(out).toContain("timeout")
+    })
+  })
+
+  describe("--plain オプション", () => {
+    it("TSV 形式で出力する（ヘッダ行あり）", async () => {
+      await runExitCodes(makeArgs({ plain: true }))
+      const out = captureStdout()
+      // TSV はタブ区切り
+      expect(out).toContain("\t")
+      expect(out).toContain("code")
+    })
+  })
+
+  describe("正常終了", () => {
+    it("process.exit を呼ばず正常終了する", async () => {
+      await runExitCodes(makeArgs({ json: true }))
+      expect(exitMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/commands/schema.test.ts
+++ b/tests/unit/commands/schema.test.ts
@@ -101,7 +101,7 @@ async function runAndIgnoreExit(args: Record<string, unknown>): Promise<void> {
 }
 
 beforeEach(() => {
-  setRootCommand(testRoot)
+  setRootCommand(testRoot, true)
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
@@ -173,6 +173,15 @@ describe("schemaCommand", () => {
       const projectArg = schema.args.find((a: { name: string }) => a.name === "project")
       expect(projectArg).toBeDefined()
       expect(projectArg?.alias).toEqual(["p"])
+    })
+  })
+
+  describe("デフォルト出力（JSON なし）", () => {
+    it("JSON 指定なしでも UNKNOWN_COMMAND エラーを文字列で出力する（未知パス）", async () => {
+      await runAndIgnoreExit(makeArgs({ json: false, _: ["page", "unknown"] }))
+      const out = captureStdout()
+      // JSON 形式のエラー出力になる（writeErrorJson は常に JSON を使う）
+      expect(out).toContain("UNKNOWN_COMMAND")
     })
   })
 

--- a/tests/unit/commands/schema.test.ts
+++ b/tests/unit/commands/schema.test.ts
@@ -1,0 +1,196 @@
+/**
+ * schema.test.ts — `cos schema` コマンドのテスト。
+ *
+ * JSON 出力・パス指定・alias グルーピング・未知コマンドのエラーを検証する。
+ * ルートコマンドは cli-root singleton にテスト用のダミーを注入して使用する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { schemaCommand } from "@/commands/schema"
+import { setRootCommand } from "@/core/cli-root"
+import type { CommandDef } from "citty"
+
+/** テスト用の list コマンド（list / ls で alias 共有） */
+const testListCommand: CommandDef = {
+  meta: { name: "list", description: "ページ一覧を取得する" },
+  args: {
+    project: { type: "string", description: "プロジェクト名", alias: "p" },
+    json: { type: "boolean", alias: ["J"], default: false },
+  },
+}
+
+/** テスト用の auth コマンドグループ */
+const testAuthCommand: CommandDef = {
+  meta: { name: "auth", description: "認証コマンド" },
+  args: {},
+  subCommands: {
+    login: { meta: { name: "login", description: "ログインする" }, args: {} },
+  },
+}
+
+/** テスト用のページコマンドグループ */
+const testPageCommand: CommandDef = {
+  meta: { name: "page", description: "ページ操作コマンド" },
+  args: {},
+  subCommands: {
+    list: testListCommand,
+    ls: testListCommand, // alias
+  },
+}
+
+/** テスト用のルートコマンド */
+const testRoot: CommandDef = {
+  meta: { name: "cos", version: "test", description: "テスト用ルートコマンド" },
+  args: {
+    color: { type: "string", default: "auto" },
+  },
+  subCommands: {
+    page: testPageCommand,
+    auth: testAuthCommand,
+  },
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+/** テスト用の共通引数ヘルパー */
+function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _: [],
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "dry-run": false,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    profile: undefined,
+    project: undefined,
+    ...overrides,
+  }
+}
+
+async function runSchema(args: Record<string, unknown>): Promise<void> {
+  await (
+    schemaCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** stdout に書き出された文字列を結合して返す */
+function captureStdout(): string {
+  return (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+}
+
+/** process.exit モック後の継続 throw を握り潰してコマンドを実行する */
+async function runAndIgnoreExit(args: Record<string, unknown>): Promise<void> {
+  try {
+    await runSchema(args)
+  } catch {
+    // process.exit モック後の継続による throw は想定内
+  }
+}
+
+beforeEach(() => {
+  setRootCommand(testRoot)
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("schemaCommand", () => {
+  describe("全体スキーマ出力（パス指定なし）", () => {
+    it("JSON 出力でルートの name が 'cos' である", async () => {
+      await runSchema(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.data?.name ?? parsed.name).toBe("cos")
+    })
+
+    it("subCommands に page / auth が含まれる", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      const names = schema.subCommands.map((c: { name: string }) => c.name)
+      expect(names).toContain("page")
+      expect(names).toContain("auth")
+    })
+
+    it("list コマンドが aliases: ['ls'] を持つ", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      const pageCmd = schema.subCommands.find((c: { name: string }) => c.name === "page")
+      const listCmd = pageCmd?.subCommands.find((c: { name: string }) => c.name === "list")
+      expect(listCmd?.aliases).toContain("ls")
+    })
+
+    it("--results-only で envelope なし配列（オブジェクト）を直接出力する", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      // envelope なしの場合は data プロパティがなく name プロパティがある
+      expect(schema).toHaveProperty("name")
+      expect(schema).not.toHaveProperty("data")
+    })
+  })
+
+  describe("パス指定（個別コマンド）", () => {
+    it("['page'] で page グループのスキーマを返す", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true, _: ["page"] }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      expect(schema.name).toBe("page")
+    })
+
+    it("['page', 'list'] で list コマンドのスキーマを返す", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true, _: ["page", "list"] }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      expect(schema.name).toBe("list")
+      expect(schema.description).toBe("ページ一覧を取得する")
+    })
+
+    it("list スキーマに project フラグが含まれる", async () => {
+      await runSchema(makeArgs({ json: true, "results-only": true, _: ["page", "list"] }))
+      const out = captureStdout()
+      const schema = JSON.parse(out)
+      const projectArg = schema.args.find((a: { name: string }) => a.name === "project")
+      expect(projectArg).toBeDefined()
+      expect(projectArg?.alias).toEqual(["p"])
+    })
+  })
+
+  describe("未知コマンドのエラー処理", () => {
+    it("未知コマンドパスで exit 4 を呼ぶ", async () => {
+      await runAndIgnoreExit(makeArgs({ json: true, _: ["page", "unknown"] }))
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("未知コマンドパスで UNKNOWN_COMMAND エラーを出力する", async () => {
+      await runAndIgnoreExit(makeArgs({ json: true, _: ["page", "unknown"] }))
+      const out = captureStdout()
+      expect(out).toContain("UNKNOWN_COMMAND")
+    })
+
+    it("存在しないグループパスで exit 4 を呼ぶ", async () => {
+      await runAndIgnoreExit(makeArgs({ json: true, _: ["nonexistent"] }))
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+  })
+})

--- a/tests/unit/core/exit-codes.test.ts
+++ b/tests/unit/core/exit-codes.test.ts
@@ -21,22 +21,13 @@ import {
 describe("EXIT_CODES 配列", () => {
   it("必須の終了コードをすべて含む", () => {
     const codes = EXIT_CODES.map((e) => e.code)
-    expect(codes).toContain(0)
-    expect(codes).toContain(1)
-    expect(codes).toContain(2)
-    expect(codes).toContain(3)
-    expect(codes).toContain(4)
-    expect(codes).toContain(5)
-    expect(codes).toContain(6)
-    expect(codes).toContain(7)
-    expect(codes).toContain(124)
+    expect(codes).toEqual(expect.arrayContaining([0, 1, 2, 3, 4, 5, 6, 7, 124]))
   })
 
   it("code 昇順で並んでいる", () => {
     const codes = EXIT_CODES.map((e) => e.code)
-    for (let i = 1; i < codes.length; i++) {
-      expect(codes[i]).toBeGreaterThan(codes[i - 1] as number)
-    }
+    const sorted = [...codes].sort((a, b) => a - b)
+    expect(codes).toEqual(sorted)
   })
 
   it("code が一意である", () => {

--- a/tests/unit/core/exit-codes.test.ts
+++ b/tests/unit/core/exit-codes.test.ts
@@ -1,0 +1,117 @@
+/**
+ * exit-codes.test.ts — 終了コード定義の構造テスト。
+ *
+ * EXIT_CODES 配列と EXIT_* 個別定数の正確性・一意性・順序を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  EXIT_CODES,
+  EXIT_CONFLICT,
+  EXIT_ERROR,
+  EXIT_FORBIDDEN,
+  EXIT_NOT_FOUND,
+  EXIT_POLICY_DENIED,
+  EXIT_SUCCESS,
+  EXIT_TIMEOUT,
+  EXIT_UNAUTHORIZED,
+  EXIT_VALIDATION_ERROR,
+} from "@/core/exit-codes"
+
+describe("EXIT_CODES 配列", () => {
+  it("必須の終了コードをすべて含む", () => {
+    const codes = EXIT_CODES.map((e) => e.code)
+    expect(codes).toContain(0)
+    expect(codes).toContain(1)
+    expect(codes).toContain(2)
+    expect(codes).toContain(3)
+    expect(codes).toContain(4)
+    expect(codes).toContain(5)
+    expect(codes).toContain(6)
+    expect(codes).toContain(7)
+    expect(codes).toContain(124)
+  })
+
+  it("code 昇順で並んでいる", () => {
+    const codes = EXIT_CODES.map((e) => e.code)
+    for (let i = 1; i < codes.length; i++) {
+      expect(codes[i]).toBeGreaterThan(codes[i - 1] as number)
+    }
+  })
+
+  it("code が一意である", () => {
+    const codes = EXIT_CODES.map((e) => e.code)
+    const unique = new Set(codes)
+    expect(unique.size).toBe(codes.length)
+  })
+
+  it("name が一意である", () => {
+    const names = EXIT_CODES.map((e) => e.name)
+    const unique = new Set(names)
+    expect(unique.size).toBe(names.length)
+  })
+
+  it("name が snake_case である", () => {
+    const snakeCasePattern = /^[a-z][a-z0-9_]*$/
+    for (const entry of EXIT_CODES) {
+      expect(entry.name).toMatch(snakeCasePattern)
+    }
+  })
+
+  it("description が空でない", () => {
+    for (const entry of EXIT_CODES) {
+      expect(entry.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("EXIT_* 個別定数", () => {
+  it("EXIT_SUCCESS は 0 である", () => {
+    expect(EXIT_SUCCESS).toBe(0)
+  })
+
+  it("EXIT_ERROR は 1 である", () => {
+    expect(EXIT_ERROR).toBe(1)
+  })
+
+  it("EXIT_UNAUTHORIZED は 2 である", () => {
+    expect(EXIT_UNAUTHORIZED).toBe(2)
+  })
+
+  it("EXIT_FORBIDDEN は 3 である", () => {
+    expect(EXIT_FORBIDDEN).toBe(3)
+  })
+
+  it("EXIT_NOT_FOUND は 4 である", () => {
+    expect(EXIT_NOT_FOUND).toBe(4)
+  })
+
+  it("EXIT_VALIDATION_ERROR は 5 である", () => {
+    expect(EXIT_VALIDATION_ERROR).toBe(5)
+  })
+
+  it("EXIT_CONFLICT は 6 である", () => {
+    expect(EXIT_CONFLICT).toBe(6)
+  })
+
+  it("EXIT_POLICY_DENIED は 7 である", () => {
+    expect(EXIT_POLICY_DENIED).toBe(7)
+  })
+
+  it("EXIT_TIMEOUT は 124 である", () => {
+    expect(EXIT_TIMEOUT).toBe(124)
+  })
+
+  it("各定数が EXIT_CODES 配列の code と一致する", () => {
+    const codeMap = new Map(EXIT_CODES.map((e) => [e.code, e.name]))
+    expect(codeMap.get(EXIT_SUCCESS)).toBe("success")
+    expect(codeMap.get(EXIT_ERROR)).toBe("error")
+    expect(codeMap.get(EXIT_UNAUTHORIZED)).toBe("unauthorized")
+    expect(codeMap.get(EXIT_FORBIDDEN)).toBe("forbidden")
+    expect(codeMap.get(EXIT_NOT_FOUND)).toBe("not_found")
+    expect(codeMap.get(EXIT_VALIDATION_ERROR)).toBe("validation_error")
+    expect(codeMap.get(EXIT_CONFLICT)).toBe("conflict")
+    expect(codeMap.get(EXIT_POLICY_DENIED)).toBe("policy_denied")
+    expect(codeMap.get(EXIT_TIMEOUT)).toBe("timeout")
+  })
+})

--- a/tests/unit/core/schema.test.ts
+++ b/tests/unit/core/schema.test.ts
@@ -1,0 +1,180 @@
+/**
+ * schema.test.ts — citty CommandDef の再帰 JSON 化ロジックのテスト。
+ *
+ * 小さなダミー CommandDef を入力として buildSchema / findCommandByPath の
+ * 出力構造・alias グルーピング・Resolvable 解決を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { buildSchema, findCommandByPath } from "@/core/schema"
+import type { CommandDef } from "citty"
+
+/** テスト用のリーフコマンド定義（list / ls で同一参照） */
+const listCommand: CommandDef = {
+  meta: { name: "list", description: "一覧を取得する" },
+  args: {
+    project: { type: "string", description: "プロジェクト名", alias: "p", required: false },
+    json: { type: "boolean", description: "JSON 出力", alias: ["J"], default: false },
+    limit: { type: "string", description: "取得件数" },
+  },
+}
+
+/** テスト用のグループコマンド定義 */
+const pageGroup: CommandDef = {
+  meta: { name: "page", description: "ページ操作" },
+  args: {},
+  subCommands: {
+    list: listCommand,
+    ls: listCommand, // 同一参照 → aliases にまとめる
+    new: {
+      meta: { name: "new", description: "ページを作成する" },
+      args: {
+        title: { type: "positional", description: "ページタイトル" },
+      },
+    },
+  },
+}
+
+/** ルートコマンド定義 */
+const rootCommand: CommandDef = {
+  meta: { name: "cos", description: "テスト用ルートコマンド" },
+  args: {
+    color: { type: "string", description: "カラー設定", default: "auto" },
+  },
+  subCommands: {
+    page: pageGroup,
+  },
+}
+
+describe("buildSchema", () => {
+  it("ルートの name と description を返す", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    expect(schema.name).toBe("cos")
+    expect(schema.description).toBe("テスト用ルートコマンド")
+  })
+
+  it("ルートの aliases は空配列", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    expect(schema.aliases).toEqual([])
+  })
+
+  it("ルートの args を返す", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const colorArg = schema.args.find((a) => a.name === "color")
+    expect(colorArg).toBeDefined()
+    expect(colorArg?.type).toBe("string")
+    expect(colorArg?.default).toBe("auto")
+    expect(colorArg?.alias).toEqual([])
+  })
+
+  it("サブコマンドを含む", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    expect(pageCmd).toBeDefined()
+  })
+
+  it("同一参照の list と ls が canonical=list + aliases=[ls] にまとまる", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const listCmd = pageCmd?.subCommands.find((c) => c.name === "list")
+    expect(listCmd).toBeDefined()
+    expect(listCmd?.aliases).toContain("ls")
+    // ls という name のコマンドは存在しない（canonical に統合済み）
+    const lsCmd = pageCmd?.subCommands.find((c) => c.name === "ls")
+    expect(lsCmd).toBeUndefined()
+  })
+
+  it("alias が string の場合に string[] に正規化される", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const listCmd = pageCmd?.subCommands.find((c) => c.name === "list")
+    const projectArg = listCmd?.args.find((a) => a.name === "project")
+    // alias: "p" → ["p"] に正規化
+    expect(projectArg?.alias).toEqual(["p"])
+  })
+
+  it("alias が string[] の場合にそのまま保持される", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const listCmd = pageCmd?.subCommands.find((c) => c.name === "list")
+    const jsonArg = listCmd?.args.find((a) => a.name === "json")
+    expect(jsonArg?.alias).toEqual(["J"])
+  })
+
+  it("alias 未定義の場合は空配列になる", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const listCmd = pageCmd?.subCommands.find((c) => c.name === "list")
+    const limitArg = listCmd?.args.find((a) => a.name === "limit")
+    expect(limitArg?.alias).toEqual([])
+  })
+
+  it("positional 型の args を正しく含む", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const newCmd = pageCmd?.subCommands.find((c) => c.name === "new")
+    const titleArg = newCmd?.args.find((a) => a.name === "title")
+    expect(titleArg?.type).toBe("positional")
+    expect(titleArg?.alias).toEqual([])
+  })
+
+  it("Resolvable<T> が関数の場合でも解決される", async () => {
+    const lazyCommand: CommandDef = {
+      meta: () => ({ name: "lazy", description: "遅延解決テスト" }),
+      args: () => ({
+        flag: { type: "boolean" },
+      }),
+    }
+    const schema = await buildSchema(lazyCommand, "lazy")
+    expect(schema.name).toBe("lazy")
+    expect(schema.args.find((a) => a.name === "flag")).toBeDefined()
+  })
+
+  it("Resolvable<T> が async 関数の場合でも解決される", async () => {
+    const asyncCommand: CommandDef = {
+      meta: async () => ({ name: "async-cmd", description: "非同期解決テスト" }),
+      args: async () => ({
+        value: { type: "string", description: "値" },
+      }),
+    }
+    const schema = await buildSchema(asyncCommand, "async-cmd")
+    expect(schema.name).toBe("async-cmd")
+    expect(schema.args.find((a) => a.name === "value")).toBeDefined()
+  })
+})
+
+describe("findCommandByPath", () => {
+  it("空パスはルートを返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", [])
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe("cos")
+  })
+
+  it("['page'] で page グループを返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", ["page"])
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe("page")
+  })
+
+  it("['page', 'list'] で list コマンドを返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", ["page", "list"])
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe("list")
+  })
+
+  it("alias パス ['page', 'ls'] でも list コマンドを返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", ["page", "ls"])
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe("list")
+  })
+
+  it("未知のコマンドパスは null を返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", ["page", "unknown"])
+    expect(result).toBeNull()
+  })
+
+  it("存在しないグループは null を返す", async () => {
+    const result = await findCommandByPath(rootCommand, "cos", ["project"])
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- `cos exit-codes` コマンドを追加: 終了コード一覧を JSON / テーブル形式で出力する
- `cos schema [<path>...]` コマンドを追加: コマンドツリー全体またはパス指定コマンドのフラグスキーマを JSON で出力する
- `src/core/exit-codes.ts` を終了コードの単一ソースとして新設（`EXIT_CODES` 配列 + `EXIT_*` 定数）
- 循環依存を回避する `src/core/cli-root.ts` singleton レジストリを追加
- `src/infra/help.ts` の `resolveValue` / `groupSubCommandsByAlias` を export 化

## 背景

coscli は「AI エージェント親和的 CLI」を標榜しているが、エージェントが自律的に CLI を使うための補助コマンドが不足していた。
エージェントがエラーハンドリングや動的コマンド探索を行うために必要なメタ情報を提供する。

## 実行例

```bash
cos exit-codes --json                      # 終了コード一覧 (JSON)
cos exit-codes --json --results-only       # 配列直接出力
cos exit-codes --json --select "[].code"   # code のみ抽出

cos schema --json --results-only           # コマンドツリー全体
cos schema page list --json --results-only # page list コマンドのスキーマ
```

## 注意事項

- 既存 `process.exit(N)` ハードコード約 50 箇所の `EXIT_*` 定数への置換は別 PR (chore) で対応する

## Test plan

- [ ] `bun test` — 638 件 all pass
- [ ] `bunx biome check src tests` — 警告ゼロ
- [ ] `bun run typecheck` — 型エラーゼロ
- [ ] `bun run build` — ビルド完了
- [ ] `./dist/cos-darwin-arm64 exit-codes --json` — 9 件の終了コード出力
- [ ] `./dist/cos-darwin-arm64 schema --json --results-only` — exit-codes / schema を含む subcommands 一覧

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `cos exit-codes` コマンドを追加 - アプリケーションの終了コードを JSON、テーブル、または TSV 形式で出力できます。
  * `cos schema` コマンドを追加 - コマンドおよびフラグスキーマを JSON 形式で出力できます。両コマンドは `--json`、`--plain`、`--results-only` などのフラグをサポートします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->