### PR TITLE
chore: v0.1.1 リリース準備

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coscli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI",
   "bin": {
     "cos": "./dist/cos"


### PR DESCRIPTION
## Summary

- `package.json` のバージョンを `0.1.0` → `0.1.1` に更新

## Changes since v0.1.0

- fix(format): heading モードのインデント下装飾が見出しに変換されるバグを修正 (#31)
- feat(format): Scrapbox→MD 変換でページ全体から動的に heading レベルを決定する (#32)

## Test plan

- [x] `bun run typecheck` — エラーなし
- [x] `bunx biome check src tests` — 警告なし
- [x] `bun test` — 637 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)