### PR TITLE
fix(auth,page): --no-input が citty の --no-X negation で無視されてハングする問題を修正 (#39)

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -9,6 +9,9 @@
  * - --browser と --no-input は同時指定不可 (exit 5、ブラウザログインは対話前提)
  * - --no-input 時は --sid が必須 (exit 5)
  *
+ * 実装上の注意: citty は --no-X を args.X = false に自動変換するため、
+ * args 定義は `input: { default: true }` とし、--no-input で input = false になることを利用する。
+ *
  * --browser フロー:
  * 1. Chrome/Chromium を CDP デバッグポートで起動する
  * 2. https://scrapbox.io/login を表示してユーザーにログインさせる
@@ -72,10 +75,11 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
         type: "string",
         description: "connect.sid の値 (--no-input 時に使用)",
       },
-      "no-input": {
+      input: {
         type: "boolean",
-        description: "対話入力を禁止 (CI/エージェント向け)",
-        default: false,
+        description:
+          "対話入力を許可 (デフォルト: true)。--no-input で禁止 (CI/エージェント向け、要 --sid)",
+        default: true,
       },
       browser: {
         type: "boolean",
@@ -100,7 +104,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
     async run({ args }) {
       type LoginArgs = CommonArgs & {
         sid?: string
-        "no-input": boolean
+        input: boolean
         browser: boolean
         "browser-path"?: string
         "browser-port": string
@@ -123,7 +127,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
       }
 
       // 排他チェック: --browser と --no-input
-      if (a.browser && a["no-input"]) {
+      if (a.browser && !a.input) {
         writeErrorJson(
           "BROWSER_REQUIRES_INPUT",
           "--browser フラグはブラウザでの手動ログインが必要なため --no-input と併用できません。",
@@ -215,7 +219,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
         }
       } else if (a.sid) {
         sid = a.sid
-      } else if (a["no-input"]) {
+      } else if (!a.input) {
         writeErrorJson("SID_REQUIRED", "--no-input モードでは --sid フラグが必要です")
         process.exit(5)
         return

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -3,6 +3,9 @@
  *
  * ページを削除する。--force なしの場合は確認プロンプトを表示する。
  * --no-input 時は --force が必須。
+ *
+ * 実装上の注意: citty は --no-X を args.X = false に自動変換するため、
+ * args 定義は `input: { default: true }` とし、--no-input で input = false になることを利用する。
  */
 
 import {
@@ -35,20 +38,21 @@ export const pageDeleteCommand = defineCommand({
       description: "確認プロンプトをスキップ",
       default: false,
     },
-    "no-input": {
+    input: {
       type: "boolean",
-      description: "対話入力を禁止 (CI/エージェント向け)",
-      default: false,
+      description:
+        "対話入力を許可 (デフォルト: true)。--no-input で禁止 (CI/エージェント向け、要 --force)",
+      default: true,
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & { title: string; force: boolean; "no-input": boolean }
+    const a = args as WriteCommonArgs & { title: string; force: boolean; input: boolean }
     checkSandbox("page.delete", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
-    if (!a.force && !a["no-input"] && !a["dry-run"]) {
+    if (!a.force && a.input && !a["dry-run"]) {
       // 対話確認 (--force または --no-input 未指定時)
       const { confirm } = await import("@clack/prompts")
       const yes = await confirm({
@@ -57,10 +61,12 @@ export const pageDeleteCommand = defineCommand({
       if (!yes) {
         logger.info("キャンセルしました")
         process.exit(0)
+        return
       }
-    } else if (!a.force && a["no-input"] && !a["dry-run"]) {
+    } else if (!a.force && !a.input && !a["dry-run"]) {
       writeErrorJson("CONFIRMATION_REQUIRED", "--no-input モードでは --force (-y) フラグが必要です")
       process.exit(5)
+      return
     }
 
     logger.info(`"${a.title}" を削除中...`)

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -10,6 +10,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn
 import { createAuthLoginCommand } from "@/commands/auth/login"
 import type { BrowserLoginDeps } from "@/core/auth/browser-login"
 import { InMemoryTokenStore } from "@/core/auth/store"
+import { runCommand } from "citty"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
@@ -106,7 +107,7 @@ describe("authLoginCommand — 排他チェック", () => {
     await runLogin({
       browser: true,
       sid: "何かのSID",
-      "no-input": false,
+      input: true,
       profile: "default",
       json: false,
       plain: false,
@@ -119,7 +120,7 @@ describe("authLoginCommand — 排他チェック", () => {
   it("--browser と --no-input を同時指定した場合は exit 5 で終了する", async () => {
     await runLogin({
       browser: true,
-      "no-input": true,
+      input: false,
       profile: "default",
       json: false,
       plain: false,
@@ -136,7 +137,7 @@ describe("authLoginCommand — --browser フロー", () => {
     await runLogin(
       {
         browser: true,
-        "no-input": false,
+        input: true,
         profile: "default",
         json: false,
         plain: false,
@@ -161,7 +162,7 @@ describe("authLoginCommand — --browser フロー", () => {
     await runLogin(
       {
         browser: true,
-        "no-input": false,
+        input: true,
         profile: "default",
         json: false,
         plain: false,
@@ -182,7 +183,7 @@ describe("authLoginCommand — --browser フロー", () => {
     await runLogin(
       {
         browser: true,
-        "no-input": false,
+        input: true,
         profile: "default",
         json: false,
         plain: false,
@@ -203,7 +204,7 @@ describe("authLoginCommand — --browser フロー", () => {
     await runLogin(
       {
         browser: true,
-        "no-input": false,
+        input: true,
         profile: "default",
         json: false,
         plain: false,
@@ -222,7 +223,7 @@ describe("authLoginCommand — --sid フロー (回帰)", () => {
   it("--sid 指定時は getMe で検証してログインする", async () => {
     await runLogin({
       sid: testSid,
-      "no-input": false,
+      input: true,
       browser: false,
       profile: "default",
       json: false,
@@ -239,7 +240,7 @@ describe("authLoginCommand — --sid フロー (回帰)", () => {
 
   it("--no-input かつ --sid 未指定の場合は exit 5 で終了する", async () => {
     await runLogin({
-      "no-input": true,
+      input: false,
       browser: false,
       profile: "default",
       json: false,
@@ -247,6 +248,15 @@ describe("authLoginCommand — --sid フロー (回帰)", () => {
       quiet: false,
       verbose: false,
     })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("rawArgs ['--no-input'] が citty parser を経由しても exit 5 で終了する (issue #39 回帰)", async () => {
+    // citty パーサは --no-X を args.X = false に変換する。
+    // このテストは CLI から実際に --no-input を渡した場合の経路を再現し、
+    // 修正前は対話プロンプトに突入してハングすることを確認するために追加した。
+    const command = createAuthLoginCommand({ createStore: () => new InMemoryTokenStore() })
+    await runCommand(command, { rawArgs: ["--no-input"] })
     expect(exitMock).toHaveBeenCalledWith(5)
   })
 })

--- a/tests/unit/commands/page/delete.test.ts
+++ b/tests/unit/commands/page/delete.test.ts
@@ -1,0 +1,61 @@
+/**
+ * delete.test.ts — `cos page delete` コマンドのユニットテスト。
+ *
+ * --no-input / --force 排他ロジックと citty パーサを通じた CLI 経路を検証する。
+ * 主に issue #39 (--no-input ハング) の回帰防止を目的とする。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageDeleteCommand } from "@/commands/page/delete"
+import { runCommand } from "citty"
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  // 環境変数を初期化
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+})
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("pageDeleteCommand — --no-input ガード (issue #39 回帰)", () => {
+  it("rawArgs ['テストページ', '--no-input'] が citty parser を経由しても exit 5 で終了する", async () => {
+    // citty パーサは --no-input を args.input = false に変換する (args["no-input"] は undefined)。
+    // 修正前は !a["no-input"] → true になるため対話 confirm() に突入してハングする。
+    // このテストはその経路を再現して回帰を防止する。
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    await runCommand(pageDeleteCommand, { rawArgs: ["テストページ", "--no-input"] })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("rawArgs ['テストページ', '--no-input', '--force', '--dry-run'] の場合は exit 5 で終了しない", async () => {
+    // --force と --no-input を同時指定した場合は確認をスキップして削除処理に進む。
+    // --dry-run でネットワーク接続を回避しつつ、exit 5 が呼ばれないことだけを検証する。
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    process.env["COS_SID"] = "s%3Adummy-sid"
+    await runCommand(pageDeleteCommand, {
+      rawArgs: ["テストページ", "--no-input", "--force", "--dry-run"],
+    })
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+})


### PR DESCRIPTION
## Summary

- citty が `--no-X` を `args.X = false` に変換する仕様のため、`args["no-input"]` が常に未設定となり対話プロンプト (`@clack/prompts.password()`) に突入してハングしていた
- `no-input` フラグ定義を `input: { type: 'boolean', default: true }` に変更し、citty の negation 慣習に従って `--no-input` → `args.input = false` で正しく動作するよう修正した
- `auth login` と `page delete` の同根バグを同時修正
- `page/delete.ts` の `process.exit()` 後に `return` が漏れていた問題も合わせて修正

## Root cause

`node_modules/citty/dist/index.mjs:170-175` にて:
```js
} else if (arg.substring(j, j + 3) === "no-") {
  name = arg.slice(Math.max(0, j + 3));  // "no-input" → "input"
  out[name] = false;                      // args.input = false
}
```
`--no-input` が `args.input = false` に変換されるため、`args["no-input"]` は `undefined`（デフォルト `false`）のまま。ガード条件 `a["no-input"]` が偽のため対話分岐へ突入してハング。

## Changed files

- `src/commands/auth/login.ts` — `"no-input"` フラグを `input: { default: true }` へ変更、ロジック修正
- `src/commands/page/delete.ts` — 同上、`process.exit()` 後の `return` 漏れも修正
- `tests/unit/commands/auth/login.test.ts` — args キーを `input:` へ更新 + citty parser 経路の回帰テスト追加
- `tests/unit/commands/page/delete.test.ts` — 新規作成（issue #39 回帰テスト）

## Test plan

- [ ] `bun test tests/unit/commands/auth/login.test.ts` — 全 9 件 pass
- [ ] `bun test tests/unit/commands/page/delete.test.ts` — 全 2 件 pass
- [ ] `bun test` — 全 693 件 pass
- [ ] `bunx biome check src tests` — エラーなし
- [ ] `bun run typecheck` — エラーなし
- [ ] `bun run dev auth login --no-input --json` → `{"error":{"code":"SID_REQUIRED",...}}` + exit 5

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 複数のコマンドで `--no-input` フラグの挙動を改善しました。
  * 非対話モードでのコマンド実行時の検証ロジックを強化しました。

* **Tests**
  * 非対話モード時の動作を検証する回帰テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->