### PR TITLE
feat(schema): スキーマ出力に位置引数情報を追加

### DIFF
--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -14,6 +14,8 @@ export interface SchemaArg {
   name: string
   /** フラグ型 */
   type: "string" | "boolean" | "positional"
+  /** 位置引数かどうか（type === "positional" のとき true） */
+  positional: boolean
   /** フラグ説明 */
   description?: string
   /** alias リスト（string | string[] を string[] に正規化済み） */
@@ -95,9 +97,12 @@ async function buildArgsSchema(cmd: CommandDef): Promise<SchemaArg[]> {
           valueHint?: string
         }>,
       )
+      // type が "positional" の場合は positional フラグを true に設定する
+      const argType = (resolved?.type ?? "string") as SchemaArg["type"]
       const schemaArg: SchemaArg = {
         name,
-        type: (resolved?.type ?? "string") as SchemaArg["type"],
+        type: argType,
+        positional: argType === "positional",
         alias: normalizeAlias(resolved?.alias),
       }
       if (resolved?.description !== undefined) schemaArg.description = resolved.description

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -64,6 +64,20 @@ interface ParsedGroupKey {
  * groupKey のフォーマット変更に対して堅牢になるよう正規表現で検証する。
  * 不正なフォーマットの場合は aliasKeys を空配列として安全にフォールバックする。
  */
+/** 許可された引数型のセット */
+const VALID_ARG_TYPES = new Set<SchemaArg["type"]>(["string", "boolean", "positional"])
+
+/**
+ * normalizeArgType は citty の arg type 文字列を SchemaArg["type"] に正規化する。
+ * 未知の値（例: "enum"）は安全なデフォルト "string" にフォールバックする。
+ */
+function normalizeArgType(type: string | undefined): SchemaArg["type"] {
+  if (type !== undefined && VALID_ARG_TYPES.has(type as SchemaArg["type"])) {
+    return type as SchemaArg["type"]
+  }
+  return "string"
+}
+
 function parseGroupKey(groupKey: string): ParsedGroupKey {
   const match = /^(.+?) \((.+)\)$/.exec(groupKey)
   if (!match) {
@@ -97,8 +111,8 @@ async function buildArgsSchema(cmd: CommandDef): Promise<SchemaArg[]> {
           valueHint?: string
         }>,
       )
-      // type が "positional" の場合は positional フラグを true に設定する
-      const argType = (resolved?.type ?? "string") as SchemaArg["type"]
+      // 不正な type 値が混入しないよう normalizeArgType で検証・正規化する
+      const argType = normalizeArgType(resolved?.type)
       const isPositional = argType === "positional"
       // required は常に boolean で出力する。未指定の場合は位置引数なら true、フラグなら false
       const schemaArg: SchemaArg = {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -8,22 +8,22 @@
 import { groupSubCommandsByAlias, resolveValue } from "@/infra/help"
 import type { ArgsDef, CommandDef, Resolvable } from "citty"
 
-/** SchemaArg はコマンドフラグ 1 個のスキーマ表現。 */
+/** SchemaArg はコマンド引数（フラグ・位置引数）1 個のスキーマ表現。 */
 export interface SchemaArg {
-  /** フラグ名 */
+  /** 引数名 */
   name: string
-  /** フラグ型 */
+  /** 引数型 */
   type: "string" | "boolean" | "positional"
   /** 位置引数かどうか（type === "positional" のとき true） */
   positional: boolean
-  /** フラグ説明 */
+  /** 引数の説明 */
   description?: string
   /** alias リスト（string | string[] を string[] に正規化済み） */
   alias: string[]
   /** デフォルト値 */
   default?: string | boolean
-  /** 必須フラグかどうか */
-  required?: boolean
+  /** 必須かどうか（位置引数はデフォルト true、フラグはデフォルト false） */
+  required: boolean
   /** 値のヒント文字列 */
   valueHint?: string
 }
@@ -99,15 +99,17 @@ async function buildArgsSchema(cmd: CommandDef): Promise<SchemaArg[]> {
       )
       // type が "positional" の場合は positional フラグを true に設定する
       const argType = (resolved?.type ?? "string") as SchemaArg["type"]
+      const isPositional = argType === "positional"
+      // required は常に boolean で出力する。未指定の場合は位置引数なら true、フラグなら false
       const schemaArg: SchemaArg = {
         name,
         type: argType,
-        positional: argType === "positional",
+        positional: isPositional,
+        required: resolved?.required ?? isPositional,
         alias: normalizeAlias(resolved?.alias),
       }
       if (resolved?.description !== undefined) schemaArg.description = resolved.description
       if (resolved?.default !== undefined) schemaArg.default = resolved.default
-      if (resolved?.required !== undefined) schemaArg.required = resolved.required
       if (resolved?.valueHint !== undefined) schemaArg.valueHint = resolved.valueHint
       return schemaArg
     }),

--- a/tests/unit/core/schema.test.ts
+++ b/tests/unit/core/schema.test.ts
@@ -118,6 +118,24 @@ describe("buildSchema", () => {
     expect(titleArg?.alias).toEqual([])
   })
 
+  it("positional 型の args には positional: true が付与される", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const newCmd = pageCmd?.subCommands.find((c) => c.name === "new")
+    const titleArg = newCmd?.args.find((a) => a.name === "title")
+    // positional フィールドが true であること
+    expect(titleArg?.positional).toBe(true)
+  })
+
+  it("非 positional な args には positional: false が付与される", async () => {
+    const schema = await buildSchema(rootCommand, "cos")
+    const pageCmd = schema.subCommands.find((c) => c.name === "page")
+    const listCmd = pageCmd?.subCommands.find((c) => c.name === "list")
+    const projectArg = listCmd?.args.find((a) => a.name === "project")
+    // フラグ引数は positional が false であること
+    expect(projectArg?.positional).toBe(false)
+  })
+
   it("Resolvable<T> が関数の場合でも解決される", async () => {
     const lazyCommand: CommandDef = {
       meta: () => ({ name: "lazy", description: "遅延解決テスト" }),

--- a/tests/unit/core/schema.test.ts
+++ b/tests/unit/core/schema.test.ts
@@ -125,6 +125,8 @@ describe("buildSchema", () => {
     const titleArg = newCmd?.args.find((a) => a.name === "title")
     // positional フィールドが true であること
     expect(titleArg?.positional).toBe(true)
+    // 位置引数は required が true であること
+    expect(titleArg?.required).toBe(true)
   })
 
   it("非 positional な args には positional: false が付与される", async () => {
@@ -134,6 +136,8 @@ describe("buildSchema", () => {
     const projectArg = listCmd?.args.find((a) => a.name === "project")
     // フラグ引数は positional が false であること
     expect(projectArg?.positional).toBe(false)
+    // フラグ引数は required が false であること
+    expect(projectArg?.required).toBe(false)
   })
 
   it("Resolvable<T> が関数の場合でも解決される", async () => {


### PR DESCRIPTION
## Summary

- `SchemaArg` インターフェースに `positional: boolean` フィールドを追加
- `type === "positional"` のとき `positional: true`、それ以外は `positional: false` を出力
- エージェントが `cos schema --json` を参照することで、位置引数とフラグを明確に区別できるようになる

## 変更ファイル

- `src/core/schema.ts`: `SchemaArg` インターフェースと `buildArgsSchema` 関数を更新
- `tests/unit/core/schema.test.ts`: `positional` フィールドの検証テストを2件追加

## 動作確認

`cos schema page new --json` の出力例（変更後）:

```json
{
  "name": "new",
  "args": [
    {
      "name": "title",
      "type": "positional",
      "positional": true,
      "description": "ページタイトル",
      "alias": [],
      "required": true
    }
  ]
}
```

## Test plan

- [x] `bun test tests/unit/core/schema.test.ts` — 19件全パス
- [x] `bun test` — 699件全パス（16件スキップ）
- [x] `bunx biome check src tests` — 警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 引数スキーマに「位置引数」を明示するフラグが追加され、必須/任意の扱いが明確化されました。位置引数は自動的に必須扱いとなるなど、引数の位置性と必須性の判定が安定します。

* **テスト**
  * 位置引数とフラグのメタデータ（位置性・必須性）を検証するテストが追加されました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/52)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->