### PR TITLE
fix(cli): citty runMain を自前ラッパに置き換えてエラー出力1回化・exit code 分類・JSON envelope 化

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,12 @@
  */
 
 import { setRootCommand } from "@/core/cli-root"
+import { extractErrorMessage, extractStackTrace, resolveExitCode } from "@/infra/cli-error-handler"
 import { initColor } from "@/infra/color"
 import { createCustomShowUsage } from "@/infra/help"
-import { defineCommand, runMain } from "citty"
+import { Logger } from "@/infra/logger"
+import { writeErrorJson } from "@/presenter/json"
+import { defineCommand, runCommand } from "citty"
 
 // bun build --define 'VERSION="x.y.z"' でビルド時に注入される
 declare const VERSION: string
@@ -192,7 +195,45 @@ const main = defineCommand({
 // exactOptionalPropertyTypes のため具体的な args 型を CommandDef に広げてから渡す
 setRootCommand(main as unknown as import("citty").CommandDef)
 
-// main の具体的な args 型を CommandDef に広げて createCustomShowUsage に渡す
-runMain(main, {
-  showUsage: createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos"),
-})
+const rawArgs = process.argv.slice(2)
+const showUsageFn = createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos")
+
+// --help / -h: citty の showUsage を呼んで exit 0
+if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+  await showUsageFn(main as unknown as import("citty").CommandDef, null as never)
+  process.exit(0)
+}
+
+// --version (単独): バージョンを表示して exit 0
+if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+  const meta =
+    typeof main.meta === "function" ? await main.meta() : await Promise.resolve(main.meta)
+  const version = (meta?.version ?? "").replace(/^v/, "")
+  console.log(version)
+  process.exit(0)
+}
+
+// 通常コマンド実行: runCommand を直接呼び、エラーを自前で分類する
+const isJson = rawArgs.some((a) => a === "--json" || a === "-J")
+const isVerbose = rawArgs.some(
+  (a) => a === "-v" || a === "-vv" || a === "--verbose" || a.startsWith("--verbose="),
+)
+
+try {
+  await runCommand(main, { rawArgs })
+} catch (err) {
+  const exitCode = resolveExitCode(err)
+  const message = extractErrorMessage(err)
+  const stack = isVerbose ? extractStackTrace(err) : undefined
+
+  if (isJson) {
+    writeErrorJson(exitCode === 5 ? "VALIDATION_ERROR" : "ERROR", message)
+  } else {
+    const logger = new Logger()
+    logger.error(message)
+    if (stack) {
+      process.stderr.write(`${stack}\n`)
+    }
+  }
+  process.exit(exitCode)
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,12 @@
  */
 
 import { setRootCommand } from "@/core/cli-root"
-import { extractErrorMessage, extractStackTrace, resolveExitCode } from "@/infra/cli-error-handler"
+import {
+  extractErrorMessage,
+  extractStackTrace,
+  resolveErrorCode,
+  resolveExitCode,
+} from "@/infra/cli-error-handler"
 import { initColor } from "@/infra/color"
 import { createCustomShowUsage } from "@/infra/help"
 import { Logger } from "@/infra/logger"
@@ -227,7 +232,7 @@ try {
   const stack = isVerbose ? extractStackTrace(err) : undefined
 
   if (isJson) {
-    writeErrorJson(exitCode === 5 ? "VALIDATION_ERROR" : "ERROR", message)
+    writeErrorJson(resolveErrorCode(err), message)
   } else {
     const logger = new Logger()
     logger.error(message)

--- a/src/infra/cli-error-handler.ts
+++ b/src/infra/cli-error-handler.ts
@@ -37,11 +37,30 @@ export function resolveExitCode(err: unknown): number {
 }
 
 /**
+ * resolveErrorCode はエラーの種類に応じた JSON envelope 用エラーコード文字列を返す。
+ *
+ * resolveExitCode と同じ分類粒度で文字列コードを返すことで、
+ * --json 時のエラーレスポンスで種別が判別できるようにする。
+ */
+export function resolveErrorCode(err: unknown): string {
+  if (err instanceof ZodError) return "VALIDATION_ERROR"
+  if (err instanceof AuthError) return "AUTH_REQUIRED"
+  if (err instanceof ForbiddenError) return "FORBIDDEN"
+  if (err instanceof NotFoundError) return "NOT_FOUND"
+  return "ERROR"
+}
+
+/**
  * extractErrorMessage はエラーから人間向けメッセージを取り出す。
  */
 export function extractErrorMessage(err: unknown): string {
   if (err instanceof ZodError) {
-    return `レスポンス検証エラー: ${err.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`
+    const parts = err.issues.map((e) => {
+      const pathStr = e.path.join(".")
+      // path が空の場合 (トップレベルの型ミスマッチ等) はパス部分を省略する
+      return pathStr ? `${pathStr}: ${e.message}` : e.message
+    })
+    return `レスポンス検証エラー: ${parts.join(", ")}`
   }
   if (err instanceof Error) return err.message
   return String(err)

--- a/src/infra/cli-error-handler.ts
+++ b/src/infra/cli-error-handler.ts
@@ -1,0 +1,59 @@
+/**
+ * cli-error-handler.ts — CLI のトップレベルエラーハンドリング。
+ *
+ * citty の runMain が持つ2重エラー出力・exit code 固定の問題を回避するため、
+ * runCommand を直接呼ぶ自前ラッパから使用する。
+ *
+ * エラークラスを分類して適切な終了コードを返す。
+ * --json 指定時は writeErrorJson で envelope 形式に変換する。
+ */
+
+import { AuthError, CosenseApiError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import {
+  EXIT_ERROR,
+  EXIT_FORBIDDEN,
+  EXIT_NOT_FOUND,
+  EXIT_UNAUTHORIZED,
+  EXIT_VALIDATION_ERROR,
+} from "@/core/exit-codes"
+import { ZodError } from "zod"
+
+/**
+ * resolveExitCode はエラーの種類に応じた終了コードを返す。
+ *
+ * - ZodError → 5 (バリデーションエラー)
+ * - AuthError → 2 (認証エラー)
+ * - ForbiddenError → 3 (権限エラー)
+ * - NotFoundError → 4 (NotFound)
+ * - その他 → 1 (一般エラー)
+ */
+export function resolveExitCode(err: unknown): number {
+  if (err instanceof ZodError) return EXIT_VALIDATION_ERROR
+  if (err instanceof AuthError) return EXIT_UNAUTHORIZED
+  if (err instanceof ForbiddenError) return EXIT_FORBIDDEN
+  if (err instanceof NotFoundError) return EXIT_NOT_FOUND
+  if (err instanceof CosenseApiError) return EXIT_ERROR
+  return EXIT_ERROR
+}
+
+/**
+ * extractErrorMessage はエラーから人間向けメッセージを取り出す。
+ */
+export function extractErrorMessage(err: unknown): string {
+  if (err instanceof ZodError) {
+    return `レスポンス検証エラー: ${err.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+/**
+ * extractStackTrace はスタックトレースを取り出す。verbose 時のみ表示する。
+ *
+ * Bun バンドルの内部パス (/$bunfs/...) が含まれるため、
+ * 本番バイナリ実行時はデフォルトで非表示とし、-v 以上のみ表示する。
+ */
+export function extractStackTrace(err: unknown): string | undefined {
+  if (err instanceof Error && err.stack) return err.stack
+  return undefined
+}

--- a/tests/unit/cli/error-handling.test.ts
+++ b/tests/unit/cli/error-handling.test.ts
@@ -1,0 +1,67 @@
+/**
+ * error-handling.test.ts — CLI エラーハンドリングのユニットテスト。
+ *
+ * resolveExitCode が各エラークラスに対して適切な終了コードを返すことを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  AuthError,
+  CosenseApiError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} from "@/core/api/rest"
+import {
+  EXIT_ERROR,
+  EXIT_FORBIDDEN,
+  EXIT_NOT_FOUND,
+  EXIT_UNAUTHORIZED,
+  EXIT_VALIDATION_ERROR,
+} from "@/core/exit-codes"
+import { resolveExitCode } from "@/infra/cli-error-handler"
+import { ZodError, z } from "zod"
+
+describe("resolveExitCode", () => {
+  it("ZodError は EXIT_VALIDATION_ERROR (5) を返す", () => {
+    // zod の parse 失敗で生成されるエラー
+    let zodErr: ZodError | undefined
+    try {
+      z.string().parse(123)
+    } catch (e) {
+      if (e instanceof ZodError) zodErr = e
+    }
+    expect(zodErr).toBeDefined()
+    expect(resolveExitCode(zodErr)).toBe(EXIT_VALIDATION_ERROR)
+  })
+
+  it("AuthError は EXIT_UNAUTHORIZED (2) を返す", () => {
+    expect(resolveExitCode(new AuthError())).toBe(EXIT_UNAUTHORIZED)
+  })
+
+  it("ForbiddenError は EXIT_FORBIDDEN (3) を返す", () => {
+    expect(resolveExitCode(new ForbiddenError())).toBe(EXIT_FORBIDDEN)
+  })
+
+  it("NotFoundError は EXIT_NOT_FOUND (4) を返す", () => {
+    expect(
+      resolveExitCode(new NotFoundError("https://scrapbox.io/api/pages/test/存在しないページ")),
+    ).toBe(EXIT_NOT_FOUND)
+  })
+
+  it("RateLimitError は EXIT_ERROR (1) を返す", () => {
+    expect(resolveExitCode(new RateLimitError())).toBe(EXIT_ERROR)
+  })
+
+  it("その他の CosenseApiError は EXIT_ERROR (1) を返す", () => {
+    expect(resolveExitCode(new CosenseApiError(500, "サーバーエラー"))).toBe(EXIT_ERROR)
+  })
+
+  it("未知の Error は EXIT_ERROR (1) を返す", () => {
+    expect(resolveExitCode(new Error("予期しないエラー"))).toBe(EXIT_ERROR)
+  })
+
+  it("文字列エラーは EXIT_ERROR (1) を返す", () => {
+    expect(resolveExitCode("予期しない文字列エラー")).toBe(EXIT_ERROR)
+  })
+})

--- a/tests/unit/cli/error-handling.test.ts
+++ b/tests/unit/cli/error-handling.test.ts
@@ -1,7 +1,8 @@
 /**
  * error-handling.test.ts — CLI エラーハンドリングのユニットテスト。
  *
- * resolveExitCode が各エラークラスに対して適切な終了コードを返すことを検証する。
+ * resolveExitCode / resolveErrorCode / extractErrorMessage が
+ * 各エラークラスに対して適切な値を返すことを検証する。
  */
 
 import { describe, expect, it } from "bun:test"
@@ -19,7 +20,7 @@ import {
   EXIT_UNAUTHORIZED,
   EXIT_VALIDATION_ERROR,
 } from "@/core/exit-codes"
-import { resolveExitCode } from "@/infra/cli-error-handler"
+import { extractErrorMessage, resolveErrorCode, resolveExitCode } from "@/infra/cli-error-handler"
 import { ZodError, z } from "zod"
 
 describe("resolveExitCode", () => {
@@ -63,5 +64,75 @@ describe("resolveExitCode", () => {
 
   it("文字列エラーは EXIT_ERROR (1) を返す", () => {
     expect(resolveExitCode("予期しない文字列エラー")).toBe(EXIT_ERROR)
+  })
+})
+
+describe("resolveErrorCode", () => {
+  it("ZodError は VALIDATION_ERROR を返す", () => {
+    let zodErr: ZodError | undefined
+    try {
+      z.string().parse(123)
+    } catch (e) {
+      if (e instanceof ZodError) zodErr = e
+    }
+    expect(resolveErrorCode(zodErr)).toBe("VALIDATION_ERROR")
+  })
+
+  it("AuthError は AUTH_REQUIRED を返す", () => {
+    expect(resolveErrorCode(new AuthError())).toBe("AUTH_REQUIRED")
+  })
+
+  it("ForbiddenError は FORBIDDEN を返す", () => {
+    expect(resolveErrorCode(new ForbiddenError())).toBe("FORBIDDEN")
+  })
+
+  it("NotFoundError は NOT_FOUND を返す", () => {
+    expect(
+      resolveErrorCode(new NotFoundError("https://scrapbox.io/api/pages/test/存在しないページ")),
+    ).toBe("NOT_FOUND")
+  })
+
+  it("その他のエラーは ERROR を返す", () => {
+    expect(resolveErrorCode(new Error("予期しないエラー"))).toBe("ERROR")
+    expect(resolveErrorCode(new CosenseApiError(500, "サーバーエラー"))).toBe("ERROR")
+    expect(resolveErrorCode("文字列エラー")).toBe("ERROR")
+  })
+})
+
+describe("extractErrorMessage", () => {
+  it("ZodError でパスあり: 'フィールド名: メッセージ' 形式で返す", () => {
+    let zodErr: ZodError | undefined
+    try {
+      // path が ["name"] になる ZodError を生成する
+      z.object({ name: z.string() }).parse({ name: 123 })
+    } catch (e) {
+      if (e instanceof ZodError) zodErr = e
+    }
+    const msg = extractErrorMessage(zodErr)
+    // "レスポンス検証エラー: name: Expected string, received number" のような形式
+    expect(msg).toContain("name:")
+    expect(msg).not.toMatch(/^レスポンス検証エラー: :/)
+  })
+
+  it("ZodError でパスなし: 先頭コロンなしのメッセージを返す", () => {
+    let zodErr: ZodError | undefined
+    try {
+      // path が [] になる ZodError を生成する (トップレベルの型ミスマッチ)
+      z.string().parse(123)
+    } catch (e) {
+      if (e instanceof ZodError) zodErr = e
+    }
+    const msg = extractErrorMessage(zodErr)
+    // ": Expected string..." のような先頭コロン形式にならないこと
+    expect(msg).not.toMatch(/レスポンス検証エラー: :/)
+    expect(msg).toContain("レスポンス検証エラー:")
+  })
+
+  it("通常の Error はメッセージをそのまま返す", () => {
+    expect(extractErrorMessage(new Error("通常のエラーメッセージ"))).toBe("通常のエラーメッセージ")
+  })
+
+  it("文字列はそのまま返す", () => {
+    expect(extractErrorMessage("文字列エラー")).toBe("文字列エラー")
   })
 })


### PR DESCRIPTION
## Summary

- citty 0.1.6 の `runMain` が `consola.error` を2回呼ぶ仕様を回避するため、`runCommand` を直接呼ぶ自前ラッパに置き換えた
- エラー種別 (ZodError/AuthError/ForbiddenError/NotFoundError/CosenseApiError) ごとに適切な終了コードを返す `resolveExitCode` を実装
- `--json` 指定時は `writeErrorJson` で envelope 形式のエラーレスポンスを返す
- `-v`/`--verbose` 指定時のみスタックトレースを stderr に表示する

## Test plan

- [x] `bun test` — 645 pass, 16 skip, 0 fail
- [x] `bunx biome check src tests` — クリーン
- [x] `bun run typecheck` — エラーなし
- [x] `tests/unit/cli/error-handling.test.ts` — 各エラークラスの終了コード分類を8ケース検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)