### PR TITLE
fix(cli): ルートフラグをスペース区切りで渡すとサブコマンドと誤認識される問題を修正

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { setRootCommand } from "@/core/cli-root"
+import { normalizeRootStringFlags } from "@/infra/args"
 import {
   extractErrorMessage,
   extractStackTrace,
@@ -202,7 +203,9 @@ const main = defineCommand({
 // exactOptionalPropertyTypes のため具体的な args 型を CommandDef に広げてから渡す
 setRootCommand(main as unknown as import("citty").CommandDef)
 
-const rawArgs = process.argv.slice(2)
+// citty がスペース区切りの string フラグ値をサブコマンドと誤認識する問題を回避する
+const ROOT_STRING_FLAGS = ["color", "enable-commands", "disable-commands"]
+const rawArgs = normalizeRootStringFlags(process.argv.slice(2), ROOT_STRING_FLAGS)
 const showUsageFn = createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos")
 
 // --help / -h: citty の showUsage を呼んで exit 0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { setRootCommand } from "@/core/cli-root"
-import { normalizeRootStringFlags } from "@/infra/args"
+import { ROOT_STRING_FLAGS, normalizeRootStringFlags } from "@/infra/args"
 import {
   extractErrorMessage,
   extractStackTrace,
@@ -204,7 +204,6 @@ const main = defineCommand({
 setRootCommand(main as unknown as import("citty").CommandDef)
 
 // citty がスペース区切りの string フラグ値をサブコマンドと誤認識する問題を回避する
-const ROOT_STRING_FLAGS = ["color", "enable-commands", "disable-commands"]
 const rawArgs = normalizeRootStringFlags(process.argv.slice(2), ROOT_STRING_FLAGS)
 const showUsageFn = createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos")
 

--- a/src/infra/args.ts
+++ b/src/infra/args.ts
@@ -8,6 +8,14 @@
  */
 
 /**
+ * ROOT_STRING_FLAGS はルートコマンドが定義する string 型フラグ名の一覧。
+ *
+ * ルートコマンド (src/cli.ts) に新しい string 型フラグを追加した場合は、
+ * この定数も同時に更新すること。
+ */
+export const ROOT_STRING_FLAGS = ["color", "enable-commands", "disable-commands"]
+
+/**
  * normalizeRootStringFlags は `--flag value` 形式の string フラグを
  * `--flag=value` 形式に正規化した新しい配列を返す。
  *

--- a/src/infra/args.ts
+++ b/src/infra/args.ts
@@ -1,0 +1,41 @@
+/**
+ * args.ts — CLI 引数のプリプロセスユーティリティ。
+ *
+ * citty はルートレベルの string 型フラグをスペース区切りで受け取ると
+ * 次トークンをサブコマンド候補として誤認識する。
+ * normalizeRootStringFlags は渡した rawArgs を走査し、
+ * `--flag value` 形式を `--flag=value` 形式に変換することでこの問題を回避する。
+ */
+
+/**
+ * normalizeRootStringFlags は `--flag value` 形式の string フラグを
+ * `--flag=value` 形式に正規化した新しい配列を返す。
+ *
+ * @param args - process.argv.slice(2) 等の生の引数配列
+ * @param stringFlags - 変換対象のフラグ名一覧 (先頭の -- を除いた形式: "color", "enable-commands" 等)
+ * @returns 正規化後の引数配列
+ */
+export function normalizeRootStringFlags(args: string[], stringFlags: string[]): string[] {
+  // 高速な O(1) 探索のため Set に変換する
+  const flagNames = new Set(stringFlags.map((f) => `--${f}`))
+  const result: string[] = []
+  let i = 0
+
+  while (i < args.length) {
+    const arg = args[i]
+    // noUncheckedIndexedAccess: i < args.length で存在が保証されているが型上は undefined になり得る
+    if (arg === undefined) break
+    const nextArg = args[i + 1]
+
+    // `--flag` 形式 (= を含まない) かつ次トークンが存在し、- で始まらない場合のみ変換する
+    if (flagNames.has(arg) && nextArg !== undefined && !nextArg.startsWith("-")) {
+      result.push(`${arg}=${nextArg}`)
+      i += 2
+    } else {
+      result.push(arg)
+      i++
+    }
+  }
+
+  return result
+}

--- a/src/infra/args.ts
+++ b/src/infra/args.ts
@@ -33,6 +33,13 @@ export function normalizeRootStringFlags(args: string[], stringFlags: string[]):
     const arg = args[i]
     // noUncheckedIndexedAccess: i < args.length で存在が保証されているが型上は undefined になり得る
     if (arg === undefined) break
+
+    // `--` セパレーター以降はすべてそのまま残してループを終了する (POSIX 準拠)
+    if (arg === "--") {
+      result.push(...args.slice(i))
+      break
+    }
+
     const nextArg = args[i + 1]
 
     // `--flag` 形式 (= を含まない) かつ次トークンが存在し、- で始まらない場合のみ変換する

--- a/tests/unit/cli/args.test.ts
+++ b/tests/unit/cli/args.test.ts
@@ -95,13 +95,27 @@ describe("normalizeRootStringFlags", () => {
       expect(result).toEqual(["--color", "--json", "auth", "whoami"])
     })
 
-    it("-- セパレーター以降のトークンは干渉しない", () => {
+    it("-- セパレーター前のフラグは変換し、-- 以降はそのまま維持する", () => {
       // --color never は変換し、-- 以降はそのまま維持する
       const result = normalizeRootStringFlags(
         ["--color", "never", "--", "--json"],
         ROOT_STRING_FLAGS,
       )
       expect(result).toEqual(["--color=never", "--", "--json"])
+    })
+
+    it("-- セパレーター後に ROOT_STRING_FLAGS と同名トークンが来ても変換しない", () => {
+      // POSIX: -- 以降はすべてフラグではなく位置引数として扱う
+      const result = normalizeRootStringFlags(["--", "--color", "never"], ROOT_STRING_FLAGS)
+      expect(result).toEqual(["--", "--color", "never"])
+    })
+
+    it("-- セパレーター後の --enable-commands も変換しない", () => {
+      const result = normalizeRootStringFlags(
+        ["--", "--enable-commands", "page.list"],
+        ROOT_STRING_FLAGS,
+      )
+      expect(result).toEqual(["--", "--enable-commands", "page.list"])
     })
   })
 

--- a/tests/unit/cli/args.test.ts
+++ b/tests/unit/cli/args.test.ts
@@ -6,21 +6,22 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { normalizeRootStringFlags } from "@/infra/args"
+import { ROOT_STRING_FLAGS, normalizeRootStringFlags } from "@/infra/args"
 
 describe("normalizeRootStringFlags", () => {
-  const STRING_FLAGS = ["color", "enable-commands", "disable-commands"]
-
   describe("スペース区切りの値を = 形式に変換する", () => {
     it("--color never auth whoami → --color=never auth whoami", () => {
-      const result = normalizeRootStringFlags(["--color", "never", "auth", "whoami"], STRING_FLAGS)
+      const result = normalizeRootStringFlags(
+        ["--color", "never", "auth", "whoami"],
+        ROOT_STRING_FLAGS,
+      )
       expect(result).toEqual(["--color=never", "auth", "whoami"])
     })
 
     it("--enable-commands page.list page list → --enable-commands=page.list page list", () => {
       const result = normalizeRootStringFlags(
         ["--enable-commands", "page.list", "page", "list"],
-        STRING_FLAGS,
+        ROOT_STRING_FLAGS,
       )
       expect(result).toEqual(["--enable-commands=page.list", "page", "list"])
     })
@@ -28,7 +29,7 @@ describe("normalizeRootStringFlags", () => {
     it("--disable-commands page.delete page delete → --disable-commands=page.delete page delete", () => {
       const result = normalizeRootStringFlags(
         ["--disable-commands", "page.delete", "page", "delete", "-p", "sandbox", "タイトル"],
-        STRING_FLAGS,
+        ROOT_STRING_FLAGS,
       )
       expect(result).toEqual([
         "--disable-commands=page.delete",
@@ -43,22 +44,43 @@ describe("normalizeRootStringFlags", () => {
     it("複数の string フラグが連続する場合も正しく変換する", () => {
       const result = normalizeRootStringFlags(
         ["--enable-commands", "page.list", "--color", "never", "page", "list"],
-        STRING_FLAGS,
+        ROOT_STRING_FLAGS,
       )
       expect(result).toEqual(["--enable-commands=page.list", "--color=never", "page", "list"])
+    })
+
+    it("値に空白を含む場合 (シェルがクォート処理した結果) も変換する", () => {
+      // シェルの `--color "never ever"` は ["--color", "never ever"] として届く
+      const result = normalizeRootStringFlags(
+        ["--color", "never ever", "auth", "whoami"],
+        ROOT_STRING_FLAGS,
+      )
+      expect(result).toEqual(["--color=never ever", "auth", "whoami"])
+    })
+
+    it("値に = を含む場合も先頭の = のみを区切りとして変換する", () => {
+      // --enable-commands=page.get=extra は "--enable-commands=page.get=extra" 形式になる
+      const result = normalizeRootStringFlags(
+        ["--enable-commands", "page.get=extra", "page", "get"],
+        ROOT_STRING_FLAGS,
+      )
+      expect(result).toEqual(["--enable-commands=page.get=extra", "page", "get"])
     })
   })
 
   describe("すでに = 形式のフラグは変換しない", () => {
     it("--color=never は変更しない", () => {
-      const result = normalizeRootStringFlags(["--color=never", "auth", "whoami"], STRING_FLAGS)
+      const result = normalizeRootStringFlags(
+        ["--color=never", "auth", "whoami"],
+        ROOT_STRING_FLAGS,
+      )
       expect(result).toEqual(["--color=never", "auth", "whoami"])
     })
 
     it("--enable-commands=page.list は変更しない", () => {
       const result = normalizeRootStringFlags(
         ["--enable-commands=page.list", "page", "list"],
-        STRING_FLAGS,
+        ROOT_STRING_FLAGS,
       )
       expect(result).toEqual(["--enable-commands=page.list", "page", "list"])
     })
@@ -66,36 +88,48 @@ describe("normalizeRootStringFlags", () => {
 
   describe("次トークンが - で始まる場合は値として消費しない", () => {
     it("--color --json のように次が別フラグならそのまま残す", () => {
-      const result = normalizeRootStringFlags(["--color", "--json", "auth", "whoami"], STRING_FLAGS)
+      const result = normalizeRootStringFlags(
+        ["--color", "--json", "auth", "whoami"],
+        ROOT_STRING_FLAGS,
+      )
       expect(result).toEqual(["--color", "--json", "auth", "whoami"])
+    })
+
+    it("-- セパレーター以降のトークンは干渉しない", () => {
+      // --color never は変換し、-- 以降はそのまま維持する
+      const result = normalizeRootStringFlags(
+        ["--color", "never", "--", "--json"],
+        ROOT_STRING_FLAGS,
+      )
+      expect(result).toEqual(["--color=never", "--", "--json"])
     })
   })
 
   describe("フラグが末尾で値がない場合は変換しない", () => {
     it("--color のみ (次トークンなし) はそのまま残す", () => {
-      const result = normalizeRootStringFlags(["--color"], STRING_FLAGS)
+      const result = normalizeRootStringFlags(["--color"], ROOT_STRING_FLAGS)
       expect(result).toEqual(["--color"])
     })
   })
 
   describe("string フラグが含まれない場合は変換しない", () => {
     it("auth whoami はそのまま", () => {
-      const result = normalizeRootStringFlags(["auth", "whoami"], STRING_FLAGS)
+      const result = normalizeRootStringFlags(["auth", "whoami"], ROOT_STRING_FLAGS)
       expect(result).toEqual(["auth", "whoami"])
     })
 
     it("空配列はそのまま", () => {
-      const result = normalizeRootStringFlags([], STRING_FLAGS)
+      const result = normalizeRootStringFlags([], ROOT_STRING_FLAGS)
       expect(result).toEqual([])
     })
   })
 
   describe("指定した stringFlags にないフラグは変換しない", () => {
     it("--project はリストにないのでスペース区切りのまま残す", () => {
-      // --project は各サブコマンドで定義されており root string flags に含まない
+      // --project は各サブコマンドで定義されており ROOT_STRING_FLAGS に含まない
       const result = normalizeRootStringFlags(
         ["--project", "sandbox", "page", "list"],
-        STRING_FLAGS,
+        ROOT_STRING_FLAGS,
       )
       expect(result).toEqual(["--project", "sandbox", "page", "list"])
     })

--- a/tests/unit/cli/args.test.ts
+++ b/tests/unit/cli/args.test.ts
@@ -1,0 +1,103 @@
+/**
+ * args.test.ts — normalizeRootStringFlags のユニットテスト。
+ *
+ * citty がスペース区切りの string 型フラグ値をサブコマンドと誤認識する問題を
+ * プリプロセスで回避する関数の動作を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { normalizeRootStringFlags } from "@/infra/args"
+
+describe("normalizeRootStringFlags", () => {
+  const STRING_FLAGS = ["color", "enable-commands", "disable-commands"]
+
+  describe("スペース区切りの値を = 形式に変換する", () => {
+    it("--color never auth whoami → --color=never auth whoami", () => {
+      const result = normalizeRootStringFlags(["--color", "never", "auth", "whoami"], STRING_FLAGS)
+      expect(result).toEqual(["--color=never", "auth", "whoami"])
+    })
+
+    it("--enable-commands page.list page list → --enable-commands=page.list page list", () => {
+      const result = normalizeRootStringFlags(
+        ["--enable-commands", "page.list", "page", "list"],
+        STRING_FLAGS,
+      )
+      expect(result).toEqual(["--enable-commands=page.list", "page", "list"])
+    })
+
+    it("--disable-commands page.delete page delete → --disable-commands=page.delete page delete", () => {
+      const result = normalizeRootStringFlags(
+        ["--disable-commands", "page.delete", "page", "delete", "-p", "sandbox", "タイトル"],
+        STRING_FLAGS,
+      )
+      expect(result).toEqual([
+        "--disable-commands=page.delete",
+        "page",
+        "delete",
+        "-p",
+        "sandbox",
+        "タイトル",
+      ])
+    })
+
+    it("複数の string フラグが連続する場合も正しく変換する", () => {
+      const result = normalizeRootStringFlags(
+        ["--enable-commands", "page.list", "--color", "never", "page", "list"],
+        STRING_FLAGS,
+      )
+      expect(result).toEqual(["--enable-commands=page.list", "--color=never", "page", "list"])
+    })
+  })
+
+  describe("すでに = 形式のフラグは変換しない", () => {
+    it("--color=never は変更しない", () => {
+      const result = normalizeRootStringFlags(["--color=never", "auth", "whoami"], STRING_FLAGS)
+      expect(result).toEqual(["--color=never", "auth", "whoami"])
+    })
+
+    it("--enable-commands=page.list は変更しない", () => {
+      const result = normalizeRootStringFlags(
+        ["--enable-commands=page.list", "page", "list"],
+        STRING_FLAGS,
+      )
+      expect(result).toEqual(["--enable-commands=page.list", "page", "list"])
+    })
+  })
+
+  describe("次トークンが - で始まる場合は値として消費しない", () => {
+    it("--color --json のように次が別フラグならそのまま残す", () => {
+      const result = normalizeRootStringFlags(["--color", "--json", "auth", "whoami"], STRING_FLAGS)
+      expect(result).toEqual(["--color", "--json", "auth", "whoami"])
+    })
+  })
+
+  describe("フラグが末尾で値がない場合は変換しない", () => {
+    it("--color のみ (次トークンなし) はそのまま残す", () => {
+      const result = normalizeRootStringFlags(["--color"], STRING_FLAGS)
+      expect(result).toEqual(["--color"])
+    })
+  })
+
+  describe("string フラグが含まれない場合は変換しない", () => {
+    it("auth whoami はそのまま", () => {
+      const result = normalizeRootStringFlags(["auth", "whoami"], STRING_FLAGS)
+      expect(result).toEqual(["auth", "whoami"])
+    })
+
+    it("空配列はそのまま", () => {
+      const result = normalizeRootStringFlags([], STRING_FLAGS)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("指定した stringFlags にないフラグは変換しない", () => {
+    it("--project はリストにないのでスペース区切りのまま残す", () => {
+      // --project は各サブコマンドで定義されており root string flags に含まない
+      const result = normalizeRootStringFlags(
+        ["--project", "sandbox", "page", "list"],
+        STRING_FLAGS,
+      )
+      expect(result).toEqual(["--project", "sandbox", "page", "list"])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `cos --color never auth whoami` のように string 型ルートフラグをスペース区切りで渡すと、値のトークンがサブコマンドとして誤認識される問題を修正
- `rawArgs` を `runCommand` に渡す前にプリプロセスし、`--flag value` 形式を `--flag=value` 形式に変換する `normalizeRootStringFlags` を `src/infra/args.ts` に追加
- 対象フラグ: `--color`, `--enable-commands`, `--disable-commands`

## 変更内容

- `src/infra/args.ts` (新規): `normalizeRootStringFlags` と `ROOT_STRING_FLAGS` の実装
- `src/cli.ts`: プリプロセス処理を組み込み
- `tests/unit/cli/args.test.ts` (新規): 14 件のユニットテスト

## Test plan

- [x] `bun test` — 695 pass / 0 fail
- [x] `bunx biome check` — エラーなし
- [x] `bun run typecheck` — エラーなし

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI引数の処理を改善し、スペース区切りで指定される文字列フラグの値が誤ってサブコマンドとして扱われる問題を解消しました。

* **Tests**
  * CLI引数の正規化動作を対象とした包括的なユニットテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/50)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->