### PR TITLE
fix(schema): 実 API レスポンスに合わせて zod スキーマを修正

### DIFF
--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -49,9 +49,11 @@ export async function syncPull(
   const page = await client.getPage(project, title)
   // lines[0] はタイトル行なので除外して本文だけ取り出す
   const bodyLines = page.lines.slice(1).map((l) => l.text)
+  // commitId が欠落している場合 (新規作成直後等) は空文字列でフォールバック
+  const commitId = page.commitId ?? ""
 
   if (opts.dryRun) {
-    return { title, commitId: page.commitId, lines: bodyLines, dryRun: true }
+    return { title, commitId, lines: bodyLines, dryRun: true }
   }
 
   writeLocalContent(syncDir, title, format, bodyLines)
@@ -62,14 +64,14 @@ export async function syncPull(
     project,
     title,
     pageId: page.id,
-    commitId: page.commitId,
+    commitId,
     lastPulledAt: Date.now(),
     format,
     contentSha256: sha256(contentStr),
   }
   writeMeta(syncDir, meta)
 
-  return { title, commitId: page.commitId, lines: bodyLines }
+  return { title, commitId, lines: bodyLines }
 }
 
 /** SyncPushOptions は syncPush のオプション。 */
@@ -122,7 +124,8 @@ export async function syncPush(
   while (true) {
     const serverPage = await client.getPage(project, title)
 
-    if (meta.commitId !== serverPage.commitId) {
+    const serverCommitId = serverPage.commitId ?? ""
+    if (meta.commitId !== serverCommitId) {
       // commitId 不一致 = 競合
       const localContentStr = contentToString(localLines)
       const localUnchanged = sha256(localContentStr) === meta.contentSha256
@@ -148,7 +151,7 @@ export async function syncPush(
         committed: false,
         errorCode: "CONFLICT",
         localCommitId: meta.commitId,
-        serverCommitId: serverPage.commitId,
+        serverCommitId,
       }
     }
 
@@ -222,6 +225,8 @@ export async function syncDiff(
   const localLines = readLocalContent(syncDir, title, format)
   const meta = readMeta(syncDir, project, title)
 
+  const serverCommitId = serverPage.commitId ?? ""
+
   if (localLines === null) {
     // ローカルファイルが存在しない = リモートのみ
     return {
@@ -229,7 +234,7 @@ export async function syncDiff(
       title,
       status: "remote-only",
       local: null,
-      remote: { commitId: serverPage.commitId, lineCount: serverBodyLines.length },
+      remote: { commitId: serverCommitId, lineCount: serverBodyLines.length },
       diff: computeDiff([], serverBodyLines),
     }
   }
@@ -247,7 +252,7 @@ export async function syncDiff(
       title,
       status: "local-only",
       local: localInfo,
-      remote: { commitId: serverPage.commitId, lineCount: 0 },
+      remote: { commitId: serverCommitId, lineCount: 0 },
       diff: computeDiff(localLines, []),
     }
   }
@@ -267,7 +272,7 @@ export async function syncDiff(
     title,
     status,
     local: localInfo,
-    remote: { commitId: serverPage.commitId, lineCount: serverBodyLines.length },
+    remote: { commitId: serverCommitId, lineCount: serverBodyLines.length },
     diff: diffResult,
   }
 }

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -25,8 +25,9 @@ export const PageSummarySchema = z.object({
   user: z
     .object({
       id: z.string(),
-      name: z.string(),
-      displayName: z.string(),
+      // 実 API では name / displayName が省略される場合がある
+      name: z.string().optional(),
+      displayName: z.string().optional(),
     })
     .optional(),
   pin: z.number().optional(),
@@ -50,14 +51,16 @@ export const PageSchema = z.object({
   user: z
     .object({
       id: z.string(),
-      name: z.string(),
-      displayName: z.string(),
+      // 実 API では name / displayName が省略される場合がある
+      name: z.string().optional(),
+      displayName: z.string().optional(),
     })
     .optional(),
   pin: z.number().optional(),
   views: z.number().optional(),
   linked: z.number().optional(),
-  commitId: z.string(),
+  // 実 API: 新規作成直後のページは commitId が無いことがある
+  commitId: z.string().optional(),
   created: z.number(),
   updated: z.number(),
   accessed: z.number().optional(),
@@ -89,7 +92,8 @@ export type PageListResponse = z.infer<typeof PageListResponseSchema>
 
 /** SearchResult は /api/pages/:project/search/query のレスポンス。 */
 export const SearchResultSchema = z.object({
-  query: z.string().optional(),
+  // 実 API (認証あり): query はオブジェクト形式 { words, excludes } を返すことがある
+  query: z.union([z.string(), z.object({}).passthrough()]).optional(),
   pages: z.array(
     z.object({
       id: z.string(),
@@ -97,6 +101,8 @@ export const SearchResultSchema = z.object({
       image: z.string().nullable().optional(),
       descriptions: z.array(z.string()).optional(),
       words: z.array(z.string()).optional(),
+      // 実 API: search/query の pages[] は lines: string[] を含む
+      lines: z.array(z.string()).optional(),
     }),
   ),
   existsSelectedProject: z.boolean().optional(),

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -11,7 +11,8 @@ export const ProjectSchema = z.object({
   displayName: z.string(),
   publicVisible: z.boolean(),
   loginStrategies: z.array(z.string()).optional(),
-  plan: z.string().optional(),
+  // 実 API: 有料プランに未加入のプロジェクトは null を返す
+  plan: z.string().nullable().optional(),
   gyazoTeamsName: z.string().nullable().optional(),
   image: z.string().nullable().optional(),
   theme: z.string().optional(),

--- a/tests/fixtures/page-detail.json
+++ b/tests/fixtures/page-detail.json
@@ -4,14 +4,11 @@
   "image": null,
   "descriptions": ["最初の行", "2行目"],
   "user": {
-    "id": "user-id-1",
-    "name": "テストユーザー",
-    "displayName": "テストユーザー表示名"
+    "id": "user-id-1"
   },
   "pin": 0,
   "views": 10,
   "linked": 3,
-  "commitId": "commit-id-hello",
   "created": 1700000000,
   "updated": 1700100000,
   "accessed": 1700200000,

--- a/tests/fixtures/page-list.json
+++ b/tests/fixtures/page-list.json
@@ -10,14 +10,11 @@
       "image": null,
       "descriptions": ["最初の行", "2行目"],
       "user": {
-        "id": "user-id-1",
-        "name": "テストユーザー",
-        "displayName": "テストユーザー表示名"
+        "id": "user-id-1"
       },
       "pin": 0,
       "views": 10,
       "linked": 3,
-      "commitId": "commit-id-hello",
       "created": 1700000000,
       "updated": 1700100000,
       "accessed": 1700200000,
@@ -29,14 +26,11 @@
       "image": null,
       "descriptions": ["日本語の説明文"],
       "user": {
-        "id": "user-id-1",
-        "name": "テストユーザー",
-        "displayName": "テストユーザー表示名"
+        "id": "user-id-1"
       },
       "pin": 0,
       "views": 5,
       "linked": 0,
-      "commitId": "commit-id-japanese",
       "created": 1700050000,
       "updated": 1700150000,
       "accessed": 1700250000,

--- a/tests/fixtures/project-info.json
+++ b/tests/fixtures/project-info.json
@@ -1,0 +1,17 @@
+{
+  "id": "project-id-sandbox",
+  "name": "テストサンドボックス",
+  "displayName": "テスト サンドボックス",
+  "publicVisible": true,
+  "loginStrategies": [],
+  "plan": null,
+  "gyazoTeamsName": null,
+  "image": null,
+  "theme": "default",
+  "created": 1700000000,
+  "updated": 1700100000,
+  "isMember": true,
+  "isAdmin": true,
+  "pageCount": 5,
+  "memberCount": 1
+}

--- a/tests/unit/core/sync/engine.test.ts
+++ b/tests/unit/core/sync/engine.test.ts
@@ -35,6 +35,13 @@ function makePage(overrides: Partial<Page> = {}): Page {
   }
 }
 
+/** commitId を持たないテスト用 Page を生成するファクトリ (新規作成直後等の実 API 形を再現) */
+function makePageWithoutCommitId(): Page {
+  // exactOptionalPropertyTypes 対応: commitId プロパティを spread で除外して absent にする
+  const { commitId: _removed, ...rest } = makePage()
+  return rest as Page
+}
+
 /** モック REST クライアントを生成する */
 function makeRestClient(page: Page): CosenseRestClient {
   return {
@@ -328,5 +335,60 @@ describe("syncDiff", () => {
       ...result.diff.modified.map((m) => m.after),
     ]
     expect(allChanges.length).toBeGreaterThan(0)
+  })
+})
+
+describe("commitId が欠落した実 API レスポンスへのフォールバック", () => {
+  test("syncPull: commitId なしのページを pull すると meta.commitId が空文字列になる", async () => {
+    const page = makePageWithoutCommitId()
+    const client = makeRestClient(page)
+
+    const result = await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // 戻り値の commitId が空文字列
+    expect(result.commitId).toBe("")
+
+    // メタの commitId も空文字列で保存される
+    const meta = readMeta(TEST_DIR, "テストプロジェクト", "テストページ")
+    expect(meta?.commitId).toBe("")
+  })
+
+  test("syncPush: サーバの commitId が欠落かつローカルも空文字列のとき競合なしで push できる", async () => {
+    // commitId なしページを pull → meta.commitId = ""
+    const page = makePageWithoutCommitId()
+    const pullClient = makeRestClient(page)
+    await syncPull(pullClient, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // ローカルを編集
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "変更した本文\n", "utf-8")
+
+    // サーバも commitId なしのまま (他者更新なし)
+    const pushClient = makeRestClient(page)
+    const writer = makeWriter("新コミット123")
+    const result = await syncPush(
+      pushClient,
+      writer,
+      TEST_DIR,
+      "テストプロジェクト",
+      "テストページ",
+    )
+
+    // "" === "" で競合なし → push 成功
+    expect(result.committed).toBe(true)
+    expect(result.newCommitId).toBe("新コミット123")
+  })
+
+  test("syncDiff: commitId なしページを pull した後の差分検出が正常に動作する", async () => {
+    const page = makePageWithoutCommitId()
+    const client = makeRestClient(page)
+    await syncPull(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // ローカルを変更
+    writeFileSync(join(TEST_DIR, "テストページ.txt"), "変更後の本文\n", "utf-8")
+
+    const result = await syncDiff(client, TEST_DIR, "テストプロジェクト", "テストページ")
+
+    // commitId が欠落していても差分検出が正常に動作する
+    expect(result.status).toBe("modified")
   })
 })

--- a/tests/unit/schemas/page.test.ts
+++ b/tests/unit/schemas/page.test.ts
@@ -1,12 +1,20 @@
 /**
  * page.test.ts — page スキーマの検証テスト。
  *
- * TitleSearchResultSchema が links・image フィールドを含む
- * /api/pages/:project/search/titles レスポンスを正しく解析できることを検証する。
+ * 実 API レスポンスとの整合性を検証する。
+ * - TitleSearchResultSchema: /api/pages/:project/search/titles
+ * - PageSummarySchema: /api/pages/:project の pages[] 要素
+ * - PageSchema: /api/pages/:project/:title の個別ページ
+ * - SearchResultSchema: /api/pages/:project/search/query
  */
 
 import { describe, expect, it } from "bun:test"
-import { TitleSearchResultSchema } from "@/schemas/page"
+import {
+  PageSchema,
+  PageSummarySchema,
+  SearchResultSchema,
+  TitleSearchResultSchema,
+} from "@/schemas/page"
 
 describe("TitleSearchResultSchema", () => {
   it("id・title・updated の最小フィールドを解析できる", () => {
@@ -104,5 +112,113 @@ describe("TitleSearchResultSchema", () => {
         links: [123, "正常タイトル"],
       }),
     ).toThrow()
+  })
+})
+
+describe("PageSummarySchema — 実 API レスポンスとの整合性", () => {
+  it("user が id のみ (name/displayName 欠落) でもパースできる", () => {
+    // 実 API: user オブジェクトは id だけを返す場合がある
+    const result = PageSummarySchema.parse({
+      id: "ページID-001",
+      title: "テストページ",
+      user: { id: "ユーザーID-001" },
+      created: 1700000000,
+      updated: 1700100000,
+    })
+    expect(result.id).toBe("ページID-001")
+    expect(result.user?.id).toBe("ユーザーID-001")
+    expect(result.user?.name).toBeUndefined()
+    expect(result.user?.displayName).toBeUndefined()
+  })
+
+  it("user フィールド自体が省略されてもパースできる", () => {
+    const result = PageSummarySchema.parse({
+      id: "ページID-002",
+      title: "ユーザー情報なしページ",
+      created: 1700000000,
+      updated: 1700100000,
+    })
+    expect(result.user).toBeUndefined()
+  })
+})
+
+describe("PageSchema — 実 API レスポンスとの整合性", () => {
+  it("commitId が省略されてもパースできる", () => {
+    // 実 API: 新規作成直後のページは commitId が無いことがある
+    const result = PageSchema.parse({
+      id: "ページID-003",
+      title: "新規作成ページ",
+      user: { id: "ユーザーID-001" },
+      created: 1700000000,
+      updated: 1700100000,
+      lines: [
+        {
+          id: "行ID-001",
+          text: "新規作成ページ",
+          userId: "ユーザーID-001",
+          created: 1700000000,
+          updated: 1700000000,
+        },
+      ],
+    })
+    expect(result.commitId).toBeUndefined()
+  })
+
+  it("user に name/displayName が無くてもパースできる", () => {
+    const result = PageSchema.parse({
+      id: "ページID-004",
+      title: "ユーザー情報省略ページ",
+      user: { id: "ユーザーID-002" },
+      commitId: "コミットID-001",
+      created: 1700000000,
+      updated: 1700100000,
+      lines: [
+        {
+          id: "行ID-001",
+          text: "ユーザー情報省略ページ",
+          userId: "ユーザーID-002",
+          created: 1700000000,
+          updated: 1700000000,
+        },
+      ],
+    })
+    expect(result.user?.name).toBeUndefined()
+    expect(result.user?.displayName).toBeUndefined()
+  })
+})
+
+describe("SearchResultSchema — 実 API レスポンスとの整合性", () => {
+  it("query フィールドがオブジェクトでもパースできる", () => {
+    // 実 API (認証あり): query は { words: [...], excludes: [...] } 形式のオブジェクトを返す
+    const result = SearchResultSchema.parse({
+      query: { words: ["テスト"], excludes: [] },
+      pages: [],
+      projectName: "テストプロジェクト",
+    })
+    expect(result.projectName).toBe("テストプロジェクト")
+  })
+
+  it("query フィールドが文字列でもパースできる", () => {
+    const result = SearchResultSchema.parse({
+      query: "テスト",
+      pages: [],
+      projectName: "テストプロジェクト",
+    })
+    expect(result.query).toBe("テスト")
+  })
+
+  it("search の pages 要素に lines フィールドが含まれてもパースできる", () => {
+    // 実 API: search/query の pages[] 要素は lines: string[] を返す
+    const result = SearchResultSchema.parse({
+      pages: [
+        {
+          id: "ページID-001",
+          title: "検索結果ページ",
+          lines: ["行1のテキスト", "行2のテキスト"],
+        },
+      ],
+      projectName: "テストプロジェクト",
+    })
+    expect(result.pages[0]?.title).toBe("検索結果ページ")
   })
 })

--- a/tests/unit/schemas/project.test.ts
+++ b/tests/unit/schemas/project.test.ts
@@ -1,0 +1,52 @@
+/**
+ * project.test.ts — project スキーマの検証テスト。
+ *
+ * 実 API レスポンスとの整合性を検証する。
+ * - ProjectSchema: /api/projects/:project のレスポンス
+ * - ProjectListResponseSchema: /api/projects のレスポンス
+ */
+
+import { describe, expect, it } from "bun:test"
+import { ProjectSchema } from "@/schemas/project"
+
+describe("ProjectSchema — 実 API レスポンスとの整合性", () => {
+  it("plan が null でもパースできる", () => {
+    // 実 API: 有料プランに入っていないプロジェクトは plan: null を返す
+    const result = ProjectSchema.parse({
+      id: "プロジェクトID-001",
+      name: "テストプロジェクト",
+      displayName: "テスト表示名",
+      publicVisible: true,
+      plan: null,
+      created: 1700000000,
+      updated: 1700100000,
+    })
+    expect(result.name).toBe("テストプロジェクト")
+    expect(result.plan).toBeNull()
+  })
+
+  it("plan が文字列でもパースできる", () => {
+    const result = ProjectSchema.parse({
+      id: "プロジェクトID-002",
+      name: "有料プロジェクト",
+      displayName: "有料表示名",
+      publicVisible: false,
+      plan: "business",
+      created: 1700000000,
+      updated: 1700100000,
+    })
+    expect(result.plan).toBe("business")
+  })
+
+  it("plan フィールド自体が省略されてもパースできる", () => {
+    const result = ProjectSchema.parse({
+      id: "プロジェクトID-003",
+      name: "プランなしプロジェクト",
+      displayName: "プランなし表示名",
+      publicVisible: true,
+      created: 1700000000,
+      updated: 1700100000,
+    })
+    expect(result.plan).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- 実環境で `page list` / `page get` / `project list` / `project info` / `search` が zod バリデーションエラーで全滅する致命的な問題を修正
- テストフィクスチャを実 API 形式に修正し、テストが実際のレスポンス構造を反映するようにした

## 変更詳細

### スキーマ修正 (`src/schemas/`)
| 対象 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `PageSummarySchema.user.name / displayName` | required | `.optional()` | 実 API は `user: { id }` のみ返す |
| `PageSchema.user.name / displayName` | required | `.optional()` | 同上 |
| `PageSchema.commitId` | `z.string()` | `z.string().optional()` | 新規作成直後のページは欠落することがある |
| `ProjectSchema.plan` | `z.string().optional()` | `z.string().nullable().optional()` | 未加入のプロジェクトは `null` を返す |
| `SearchResultSchema.query` | `z.string().optional()` | `z.union([z.string(), z.object({}).passthrough()]).optional()` | 認証ありで `{ words, excludes }` 形式オブジェクトを返す |
| `SearchResultSchema.pages[].lines` | (なし) | `z.array(z.string()).optional()` | 実 API レスポンスに含まれるフィールド |

### フィクスチャ修正 (`tests/fixtures/`)
- `page-list.json` / `page-detail.json` の `user` を `{ id }` のみに変更 (実 API 形式)
- `project-info.json` を新規追加 (`plan: null` を含む実 API 形式)

### 型修正 (`src/core/sync/engine.ts`)
- `page.commitId` が `string | undefined` になったため、`?? ""` フォールバックを追加

## Test plan

- [x] `bun test` — 647 pass, 0 fail
- [x] `bunx biome check src tests` — エラーゼロ
- [x] `bun run typecheck` — エラーゼロ
- [x] ビルド後に実環境で以下を確認:
  - `./dist/cos-darwin-arm64 page list --project mtane0412-sandbox --json --results-only --select 'pages[].title'` → 正常
  - `./dist/cos-darwin-arm64 project info --project mtane0412-sandbox --json --results-only` → 正常
  - `./dist/cos-darwin-arm64 project list --json --results-only --select 'projects[].name'` → 正常
  - `./dist/cos-darwin-arm64 search "coscli" --project mtane0412-sandbox --json --results-only` → 正常
  - `./dist/cos-darwin-arm64 page get "coscli実検証_1778488258" --project mtane0412-sandbox --json` → 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * APIレスポンスの互換性を向上させ、一部のフィールドが省略されたケースに対応しました
  * データ同期処理で欠落値の正規化を改善し、より堅牢な処理を実現しました

* **Tests**
  * スキーマの妥当性検証テストを拡張し、様々なAPIレスポンスパターンへの対応を確認するようにしました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->