### PR TITLE
feat(format): Scrapbox→MD 変換でページ全体から動的に heading レベルを決定する

### DIFF
--- a/src/core/format/scrapbox-to-md.ts
+++ b/src/core/format/scrapbox-to-md.ts
@@ -26,15 +26,7 @@ export interface ScrapboxToMdOptions {
   boldStyle?: BoldStyle
 }
 
-/**
- * scrapboxToMd は Scrapbox 記法テキストを Markdown 文字列に変換する。
- *
- * 第1パスでページ全体の見出し候補アスタリスクレベルを収集し、降順に h2 から割り当てる。
- * 5 レベル以上使用時は h6 で飽和する。
- *
- * @param input Scrapbox ページ本文 (先頭行がタイトル)
- * @param opts 変換オプション
- */
+/** scrapboxToMd は Scrapbox 記法テキストを Markdown 文字列として返す。 */
 export function scrapboxToMd(input: string, opts: ScrapboxToMdOptions = {}): string {
   const boldStyle = opts.boldStyle ?? "auto"
   const blocks = parse(input, { hasTitle: true })

--- a/src/core/format/scrapbox-to-md.ts
+++ b/src/core/format/scrapbox-to-md.ts
@@ -3,6 +3,8 @@
  *
  * @progfay/scrapbox-parser で AST に変換してから Markdown 文字列に直列化する。
  * タイトル行 (先頭行) は h1 に変換する。
+ * heading レベルはページ全体で使用されているアスタリスクレベル集合から動的に決定する
+ * (2 パス方式)。
  */
 
 import type {
@@ -27,24 +29,85 @@ export interface ScrapboxToMdOptions {
 /**
  * scrapboxToMd は Scrapbox 記法テキストを Markdown 文字列に変換する。
  *
+ * 第1パスでページ全体の見出し候補アスタリスクレベルを収集し、降順に h2 から割り当てる。
+ * 5 レベル以上使用時は h6 で飽和する。
+ *
  * @param input Scrapbox ページ本文 (先頭行がタイトル)
  * @param opts 変換オプション
  */
 export function scrapboxToMd(input: string, opts: ScrapboxToMdOptions = {}): string {
   const boldStyle = opts.boldStyle ?? "auto"
   const blocks = parse(input, { hasTitle: true })
+
+  // emphasis モードでは見出し昇格しないため第1パスをスキップ
+  const usedLevels = boldStyle === "emphasis" ? new Set<number>() : collectHeadingLevels(blocks)
+  const levelMap = buildLevelMap(usedLevels)
+  const tryHeading = makeTryHeading(levelMap)
+
   const lines: string[] = []
-
   for (const block of blocks) {
-    const converted = blockToMd(block, boldStyle)
-    lines.push(converted)
+    lines.push(blockToMd(block, boldStyle, tryHeading))
   }
-
   return lines.join("\n")
 }
 
+/**
+ * collectHeadingLevels はブロック配列から見出し候補のアスタリスクレベル集合を返す。
+ *
+ * 見出しに昇格する条件 (isHeadingCandidate) と完全一致させることで、
+ * 第1パスと第2パスの判定ロジックを同期する。
+ */
+function collectHeadingLevels(blocks: Block[]): Set<number> {
+  const used = new Set<number>()
+  for (const block of blocks) {
+    if (block.type !== "line") continue
+    if (!isHeadingCandidate(block)) continue
+    const node = block.nodes[0] as DecorationNode
+    const level = getAsteriskLevel(node.decos)
+    if (level > 0) used.add(level)
+  }
+  return used
+}
+
+/**
+ * buildLevelMap は使用レベル集合から「Scrapbox アスタリスク数 → Markdown h レベル」マップを構築する。
+ *
+ * 降順ソートして h2 から順に割り当て、5 番目以降は h6 で飽和する。
+ */
+function buildLevelMap(used: Set<number>): ReadonlyMap<number, number> {
+  const sorted = [...used].sort((a, b) => b - a)
+  const map = new Map<number, number>()
+  sorted.forEach((lv, i) => map.set(lv, Math.min(2 + i, 6)))
+  return map
+}
+
+/**
+ * makeTryHeading は levelMap を束ねた tryHeading 関数を返す。
+ *
+ * 返す関数は DecorationNode のアスタリスクレベルを levelMap で引き、
+ * 対応する Markdown h レベルを返す。マップに存在しない場合は null を返す。
+ */
+function makeTryHeading(
+  levelMap: ReadonlyMap<number, number>,
+): (deco: DecorationNode) => number | null {
+  return (deco) => {
+    const level = getAsteriskLevel(deco.decos)
+    if (level === 0) return null
+    return levelMap.get(level) ?? null
+  }
+}
+
+/** isHeadingCandidate は Line が見出し昇格条件 (インデントなし・単一 DecorationNode) を満たすかを返す。 */
+function isHeadingCandidate(line: Line): boolean {
+  return line.indent === 0 && line.nodes.length === 1 && line.nodes[0]?.type === "decoration"
+}
+
 /** blockToMd はブロックを Markdown 行(群)に変換する。 */
-function blockToMd(block: Block, boldStyle: BoldStyle): string {
+function blockToMd(
+  block: Block,
+  boldStyle: BoldStyle,
+  tryHeading: (deco: DecorationNode) => number | null,
+): string {
   switch (block.type) {
     case "title":
       return titleToMd(block)
@@ -53,7 +116,7 @@ function blockToMd(block: Block, boldStyle: BoldStyle): string {
     case "table":
       return tableToMd(block)
     case "line":
-      return lineToMd(block, boldStyle)
+      return lineToMd(block, boldStyle, tryHeading)
     default: {
       const _exhaustive: never = block
       return ""
@@ -82,18 +145,18 @@ function tableToMd(block: Table): string {
 }
 
 /** lineToMd は Line ブロックを Markdown の 1 行に変換する。 */
-function lineToMd(line: Line, boldStyle: BoldStyle): string {
+function lineToMd(
+  line: Line,
+  boldStyle: BoldStyle,
+  tryHeading: (deco: DecorationNode) => number | null,
+): string {
   if (line.nodes.length === 0) return ""
 
   const indent = line.indent
   const indentStr = "\t".repeat(indent)
 
-  // auto / heading モード: インデントなし かつ 行全体が単一の DecorationNode なら見出し
-  if (
-    (boldStyle === "auto" || boldStyle === "heading") &&
-    indent === 0 &&
-    isSingleDecoration(line)
-  ) {
+  // auto / heading モード: isHeadingCandidate を満たす行のみ見出しに昇格
+  if ((boldStyle === "auto" || boldStyle === "heading") && isHeadingCandidate(line)) {
     const deco = line.nodes[0] as DecorationNode
     const heading = tryHeading(deco)
     if (heading !== null) {
@@ -104,24 +167,6 @@ function lineToMd(line: Line, boldStyle: BoldStyle): string {
 
   const content = nodesToMd(line.nodes, boldStyle)
   return `${indentStr}${content}`
-}
-
-/** isSingleDecoration は Line の nodes が単一の DecorationNode かを判定する。 */
-function isSingleDecoration(line: Line): boolean {
-  return line.nodes.length === 1 && line.nodes[0]?.type === "decoration"
-}
-
-/**
- * tryHeading は DecorationNode が見出しに変換可能かを判定する。
- * 変換可能なら Markdown の # レベル数を返す。変換不可なら null を返す。
- */
-function tryHeading(deco: DecorationNode): number | null {
-  const level = getAsteriskLevel(deco.decos)
-  if (level === 0) return null
-  // level 1 → h4(4), level 2 → h3(3), level 3+ → h2(2)
-  if (level >= 3) return 2
-  if (level === 2) return 3
-  return 4
 }
 
 /** getAsteriskLevel は decos から "*-N" パターンを見つけて N を返す。なければ 0。 */

--- a/tests/unit/core/format/scrapbox-to-md.test.ts
+++ b/tests/unit/core/format/scrapbox-to-md.test.ts
@@ -22,14 +22,14 @@ describe("見出し変換 (auto モード)", () => {
     expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 大見出し")
   })
 
-  test("[** テキスト] 行全体 → h3", () => {
+  test("[** テキスト] 単独ページ → h2（単一レベルのため最上位に昇格）", () => {
     const input = "タイトル\n[** 中見出し]"
-    expect(scrapboxToMd(input)).toBe("# タイトル\n\n### 中見出し")
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 中見出し")
   })
 
-  test("[* テキスト] 行全体 → h4", () => {
+  test("[* テキスト] 単独ページ → h2（単一レベルのため最上位に昇格）", () => {
     const input = "タイトル\n[* 小見出し]"
-    expect(scrapboxToMd(input)).toBe("# タイトル\n\n#### 小見出し")
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 小見出し")
   })
 
   test("[**** テキスト] 4 個以上は h2 頭打ち", () => {
@@ -58,9 +58,9 @@ describe("見出し変換 (heading モード)", () => {
     // NOTE: インラインの場合でも行全体が見出しになるわけではなく、AST レベルでデコレーションが見出しとして扱われる
   })
 
-  test("行全体 [* テキスト] → heading モードでも h4", () => {
+  test("行全体 [* テキスト] 単独ページ → heading モードでも h2（単一レベルのため最上位に昇格）", () => {
     const input = "タイトル\n[* 小見出し]"
-    expect(scrapboxToMd(input, { boldStyle: "heading" })).toBe("# タイトル\n\n#### 小見出し")
+    expect(scrapboxToMd(input, { boldStyle: "heading" })).toBe("# タイトル\n\n## 小見出し")
   })
 
   test("インデント下の [** テキスト] → heading モードでも太字 (見出しにならない)", () => {
@@ -83,6 +83,58 @@ describe("見出し変換 (emphasis モード)", () => {
     expect(scrapboxToMd(input, { boldStyle: "emphasis" })).toBe(
       "# タイトル\n\n**強調** と普通テキスト",
     )
+  })
+})
+
+// --- 見出し変換: 動的レベル決定 (Issue #30) ---
+describe("見出し変換: 動的レベル決定", () => {
+  test("2 レベル使用: [*** ] と [** ] → ## と ###", () => {
+    const input = "タイトル\n[*** 大見出し]\n[** 中見出し]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 大見出し\n### 中見出し")
+  })
+
+  test("2 レベル使用（低位）: [** ] と [* ] → ## と ###", () => {
+    const input = "タイトル\n[** 中見出し]\n[* 小見出し]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 中見出し\n### 小見出し")
+  })
+
+  test("3 レベル使用: [*** ], [** ], [* ] → ##, ###, ####", () => {
+    const input = "タイトル\n[*** 大見出し]\n[** 中見出し]\n[* 小見出し]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 大見出し\n### 中見出し\n#### 小見出し")
+  })
+
+  test("非連続レベル: [**** ] と [* ] のみ → ## と ###（順位ベースで段差は無視）", () => {
+    const input = "タイトル\n[**** 超大]\n[* 小]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 超大\n### 小")
+  })
+
+  test("5 レベル使用: h2 〜 h6 まで割り当て", () => {
+    const input = "タイトル\n[***** 5]\n[**** 4]\n[*** 3]\n[** 2]\n[* 1]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 5\n### 4\n#### 3\n##### 2\n###### 1")
+  })
+
+  test("6 レベル使用: 最下位 2 つが h6 に飽和", () => {
+    const input = "タイトル\n[****** 6]\n[***** 5]\n[**** 4]\n[*** 3]\n[** 2]\n[* 1]"
+    expect(scrapboxToMd(input)).toBe(
+      "# タイトル\n\n## 6\n### 5\n#### 4\n##### 3\n###### 2\n###### 1",
+    )
+  })
+
+  test("emphasis モードでは見出し収集をスキップし太字になる", () => {
+    const input = "タイトル\n[** 強調テキスト]"
+    expect(scrapboxToMd(input, { boldStyle: "emphasis" })).toBe("# タイトル\n\n**強調テキスト**")
+  })
+
+  test("インライン deco は収集対象外（行に他ノードあり）", () => {
+    // [*** 大見出し] は h2 に割り当て。[** インライン] は複数ノード行のため収集されない
+    const input = "タイトル\n[*** 大見出し]\n前置き [** インライン] 後置き"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 大見出し\n前置き **インライン** 後置き")
+  })
+
+  test("インデント下 deco は収集対象外", () => {
+    // [*** 大見出し] は h2 に割り当て。[** インデント下] はインデントあり行のため収集されない
+    const input = "タイトル\n[*** 大見出し]\n\t[** インデント下]"
+    expect(scrapboxToMd(input)).toBe("# タイトル\n\n## 大見出し\n\t**インデント下**")
   })
 })
 


### PR DESCRIPTION
## Summary
- Scrapbox→MD 変換でページ全体をスキャンし、使用されているアスタリスクレベル集合を降順に h2 から割り当てる 2 パス方式へ変更。
- 5 レベル以上使われた場合は h6 で飽和する（Markdown は h6 まで）。
- `boldStyle === "emphasis"` のときは見出し昇格しないため第1パスをスキップ。
- `lineToMd` の見出し判定条件を `isHeadingCandidate` ヘルパに共通化し、収集側との同期を保証。

## Behavior change
| 入力 | 旧 | 新 |
|---|---|---|
| `[* 小見出し]` のみ | `#### 小見出し` | `## 小見出し` |
| `[** 中見出し]` のみ | `### 中見出し` | `## 中見出し` |
| `[*** ]` と `[** ]` 混在 | `##`, `###` | `##`, `###`（変化なし） |
| 5 レベル以上使用 | 全て h2-h4 内 | h2-h6 順に割り当て、超過は h6 飽和 |

## Test plan
- [x] `bun test tests/unit/core/format/scrapbox-to-md.test.ts` で新規 9 ケース pass
- [x] `bun test tests/unit/core/format/roundtrip.test.ts` 全件 pass
- [x] `bun test` 全件 pass (637 pass, 0 fail)
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Scrapbox形式からMarkdownへの変換時に、見出しレベルの自動判定精度を向上させました。複数の見出し候補から最適なレベルマッピングを動的に決定するようになります。

* **テスト**
  * 動的見出しレベル決定に対応したテストケースを追加し、複数パターンでの見出し変換を検証するようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->