### PR TITLE
fix(page/delete): non-TTY / COS_NO_INPUT=1 時にハングする問題を修正

### DIFF
--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -2,7 +2,10 @@
  * page/delete.ts — `cos page delete <title>` コマンド。
  *
  * ページを削除する。--force なしの場合は確認プロンプトを表示する。
- * --no-input 時は --force が必須。
+ * 以下のいずれかに該当する場合は非対話モードとみなし、--force が必須になる:
+ *   - --no-input フラグ指定
+ *   - stdin が TTY でない (CI / パイプ環境)
+ *   - 環境変数 COS_NO_INPUT=1
  *
  * 実装上の注意: citty は --no-X を args.X = false に自動変換するため、
  * args 定義は `input: { default: true }` とし、--no-input で input = false になることを利用する。
@@ -52,21 +55,31 @@ export const pageDeleteCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    if (!a.force && a.input && !a["dry-run"]) {
-      // 対話確認 (--force または --no-input 未指定時)
-      const { confirm } = await import("@clack/prompts")
-      const yes = await confirm({
-        message: `"${a.title}" を削除しますか？この操作は取り消せません。`,
-      })
-      if (!yes) {
-        logger.info("キャンセルしました")
-        process.exit(0)
+    // stdin が TTY かつ COS_NO_INPUT 未設定の場合のみ対話モードとする
+    const isInteractive = process.stdin.isTTY === true && !process.env["COS_NO_INPUT"]
+
+    if (!a.force && !a["dry-run"]) {
+      if (a.input && isInteractive) {
+        // 対話確認 (TTY 環境で --force / --no-input / COS_NO_INPUT が未指定の場合)
+        const { confirm } = await import("@clack/prompts")
+        const yes = await confirm({
+          message: `"${a.title}" を削除しますか？この操作は取り消せません。`,
+        })
+        if (!yes) {
+          logger.info("キャンセルしました")
+          process.exit(0)
+          return
+        }
+      } else {
+        // --no-input / non-TTY / COS_NO_INPUT=1 のいずれかの場合はエラー終了
+        writeErrorJson(
+          "CONFIRMATION_REQUIRED",
+          "非対話モードでは --force (-y) フラグが必要です",
+          "--no-input / non-TTY / COS_NO_INPUT=1 環境では --force を指定してください",
+        )
+        process.exit(5)
         return
       }
-    } else if (!a.force && !a.input && !a["dry-run"]) {
-      writeErrorJson("CONFIRMATION_REQUIRED", "--no-input モードでは --force (-y) フラグが必要です")
-      process.exit(5)
-      return
     }
 
     logger.info(`"${a.title}" を削除中...`)

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -55,8 +55,8 @@ export const pageDeleteCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // stdin が TTY かつ COS_NO_INPUT 未設定の場合のみ対話モードとする
-    const isInteractive = process.stdin.isTTY === true && !process.env["COS_NO_INPUT"]
+    // stdin が TTY かつ COS_NO_INPUT=1 未設定の場合のみ対話モードとする
+    const isInteractive = process.stdin.isTTY === true && process.env["COS_NO_INPUT"] !== "1"
 
     if (!a.force && !a["dry-run"]) {
       if (a.input && isInteractive) {

--- a/tests/unit/commands/page/delete.test.ts
+++ b/tests/unit/commands/page/delete.test.ts
@@ -2,7 +2,7 @@
  * delete.test.ts — `cos page delete` コマンドのユニットテスト。
  *
  * --no-input / --force 排他ロジックと citty パーサを通じた CLI 経路を検証する。
- * 主に issue #39 (--no-input ハング) の回帰防止を目的とする。
+ * issue #39 (--no-input ハング) および issue #40 (non-TTY / COS_NO_INPUT ハング) の回帰防止を目的とする。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -56,6 +56,69 @@ describe("pageDeleteCommand — --no-input ガード (issue #39 回帰)", () => 
     await runCommand(pageDeleteCommand, {
       rawArgs: ["テストページ", "--no-input", "--force", "--dry-run"],
     })
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+})
+
+describe("pageDeleteCommand — non-TTY / COS_NO_INPUT ガード (issue #40 回帰)", () => {
+  // テスト前後で isTTY と COS_NO_INPUT を退避・復元する
+  let originalIsTTY: boolean | undefined
+
+  beforeEach(() => {
+    originalIsTTY = process.stdin.isTTY
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+      writable: true,
+    })
+    Reflect.deleteProperty(process.env, "COS_NO_INPUT")
+  })
+
+  it("stdin が non-TTY の場合は --force なしで exit 5 で終了する", async () => {
+    // CI / パイプ環境では process.stdin.isTTY が undefined になる。
+    // この状態で --force を渡さずに実行すると対話 confirm() に突入してハングするため、
+    // 即エラー終了する必要がある。
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    await runCommand(pageDeleteCommand, { rawArgs: ["テストページ"] })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("COS_NO_INPUT=1 の場合は --force なしで exit 5 で終了する", async () => {
+    // COS_NO_INPUT 環境変数はエージェントが非対話モードを要求するために使用する。
+    // この場合も --force なしでは確認できないためエラー終了する。
+    process.env["COS_NO_INPUT"] = "1"
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    await runCommand(pageDeleteCommand, { rawArgs: ["テストページ"] })
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("stdin が non-TTY でも --force 指定時は exit 5 で終了しない", async () => {
+    // non-TTY 環境でも --force を明示すれば削除処理に進む。
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    process.env["COS_SID"] = "s%3Adummy-sid"
+    await runCommand(pageDeleteCommand, { rawArgs: ["テストページ", "--force", "--dry-run"] })
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+
+  it("COS_NO_INPUT=1 でも --force 指定時は exit 5 で終了しない", async () => {
+    // COS_NO_INPUT が設定されていても --force を明示すれば削除処理に進む。
+    process.env["COS_NO_INPUT"] = "1"
+    process.env["COS_PROJECT"] = "テストプロジェクト"
+    process.env["COS_SID"] = "s%3Adummy-sid"
+    await runCommand(pageDeleteCommand, { rawArgs: ["テストページ", "--force", "--dry-run"] })
     expect(exitMock).not.toHaveBeenCalledWith(5)
   })
 })

--- a/tests/unit/commands/page/delete.test.ts
+++ b/tests/unit/commands/page/delete.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_SID")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_NO_INPUT")
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

- `cos page delete` を CI・パイプ環境 (`process.stdin.isTTY !== true`) で `--force` なしに実行すると確認プロンプトでハングしていた
- 環境変数 `COS_NO_INPUT=1` 設定時も同様にハングしていた
- `isInteractive` フラグで TTY 判定と `COS_NO_INPUT` チェックを統合し、非対話モードでは `--force` なしの場合に即 exit 5 で終了するよう修正

## 変更内容

- `src/commands/page/delete.ts`: `isInteractive = process.stdin.isTTY === true && !process.env["COS_NO_INPUT"]` で対話可否を判定。非対話モードかつ `--force` 未指定時は `CONFIRMATION_REQUIRED` エラーで exit 5
- `tests/unit/commands/page/delete.test.ts`: non-TTY / `COS_NO_INPUT=1` の回帰テスト 4 件を追加。外側 `beforeEach` で `COS_NO_INPUT` も初期化してクロステスト汚染を防止

## Test plan

- [x] `bun test tests/unit/commands/page/delete.test.ts` — 全 6 件 pass
- [x] `bun test` — 全 681 件 pass
- [x] `bunx biome check src tests` — エラーなし
- [x] `bun run typecheck` — エラーなし

## CodeRabbit 指摘への対応

| 指摘 | 対応 |
|------|------|
| `delete.ts` の `process.exit()` 後の `return` を削除 | **スキップ**: テストで `process.exit` をモックしているため、`return` がないとモック後に削除処理へ続く (`_shared.ts:22-25` の同一パターン参照) |
| `beforeEach` で `COS_NO_INPUT` を初期化 | **対応済み**: 外側 `beforeEach` に追加 |

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ページ削除コマンドが非対話型環境でのハング問題を改善しました。TTYではない環境またはCOS_NO_INPUT環境変数が設定されている場合、`--force`フラグなしでは実行できなくなり、確認が必要なエラーが表示されます。

* **テスト**
  * 非対話型環境での動作に関する回帰テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->