### PR TITLE
fix(page/new): --line を複数指定するとクラッシュする問題を修正

### DIFF
--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -60,10 +60,11 @@ export const pageNewCommand = defineCommand({
     } else if (a["from-file"]) {
       const content = readFileSync(a["from-file"], "utf-8")
       lines = content.split("\n")
-    } else if (a.line) {
+    } else if (a.line !== undefined) {
       // citty は --line を複数回渡すと配列になるため、string と string[] の両方に対応する
+      // 実改行（\n, \r\n）とエスケープシーケンス（\\n）の両方を展開する
       const lineValues = Array.isArray(a.line) ? a.line : [a.line]
-      lines = lineValues.flatMap((l) => l.split("\\n"))
+      lines = lineValues.flatMap((l) => l.split(/\r?\n|\\n/))
     }
 
     if (lines.length === 0) {

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -36,11 +36,17 @@ export const pageNewCommand = defineCommand({
     },
     line: {
       type: "string",
-      description: "追加する行テキスト (複数行は \\n で区切る)",
+      description:
+        "追加する行テキスト。複数行は \\n で区切るか、--line を複数回指定する (例: --line 行1 --line 行2)",
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & { title: string; "from-file"?: string; line?: string }
+    const a = args as WriteCommonArgs & {
+      title: string
+      "from-file"?: string
+      /** citty が --line を複数回受け取ると string[] になる */
+      line?: string | string[]
+    }
     checkSandbox("page.new", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
@@ -55,7 +61,9 @@ export const pageNewCommand = defineCommand({
       const content = readFileSync(a["from-file"], "utf-8")
       lines = content.split("\n")
     } else if (a.line) {
-      lines = a.line.split("\\n")
+      // citty は --line を複数回渡すと配列になるため、string と string[] の両方に対応する
+      const lineValues = Array.isArray(a.line) ? a.line : [a.line]
+      lines = lineValues.flatMap((l) => l.split("\\n"))
     }
 
     if (lines.length === 0) {

--- a/tests/unit/commands/page/new.test.ts
+++ b/tests/unit/commands/page/new.test.ts
@@ -144,6 +144,22 @@ describe("pageNewCommand", () => {
     expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2", "行3"])
   })
 
+  it("--line 配列要素内の実改行も展開される", async () => {
+    await runNew({
+      title: "テストページ",
+      line: ["行1\n行2", "行3"],
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // 配列要素内の実改行（\n）も分割されること
+    expect(capturedCreatePageCalls).toHaveLength(1)
+    expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2", "行3"])
+  })
+
   it("--dry-run 時は success メッセージが stderr に出力されない", async () => {
     await runNew({
       title: "テストページ",

--- a/tests/unit/commands/page/new.test.ts
+++ b/tests/unit/commands/page/new.test.ts
@@ -1,7 +1,7 @@
 /**
  * page/new.test.ts — `cos page new <title>` コマンドのテスト。
  *
- * --line の \n 展開と --dry-run 時の success メッセージ抑制を検証する。
+ * --line の \n 展開、--line 複数指定、--dry-run 時の success メッセージ抑制を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
@@ -110,6 +110,38 @@ describe("pageNewCommand", () => {
     // createPage が呼ばれ、lines が ["行1", "行2"] に分割されること
     expect(capturedCreatePageCalls).toHaveLength(1)
     expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2"])
+  })
+
+  it("--line を配列で複数指定した場合は createPage に複数行で渡される", async () => {
+    await runNew({
+      title: "テストページ",
+      line: ["行1", "行2", "行3"],
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // --line を複数回渡すと citty が配列にするため、lines に全要素が渡されること
+    expect(capturedCreatePageCalls).toHaveLength(1)
+    expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2", "行3"])
+  })
+
+  it("--line を配列で渡した場合も \\n 区切りが展開される", async () => {
+    await runNew({
+      title: "テストページ",
+      line: ["行1\\n行2", "行3"],
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // 配列内の各要素も \n で分割されること
+    expect(capturedCreatePageCalls).toHaveLength(1)
+    expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2", "行3"])
   })
 
   it("--dry-run 時は success メッセージが stderr に出力されない", async () => {


### PR DESCRIPTION
## 問題

`cos page new` で `--line` フラグを複数回渡すと以下のエラーが発生していた。

```
{ "error": { "code": "ERROR", "message": "undefined is not an object (evaluating '(isString(text) ? text : text.text).split')" } }
```

**再現コマンド:**
```bash
cos page new -p sandbox "タイトル" --line "行1" --line "行2" --json
```

## 原因

citty は同一フラグを複数回指定すると `string[]` に変換するが、`src/commands/page/new.ts` の実装が `string` 単体のみを想定していた (`a.line.split("\\n")`)。配列が渡された場合に `split` が undefined になりクラッシュしていた。

## 修正内容

- `line` の型を `string | string[]` に変更
- `Array.isArray` で判定し、どちらの場合も `\\n` 区切りを展開して結合する
- `--line` ヘルプに複数回指定の例を追記

## テスト

以下の2ケースを追加:
- `--line` を配列で複数指定した場合に `createPage` に全行が渡される
- 配列内の各要素でも `\\n` 区切りが展開される

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ページ作成時の `--line` オプションが複数回指定に対応しました。
  * `--line` 内の実際の改行やエスケープされた `\n` を展開して複数行として扱うようになり、本文入力の柔軟性が向上しました。
* **テスト**
  * 上記の改行展開や複数指定、`--dry-run` 時の出力抑制を確認する単体テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->