### PR TITLE
fix: 読み取り専用コマンドのヘルプから --dry-run を非表示にする (#25)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -25,9 +25,10 @@ function exitWithError(code: number, message: string): never {
 }
 
 /**
- * commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義 (読み取り系)。
+ * commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義。
  *
- * --dry-run は含まない。書き込みコマンドは `dryRunArg` を併用すること。
+ * --dry-run を除く読み書き共通フラグ。書き込みコマンドは `dryRunArg` を追加スプレッドして
+ * `WriteCommonArgs` として扱うこと。
  */
 export const commonArgs = {
   project: {
@@ -90,7 +91,7 @@ export const dryRunArg = {
   },
 } as const
 
-/** CommonArgs は読み取り系コマンドが受け取る共通フラグの型。 */
+/** CommonArgs は --dry-run を除く読み書き共通フラグの型。WriteCommonArgs の基底型。 */
 export type CommonArgs = {
   project?: string
   profile?: string

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -24,7 +24,11 @@ function exitWithError(code: number, message: string): never {
   throw new Error(message)
 }
 
-/** commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義。 */
+/**
+ * commonArgs はすべてのサブコマンドが受け取るルート共通フラグ定義 (読み取り系)。
+ *
+ * --dry-run は含まない。書き込みコマンドは `dryRunArg` を併用すること。
+ */
 export const commonArgs = {
   project: {
     type: "string" as const,
@@ -56,11 +60,6 @@ export const commonArgs = {
     type: "string" as const,
     description: "出力セレクタ (例: pages[].title)",
   },
-  "dry-run": {
-    type: "boolean" as const,
-    description: "書き込み計画のみ表示して実行しない",
-    default: false,
-  },
   "enable-commands": {
     type: "string" as const,
     description: "許可するコマンドリスト (カンマ区切り)",
@@ -82,7 +81,16 @@ export const commonArgs = {
   },
 } as const
 
-/** CommonArgs はコマンドが受け取る共通フラグの型。 */
+/** dryRunArg は書き込み系コマンドが追加スプレッドする --dry-run フラグ定義。 */
+export const dryRunArg = {
+  "dry-run": {
+    type: "boolean" as const,
+    description: "書き込み計画のみ表示して実行しない",
+    default: false,
+  },
+} as const
+
+/** CommonArgs は読み取り系コマンドが受け取る共通フラグの型。 */
 export type CommonArgs = {
   project?: string
   profile?: string
@@ -90,12 +98,17 @@ export type CommonArgs = {
   plain: boolean
   "results-only": boolean
   select?: string
-  "dry-run": boolean
   "enable-commands"?: string
   "disable-commands"?: string
   verbose?: string
   quiet: boolean
 }
+
+/** DryRunArg は書き込み系コマンドが追加で受け取る --dry-run フラグの型。 */
+export type DryRunArg = { "dry-run": boolean }
+
+/** WriteCommonArgs は書き込み系コマンドが受け取る共通フラグの型。 */
+export type WriteCommonArgs = CommonArgs & DryRunArg
 
 /** buildLogger はフラグからロガーを生成する。 */
 export function buildLogger(args: CommonArgs): Logger {
@@ -194,7 +207,7 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
 }
 
 /** buildWriter は ScrapboxWriter を生成する。 */
-export async function buildWriter(args: CommonArgs) {
+export async function buildWriter(args: WriteCommonArgs) {
   const sid = await requireSid(args.profile)
   return createScrapboxWriter({ sid, dryRun: args["dry-run"] })
 }

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -7,12 +7,13 @@
 
 import { readFileSync } from "node:fs"
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { appendToPage } from "@/core/pages"
@@ -23,6 +24,7 @@ export const pageAppendCommand = defineCommand({
   meta: { name: "append", description: "ページ末尾に行を追加する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -38,7 +40,7 @@ export const pageAppendCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; line?: string; "from-file"?: string }
+    const a = args as WriteCommonArgs & { title: string; line?: string; "from-file"?: string }
     checkSandbox("page.append", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -6,12 +6,13 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { deletePage } from "@/core/pages"
@@ -22,6 +23,7 @@ export const pageDeleteCommand = defineCommand({
   meta: { name: "delete", description: "ページを削除する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -40,7 +42,7 @@ export const pageDeleteCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; force: boolean; "no-input": boolean }
+    const a = args as WriteCommonArgs & { title: string; force: boolean; "no-input": boolean }
     checkSandbox("page.delete", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -9,12 +9,13 @@
 
 import { readFileSync } from "node:fs"
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { convert } from "@/core/format/index"
@@ -28,6 +29,7 @@ export const pageEditCommand = defineCommand({
   meta: { name: "edit", description: "ページ内容を全置換する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -45,7 +47,7 @@ export const pageEditCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & {
+    const a = args as WriteCommonArgs & {
       title: string
       "from-file": string
       "input-format": string

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -8,12 +8,13 @@
 
 import { readFileSync } from "node:fs"
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { insertIntoPage } from "@/core/pages"
@@ -24,6 +25,7 @@ export const pageInsertCommand = defineCommand({
   meta: { name: "insert", description: "指定行 (1-indexed) の後ろに行を挿入する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -44,7 +46,7 @@ export const pageInsertCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & {
+    const a = args as WriteCommonArgs & {
       title: string
       after: string
       line?: string

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -7,12 +7,13 @@
 
 import { readFileSync } from "node:fs"
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { createPage } from "@/core/pages"
@@ -23,6 +24,7 @@ export const pageNewCommand = defineCommand({
   meta: { name: "new", description: "新しいページを作成する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -38,7 +40,7 @@ export const pageNewCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; "from-file"?: string; line?: string }
+    const a = args as WriteCommonArgs & { title: string; "from-file"?: string; line?: string }
     checkSandbox("page.new", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/pin.ts
+++ b/src/commands/page/pin.ts
@@ -6,13 +6,14 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildRestClient,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { pinPage } from "@/core/pages"
@@ -23,6 +24,7 @@ export const pagePinCommand = defineCommand({
   meta: { name: "pin", description: "ページをピン留めする" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -35,7 +37,7 @@ export const pagePinCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; create: boolean }
+    const a = args as WriteCommonArgs & { title: string; create: boolean }
     checkSandbox("page.pin", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -7,12 +7,13 @@
 
 import { readFileSync } from "node:fs"
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { prependToPage } from "@/core/pages"
@@ -23,6 +24,7 @@ export const pagePrependCommand = defineCommand({
   meta: { name: "prepend", description: "ページ先頭 (タイトル直後) に行を挿入する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -38,7 +40,7 @@ export const pagePrependCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; line?: string; "from-file"?: string }
+    const a = args as WriteCommonArgs & { title: string; line?: string; "from-file"?: string }
     checkSandbox("page.prepend", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -9,13 +9,14 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildRestClient,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { renamePage } from "@/core/pages"
@@ -26,6 +27,7 @@ export const pageRenameCommand = defineCommand({
   meta: { name: "rename", description: "ページタイトルを変更する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "変更前のページタイトル",
@@ -43,7 +45,7 @@ export const pageRenameCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & {
+    const a = args as WriteCommonArgs & {
       title: string
       "new-title": string
       "force-fallback": boolean

--- a/src/commands/page/unpin.ts
+++ b/src/commands/page/unpin.ts
@@ -5,12 +5,13 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { unpinPage } from "@/core/pages"
@@ -21,6 +22,7 @@ export const pageUnpinCommand = defineCommand({
   meta: { name: "unpin", description: "ページのピン留めを解除する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -28,7 +30,7 @@ export const pageUnpinCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string }
+    const a = args as WriteCommonArgs & { title: string }
     checkSandbox("page.unpin", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/watch.ts
+++ b/src/commands/page/watch.ts
@@ -89,7 +89,7 @@ export function makePageWatchCommand(deps: WatchDeps = {}) {
       }
       const format = a.format as "" | "diff"
 
-      // 4. --timeout バリデーション
+      // 3. --timeout バリデーション
       const timeoutSec = Number(a.timeout)
       if (Number.isNaN(timeoutSec) || timeoutSec < 0) {
         writeErrorJson(
@@ -100,18 +100,18 @@ export function makePageWatchCommand(deps: WatchDeps = {}) {
         process.exit(5)
       }
 
-      // 5. プロジェクト解決
+      // 4. プロジェクト解決
       const project = requireProject(a)
 
-      // 6. sid 取得
+      // 5. sid 取得
       const getSidFn = deps.getSid ?? requireSid
       const sid = await getSidFn(a.profile)
 
-      // 7. REST クライアント生成 (deps 未指定時は認証済みクライアントを生成)
+      // 6. REST クライアント生成 (deps 未指定時は認証済みクライアントを生成)
       const restClient: WatchRestClient =
         deps.restClient !== undefined ? deps.restClient : await buildRestClient(a)
 
-      // 8. ページ・プロジェクト情報取得 (pageId・projectId を確定)
+      // 7. ページ・プロジェクト情報取得 (pageId・projectId を確定)
       let page: Page
       let proj: Project
       try {
@@ -131,7 +131,7 @@ export function makePageWatchCommand(deps: WatchDeps = {}) {
         throw err
       }
 
-      // 9. AbortController と SIGINT ハンドラを設定
+      // 8. AbortController と SIGINT ハンドラを設定
       const ac = new AbortController()
       let timedOut = false
 
@@ -148,7 +148,7 @@ export function makePageWatchCommand(deps: WatchDeps = {}) {
         }, timeoutSec * 1000)
       }
 
-      // 10. subscriber 生成と購読開始
+      // 9. subscriber 生成と購読開始
       const createSubscriberFn = deps.createSubscriber ?? createScrapboxSubscriber
       const subscriber = await createSubscriberFn()
 

--- a/src/commands/page/watch.ts
+++ b/src/commands/page/watch.ts
@@ -4,7 +4,6 @@
  * 指定したページの WebSocket room に join し、commit イベントをリアルタイムで受信する。
  * --json で JSON Lines (NDJSON)、--format=diff で簡易 unified diff 風出力、
  * Ctrl+C (SIGINT) で exit 0、--timeout 秒経過で exit 124。
- * --dry-run は非対応 (exit 5)。
  */
 
 import {
@@ -79,17 +78,7 @@ export function makePageWatchCommand(deps: WatchDeps = {}) {
       // 1. sandbox チェック
       checkSandbox("page.watch", a)
 
-      // 2. --dry-run 非対応
-      if (a["dry-run"]) {
-        writeErrorJson(
-          "VALIDATION_ERROR",
-          "page.watch は --dry-run に対応していません",
-          "--dry-run フラグを外してください",
-        )
-        process.exit(5)
-      }
-
-      // 3. --format バリデーション
+      // 2. --format バリデーション
       if (a.format !== "" && a.format !== "diff") {
         writeErrorJson(
           "VALIDATION_ERROR",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7,11 +7,12 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
   requireSid,
 } from "@/commands/_shared"
@@ -65,6 +66,7 @@ export function makeServeCommand(deps: ServeDeps = {}) {
     meta: { name: "serve", description: "ローカル REST プロキシサーバーを起動する" },
     args: {
       ...commonArgs,
+      ...dryRunArg,
       rest: {
         type: "boolean" as const,
         description: "REST プロキシモードで起動する",
@@ -92,7 +94,7 @@ export function makeServeCommand(deps: ServeDeps = {}) {
     },
 
     async run({ args }) {
-      const a = args as CommonArgs & {
+      const a = args as WriteCommonArgs & {
         rest: boolean
         port: string
         host: string

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -6,12 +6,13 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { syncPull } from "@/core/sync/engine"
@@ -24,6 +25,7 @@ export const syncPullCommand = defineCommand({
   meta: { name: "pull", description: "Cosense → ローカルへ pull する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル (省略時は --all 必須)",
@@ -45,7 +47,7 @@ export const syncPullCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & {
+    const a = args as WriteCommonArgs & {
       title?: string
       all: boolean
       dir?: string

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -6,13 +6,14 @@
  */
 
 import {
-  type CommonArgs,
+  type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
   buildRestClient,
   buildWriter,
   checkSandbox,
   commonArgs,
+  dryRunArg,
   requireProject,
 } from "@/commands/_shared"
 import { syncPush } from "@/core/sync/engine"
@@ -25,6 +26,7 @@ export const syncPushCommand = defineCommand({
   meta: { name: "push", description: "ローカル → Cosense へ push する" },
   args: {
     ...commonArgs,
+    ...dryRunArg,
     title: {
       type: "positional",
       description: "ページタイトル (省略時は --all 必須)",
@@ -51,7 +53,7 @@ export const syncPushCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & {
+    const a = args as WriteCommonArgs & {
       title?: string
       all: boolean
       dir?: string

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -1,0 +1,33 @@
+/**
+ * _shared.test.ts — commonArgs / dryRunArg のフラグ分離を表明するテスト。
+ *
+ * 読み取り系コマンドは commonArgs のみを使用し --dry-run を含まない。
+ * 書き込み系コマンドは commonArgs に加えて dryRunArg をスプレッドし --dry-run を持つ。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { commonArgs, dryRunArg } from "@/commands/_shared"
+
+describe("commonArgs", () => {
+  it("--dry-run キーを含まない (読み取り専用コマンド向け)", () => {
+    expect(Object.keys(commonArgs)).not.toContain("dry-run")
+  })
+
+  it("読み取り系共通フラグ (project, json, plain 等) を含む", () => {
+    expect(Object.keys(commonArgs)).toContain("project")
+    expect(Object.keys(commonArgs)).toContain("json")
+    expect(Object.keys(commonArgs)).toContain("plain")
+    expect(Object.keys(commonArgs)).toContain("verbose")
+    expect(Object.keys(commonArgs)).toContain("quiet")
+  })
+})
+
+describe("dryRunArg", () => {
+  it("--dry-run キーを含む (書き込み系コマンド向け)", () => {
+    expect(Object.keys(dryRunArg)).toContain("dry-run")
+  })
+
+  it("dry-run フラグのデフォルト値は false", () => {
+    expect(dryRunArg["dry-run"].default).toBe(false)
+  })
+})

--- a/tests/unit/commands/convert.test.ts
+++ b/tests/unit/commands/convert.test.ts
@@ -49,7 +49,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -74,7 +73,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -96,7 +94,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -117,7 +114,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -138,7 +134,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -161,7 +156,6 @@ describe("convertCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {

--- a/tests/unit/commands/exit-codes.test.ts
+++ b/tests/unit/commands/exit-codes.test.ts
@@ -18,7 +18,6 @@ function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unkno
     plain: false,
     "results-only": false,
     select: undefined,
-    "dry-run": false,
     "enable-commands": undefined,
     "disable-commands": undefined,
     verbose: undefined,

--- a/tests/unit/commands/page/icon.test.ts
+++ b/tests/unit/commands/page/icon.test.ts
@@ -43,7 +43,6 @@ describe("pageIconCommand", () => {
       json: false,
       plain: false,
       "results-only": false,
-      "dry-run": false,
       quiet: false,
     })
 
@@ -61,7 +60,6 @@ describe("pageIconCommand", () => {
       json: true,
       plain: false,
       "results-only": false,
-      "dry-run": false,
       quiet: false,
     })
     // stdoutMock に書かれた JSON を解析して icon フィールドを検証する
@@ -79,7 +77,6 @@ describe("pageIconCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {

--- a/tests/unit/commands/page/text.test.ts
+++ b/tests/unit/commands/page/text.test.ts
@@ -77,7 +77,6 @@ describe("pageTextCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -96,7 +95,6 @@ describe("pageTextCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -116,7 +114,6 @@ describe("pageTextCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -136,7 +133,6 @@ describe("pageTextCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {
@@ -158,7 +154,6 @@ describe("pageTextCommand", () => {
         json: false,
         plain: false,
         "results-only": false,
-        "dry-run": false,
         quiet: false,
       })
     } catch {

--- a/tests/unit/commands/page/watch.test.ts
+++ b/tests/unit/commands/page/watch.test.ts
@@ -105,7 +105,6 @@ const defaultArgs: Record<string, unknown> = {
   plain: false,
   "results-only": false,
   select: undefined,
-  "dry-run": false,
   "enable-commands": undefined,
   "disable-commands": undefined,
   verbose: undefined,
@@ -167,15 +166,6 @@ describe("makePageWatchCommand", () => {
         await runWatch({ ...defaultArgs, project: undefined }, createMockDeps())
       } catch {
         // process.exit モック後の継続による throw は想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(5)
-    })
-
-    it("--dry-run 指定時は exit 5 で終了する (page.watch は --dry-run 非対応)", async () => {
-      try {
-        await runWatch({ ...defaultArgs, "dry-run": true }, createMockDeps())
-      } catch {
-        // 想定内
       }
       expect(exitMock).toHaveBeenCalledWith(5)
     })

--- a/tests/unit/commands/project/graph.test.ts
+++ b/tests/unit/commands/project/graph.test.ts
@@ -58,7 +58,6 @@ function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unkno
     plain: false,
     "results-only": false,
     select: undefined,
-    "dry-run": false,
     "enable-commands": undefined,
     "disable-commands": undefined,
     verbose: undefined,

--- a/tests/unit/commands/schema.test.ts
+++ b/tests/unit/commands/schema.test.ts
@@ -61,7 +61,6 @@ function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unkno
     plain: false,
     "results-only": false,
     select: undefined,
-    "dry-run": false,
     "enable-commands": undefined,
     "disable-commands": undefined,
     verbose: undefined,

--- a/tests/unit/commands/sync/diff.test.ts
+++ b/tests/unit/commands/sync/diff.test.ts
@@ -33,7 +33,6 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
     plain: false,
     "results-only": false,
     select: undefined,
-    "dry-run": false,
     "enable-commands": undefined,
     "disable-commands": undefined,
     verbose: undefined,

--- a/tests/unit/infra/help.test.ts
+++ b/tests/unit/infra/help.test.ts
@@ -267,6 +267,19 @@ describe("renderUsageForArgs", () => {
   })
 })
 
+describe("--dry-run フラグ表示の回帰テスト", () => {
+  test("pageListCommand の args に --dry-run が含まれない (読み取り専用)", async () => {
+    // citty が args 定義をヘルプに反映するため、args のキーが正しいことを確認する
+    const { pageListCommand } = await import("@/commands/page/list")
+    expect(Object.keys(pageListCommand.args ?? {})).not.toContain("dry-run")
+  })
+
+  test("pageEditCommand の args に --dry-run が含まれる (書き込み系)", async () => {
+    const { pageEditCommand } = await import("@/commands/page/edit")
+    expect(Object.keys(pageEditCommand.args ?? {})).toContain("dry-run")
+  })
+})
+
 describe("createCustomShowUsage", () => {
   let originalArgv: string[]
   let logOutput: unknown


### PR DESCRIPTION
## Summary

- `_shared.ts` の `commonArgs` から `dry-run` を取り除き「読み取り共通フラグ」として整理した
- 書き込み専用フラグ `dryRunArg` / 型 `DryRunArg` / `WriteCommonArgs` を新設
- 書き込み系コマンド 12 個 (`page new/edit/append/prepend/insert/delete/rename/pin/unpin`, `sync pull/push`, `serve`) のみ `...commonArgs, ...dryRunArg` をスプレッドするよう変更
- `page watch` の `--dry-run` 拒否ロジック (exit 5) を削除 (読み取り系に分類)
- 読み取り側テスト 9 ファイルから不要な `"dry-run": false` を削除
- `_shared.test.ts` 新設: `commonArgs` に dry-run がないこと / `dryRunArg` に dry-run があることを表明
- `help.test.ts` に回帰テストを追加: `pageListCommand` の args に `dry-run` がないこと / `pageEditCommand` の args に `dry-run` があることを表明

## Test plan

- [x] `bunx biome check src tests` — 警告ゼロ
- [x] `bun run typecheck` — エラーゼロ
- [x] `bun test` — 627 pass / 0 fail

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `page watch` コマンドが `--dry-run` フラグに対応しました

* **リファクタリング**
  * 書き込み機能を持つコマンドの共通引数の構造を整理化しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->