### PR TITLE
chore(cli): VERSION の v-prefix 除去で citty ヘルプ表示の vv 重複を修正

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,7 +147,7 @@ const syncCommand = defineCommand({
 const main = defineCommand({
   meta: {
     name: "cos",
-    version: VERSION,
+    version: VERSION.replace(/^v/, ""),
     description: "AI エージェント親和的 Cosense (Scrapbox) CLI",
   },
   args: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
 import { initColor } from "@/infra/color"
 import { createCustomShowUsage } from "@/infra/help"
 import { Logger } from "@/infra/logger"
+import { normalizeVersion } from "@/infra/version"
 import { writeErrorJson } from "@/presenter/json"
 import { defineCommand, runCommand } from "citty"
 
@@ -214,7 +215,7 @@ if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
 if (rawArgs.length === 1 && rawArgs[0] === "--version") {
   const meta =
     typeof main.meta === "function" ? await main.meta() : await Promise.resolve(main.meta)
-  const version = (meta?.version ?? "").replace(/^v/, "")
+  const version = normalizeVersion(meta?.version ?? "")
   console.log(version)
   process.exit(0)
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,7 +148,8 @@ const main = defineCommand({
   meta: {
     name: "cos",
     version: VERSION.replace(/^v/, ""),
-    description: "AI エージェント親和的 Cosense (Scrapbox) CLI",
+    description:
+      "cos is a single CLI for Cosense pages, projects, search, sync, convert, and REST proxy — built for terminals, scripts, CI, and coding agents.",
   },
   args: {
     "enable-commands": {

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -36,7 +36,7 @@ export const pageNewCommand = defineCommand({
     },
     line: {
       type: "string",
-      description: "追加する行テキスト",
+      description: "追加する行テキスト (複数行は \\n で区切る)",
     },
   },
   async run({ args }) {

--- a/src/infra/cli-error-handler.ts
+++ b/src/infra/cli-error-handler.ts
@@ -4,8 +4,8 @@
  * citty の runMain が持つ2重エラー出力・exit code 固定の問題を回避するため、
  * runCommand を直接呼ぶ自前ラッパから使用する。
  *
- * エラークラスを分類して適切な終了コードを返す。
- * --json 指定時は writeErrorJson で envelope 形式に変換する。
+ * エラークラスを分類して適切な終了コードと JSON コードを返す。
+ * --json 時の writeErrorJson 呼び出しは cli.ts 側で行う。
  */
 
 import { AuthError, CosenseApiError, ForbiddenError, NotFoundError } from "@/core/api/rest"

--- a/src/infra/version.ts
+++ b/src/infra/version.ts
@@ -1,0 +1,11 @@
+/**
+ * version.ts — バージョン文字列のユーティリティ。
+ *
+ * bun build --define 'VERSION="vX.Y.Z"' でタグ名 (v-prefix 付き) が注入されるため、
+ * citty の renderUsage が自動付加する "v" と重複して "vvX.Y.Z" になるのを防ぐ。
+ */
+
+/** normalizeVersion はバージョン文字列から先頭の v-prefix を除去して返す。 */
+export function normalizeVersion(version: string): string {
+  return version.replace(/^v/, "")
+}

--- a/tests/unit/cli/version.test.ts
+++ b/tests/unit/cli/version.test.ts
@@ -7,11 +7,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
-
-/** バージョン文字列から先頭の v-prefix を除去する (cli.ts で使用するロジックと同等)。 */
-function normalizeVersion(version: string): string {
-  return version.replace(/^v/, "")
-}
+import { normalizeVersion } from "@/infra/version"
 
 describe("normalizeVersion", () => {
   it("v-prefix 付きバージョンは prefix を除去して返す", () => {

--- a/tests/unit/cli/version.test.ts
+++ b/tests/unit/cli/version.test.ts
@@ -1,0 +1,31 @@
+/**
+ * version.test.ts — バージョン文字列の v-prefix 正規化ロジックのテスト。
+ *
+ * bun build --define 'VERSION="vX.Y.Z"' でタグ名 (v-prefix 付き) が注入されるため、
+ * defineCommand の meta.version に渡す前に v-prefix を除去する必要がある。
+ * citty の renderUsage が自動で "v" を付加するため、重複して "vvX.Y.Z" になるのを防ぐ。
+ */
+
+import { describe, expect, it } from "bun:test"
+
+/** バージョン文字列から先頭の v-prefix を除去する (cli.ts で使用するロジックと同等)。 */
+function normalizeVersion(version: string): string {
+  return version.replace(/^v/, "")
+}
+
+describe("normalizeVersion", () => {
+  it("v-prefix 付きバージョンは prefix を除去して返す", () => {
+    expect(normalizeVersion("v0.1.1")).toBe("0.1.1")
+    expect(normalizeVersion("v1.2.3")).toBe("1.2.3")
+    expect(normalizeVersion("v10.20.30")).toBe("10.20.30")
+  })
+
+  it("v-prefix なしバージョンはそのまま返す", () => {
+    expect(normalizeVersion("0.1.1")).toBe("0.1.1")
+    expect(normalizeVersion("1.2.3")).toBe("1.2.3")
+  })
+
+  it("空文字はそのまま返す", () => {
+    expect(normalizeVersion("")).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary

- `cos --help` のヘッダに `(cos vv0.1.1)` と v が重複して表示されていたバグを修正
- `defineCommand` の `meta.version` に渡す前に `VERSION.replace(/^v/, "")` で先頭の v を除去する

## Root Cause

`.github/workflows/release.yml` が `VERSION="${{ github.ref_name }}"` でタグ名 (`v0.1.1`) をそのまま注入する。citty の `renderUsage` は `${commandName} v${version}` 形式でヘッダを生成するため、v-prefix 付きの VERSION がそのまま渡ると `vv0.1.1` になっていた。

## Test plan

- [x] `bun test` — 652 pass, 16 skip, 0 fail
- [x] `bunx biome check src tests` — クリーン
- [x] `bun run typecheck` — エラーなし
- [x] `tests/unit/cli/version.test.ts` — v-prefix 除去ロジックを3ケース検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)