### PR TITLE
fix(page/text): --format=scrapbox を txt の alias として受け付ける

### DIFF
--- a/src/commands/page/text.ts
+++ b/src/commands/page/text.ts
@@ -3,6 +3,7 @@
  *
  * ページのプレーンテキスト本文を取得して stdout に出力する。
  * --format=md を指定すると Scrapbox 記法を Markdown に変換して出力する。
+ * --format=scrapbox は --format=txt の alias として扱う。
  * パイプや他ツールとの連携に使う。
  */
 
@@ -21,6 +22,12 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 const VALID_FORMATS = ["txt", "md"] as const
+
+/** scrapbox は txt の alias として受け付けるフォーマット値の対応表 */
+const FORMAT_ALIASES: Record<string, (typeof VALID_FORMATS)[number]> = {
+  scrapbox: "txt",
+}
+
 const VALID_BOLD_STYLES = ["auto", "heading", "emphasis"] as const
 
 export const pageTextCommand = defineCommand({
@@ -34,7 +41,7 @@ export const pageTextCommand = defineCommand({
     },
     format: {
       type: "string",
-      description: "出力フォーマット (txt | md)",
+      description: "出力フォーマット (txt | md | scrapbox)。scrapbox は txt の alias",
       default: "txt",
     },
     "bold-style": {
@@ -51,12 +58,15 @@ export const pageTextCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
+    // alias を正規値に変換する (例: scrapbox → txt)
+    const resolvedFormat = FORMAT_ALIASES[a.format] ?? a.format
+
     // --format バリデーション
-    if (!(VALID_FORMATS as readonly string[]).includes(a.format)) {
+    if (!(VALID_FORMATS as readonly string[]).includes(resolvedFormat)) {
       writeErrorJson(
         "VALIDATION_ERROR",
         `--format=${a.format} は無効な値です`,
-        `有効な値: ${VALID_FORMATS.join(", ")}`,
+        `有効な値: ${VALID_FORMATS.join(", ")}, scrapbox (txt の alias)`,
       )
       process.exit(5)
     }
@@ -77,7 +87,7 @@ export const pageTextCommand = defineCommand({
     const rawText = await getPageText(client, { project, title: a.title })
 
     const outputText =
-      a.format === "md"
+      resolvedFormat === "md"
         ? convert(rawText, "scrapbox", "md", { boldStyle: a["bold-style"] as BoldStyle })
         : rawText
 

--- a/tests/unit/commands/page/text.test.ts
+++ b/tests/unit/commands/page/text.test.ts
@@ -185,24 +185,4 @@ describe("pageTextCommand", () => {
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).toContain("[*** 大見出し]")
   })
-
-  it("--format=scrapbox は VALIDATION_ERROR にならない", async () => {
-    // scrapbox は alias として有効な値であることを検証する
-    try {
-      await runText({
-        title: TEST_TITLE,
-        project: TEST_PROJECT,
-        format: "scrapbox",
-        "bold-style": "auto",
-        json: false,
-        plain: false,
-        "results-only": false,
-        quiet: false,
-      })
-    } catch {
-      // REST クライアント初期化中の throw は想定内
-    }
-    expect(exitMock).not.toHaveBeenCalled()
-    expect(stdoutMock).not.toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
-  })
 })

--- a/tests/unit/commands/page/text.test.ts
+++ b/tests/unit/commands/page/text.test.ts
@@ -162,4 +162,47 @@ describe("pageTextCommand", () => {
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).toContain("[*** 大見出し]")
   })
+
+  it("--format=scrapbox のとき txt と同じ Scrapbox テキストそのまま出力される", async () => {
+    // scrapbox は txt の alias として機能することを検証する
+    try {
+      await runText({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        format: "scrapbox",
+        "bold-style": "auto",
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    // exit が呼ばれていないことを確認 (VALIDATION_ERROR ではない)
+    expect(exitMock).not.toHaveBeenCalled()
+    // Scrapbox 記法のテキストがそのまま出力される
+    const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(calls).toContain("[*** 大見出し]")
+  })
+
+  it("--format=scrapbox は VALIDATION_ERROR にならない", async () => {
+    // scrapbox は alias として有効な値であることを検証する
+    try {
+      await runText({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        format: "scrapbox",
+        "bold-style": "auto",
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(stdoutMock).not.toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+  })
 })


### PR DESCRIPTION
## 概要

`--format=scrapbox` を指定すると `VALIDATION_ERROR` になる問題を修正する。

- `FORMAT_ALIASES` マップ (`scrapbox → txt`) を追加し、バリデーション前に alias を正規値へ変換する
- `VALID_FORMATS` (`txt | md`) はそのまま変更しない
- ヘルプの description を `(txt | md | scrapbox)。scrapbox は txt の alias` に更新した
- バリデーションエラー時のヒントメッセージにも `scrapbox (txt の alias)` を追記した

## テスト計画

- [x] `--format=scrapbox` が VALIDATION_ERROR にならないこと
- [x] `--format=scrapbox` のとき Scrapbox テキストがそのまま出力されること (txt と同一動作)
- [x] `--format=txt` と `--format=md` が引き続き正常動作すること
- [x] 全テスト 699 pass / 0 fail
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `--format=scrapbox` オプションを追加しました。scrapbox 形式は txt として扱われ、Markdown変換は適用されません。

* **テスト**
  * `--format=scrapbox` の動作を確認するテストを追加しました（scrapboxスタイルの出力を検証）。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->