### PR TITLE
fix(format): heading モードのインデント下装飾が見出しに変換されるバグを修正

### DIFF
--- a/src/core/format/scrapbox-to-md.ts
+++ b/src/core/format/scrapbox-to-md.ts
@@ -88,18 +88,12 @@ function lineToMd(line: Line, boldStyle: BoldStyle): string {
   const indent = line.indent
   const indentStr = "\t".repeat(indent)
 
-  // auto モード: 行全体が単一の DecorationNode でインデントなしなら見出し
-  if (boldStyle === "auto" && indent === 0 && isSingleDecoration(line)) {
-    const deco = line.nodes[0] as DecorationNode
-    const heading = tryHeading(deco)
-    if (heading !== null) {
-      const text = nodesToMd(deco.nodes, boldStyle)
-      return `${"#".repeat(heading)} ${text}`
-    }
-  }
-
-  // heading モード: 行全体が単一の DecorationNode なら見出し
-  if (boldStyle === "heading" && isSingleDecoration(line)) {
+  // auto / heading モード: インデントなし かつ 行全体が単一の DecorationNode なら見出し
+  if (
+    (boldStyle === "auto" || boldStyle === "heading") &&
+    indent === 0 &&
+    isSingleDecoration(line)
+  ) {
     const deco = line.nodes[0] as DecorationNode
     const heading = tryHeading(deco)
     if (heading !== null) {

--- a/tests/unit/core/format/scrapbox-to-md.test.ts
+++ b/tests/unit/core/format/scrapbox-to-md.test.ts
@@ -62,6 +62,13 @@ describe("見出し変換 (heading モード)", () => {
     const input = "タイトル\n[* 小見出し]"
     expect(scrapboxToMd(input, { boldStyle: "heading" })).toBe("# タイトル\n\n#### 小見出し")
   })
+
+  test("インデント下の [** テキスト] → heading モードでも太字 (見出しにならない)", () => {
+    const input = "タイトル\n\t[** インデント内強調]"
+    expect(scrapboxToMd(input, { boldStyle: "heading" })).toBe(
+      "# タイトル\n\n\t**インデント内強調**",
+    )
+  })
 })
 
 // --- 見出し (boldStyle=emphasis) ---


### PR DESCRIPTION
## Summary

- `heading` モードで `indent === 0` チェックが抜けており、インデント下の単独 DecorationNode（例: `\t[** 強調]`）が誤って `### 強調` という見出しに変換されていたバグを修正
- `auto` / `heading` 両モードを同一の条件（`indent === 0 && isSingleDecoration`）にまとめることで修正
- 再現テストケースを追加

## 変更内容

### `src/core/format/scrapbox-to-md.ts`
- `auto` と `heading` の見出し判定条件を1つの `if` ブロックに統合
- `heading` モードにも `indent === 0` を必須条件として追加

### `tests/unit/core/format/scrapbox-to-md.test.ts`
- `heading` モードでインデント下の装飾が太字になることを確認するテストケースを追加

## Test plan

- [x] 新規テスト `インデント下の [** テキスト] → heading モードでも太字 (見出しにならない)` がパスすること
- [x] 既存テスト 628件がすべてパスすること
- [x] Biome lint: エラーなし
- [x] 型チェック: エラーなし
- [x] CodeRabbit: 指摘なし

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 見出し変換の判定ロジックを改善し、特定の書式条件下での変換動作を調整しました。

* **Tests**
  * 見出し変換に関するテストケースを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->