### PR TITLE
fix(build): リリースバイナリに package.json のバージョンを正しく埋め込む

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,11 +3,17 @@
  *
  * 使用方法: bun run scripts/build.ts
  * 単一ターゲット: bun run scripts/build.ts --target=bun-darwin-arm64
+ *
+ * VERSION の解決順序:
+ * 1. 環境変数 VERSION が設定されている場合はその値を使用 (CI タグビルド等)
+ * 2. それ以外は package.json の version フィールドを使用
+ * 3. どちらも取得できない場合は "dev" にフォールバック
  */
 
-export {}
+import pkg from "../package.json"
+import { resolveVersion } from "./resolve-version"
 
-const VERSION = process.env["VERSION"] ?? "dev"
+const VERSION = resolveVersion(process.env["VERSION"], pkg.version)
 
 const targets = [
   { target: "bun-darwin-arm64", output: "cos-darwin-arm64" },

--- a/scripts/resolve-version.ts
+++ b/scripts/resolve-version.ts
@@ -1,0 +1,25 @@
+/**
+ * resolve-version.ts — ビルドスクリプト用バージョン解決ユーティリティ。
+ *
+ * 優先順位:
+ * 1. 環境変数 VERSION が空でない文字列であればその値を使用する (CI タグビルド等)
+ * 2. それ以外は package.json の version フィールドを使用する
+ * 3. どちらも取得できない場合は "dev" にフォールバックする
+ */
+
+/**
+ * resolveVersion は VERSION 環境変数と package.json バージョンを合成して
+ * 最終的なバージョン文字列を返す。
+ *
+ * @param envVersion - 環境変数 VERSION の値 (undefined または空文字の場合は無視)
+ * @param pkgVersion - package.json の version フィールドの値
+ * @returns 解決済みのバージョン文字列
+ */
+export function resolveVersion(
+  envVersion: string | undefined,
+  pkgVersion: string | undefined,
+): string {
+  if (envVersion) return envVersion
+  if (pkgVersion) return pkgVersion
+  return "dev"
+}

--- a/scripts/resolve-version.ts
+++ b/scripts/resolve-version.ts
@@ -19,7 +19,10 @@ export function resolveVersion(
   envVersion: string | undefined,
   pkgVersion: string | undefined,
 ): string {
-  if (envVersion) return envVersion
-  if (pkgVersion) return pkgVersion
+  // trim() で空白のみの値を無効扱いにする（設定ミス防止）
+  const trimmedEnv = envVersion?.trim()
+  if (trimmedEnv) return trimmedEnv
+  const trimmedPkg = pkgVersion?.trim()
+  if (trimmedPkg) return trimmedPkg
   return "dev"
 }

--- a/tests/unit/scripts/resolve-version.test.ts
+++ b/tests/unit/scripts/resolve-version.test.ts
@@ -30,4 +30,14 @@ describe("resolveVersion", () => {
     // 異常系: package.json の version が取得できない場合
     expect(resolveVersion(undefined, undefined)).toBe("dev")
   })
+
+  it("環境変数 VERSION が空白のみの場合は package.json のバージョンを返す", () => {
+    // VERSION='   ' のように空白のみで渡された設定ミスのケース
+    expect(resolveVersion("   ", "0.1.1")).toBe("0.1.1")
+  })
+
+  it("package.json バージョンが空白のみの場合は dev を返す", () => {
+    // package.json の version が空白のみの場合
+    expect(resolveVersion(undefined, "   ")).toBe("dev")
+  })
 })

--- a/tests/unit/scripts/resolve-version.test.ts
+++ b/tests/unit/scripts/resolve-version.test.ts
@@ -1,0 +1,33 @@
+/**
+ * resolve-version.test.ts — ビルドスクリプトのバージョン解決ロジックのテスト。
+ *
+ * resolveVersion は以下の優先順位でバージョンを決定する:
+ * 1. 環境変数 VERSION が設定されている場合はその値を使用
+ * 2. 設定されていない場合は package.json の version フィールドを使用
+ * 3. どちらも取得できない場合は "dev" にフォールバック
+ */
+
+import { describe, expect, it } from "bun:test"
+import { resolveVersion } from "../../../scripts/resolve-version"
+
+describe("resolveVersion", () => {
+  it("環境変数 VERSION が設定されている場合はその値を返す", () => {
+    // ビルド時に CI から VERSION=v1.2.3 のように渡された場合
+    expect(resolveVersion("v1.2.3", "0.1.1")).toBe("v1.2.3")
+  })
+
+  it("環境変数 VERSION が未設定 (undefined) の場合は package.json のバージョンを返す", () => {
+    // bun run build を環境変数なしで実行した場合
+    expect(resolveVersion(undefined, "0.1.1")).toBe("0.1.1")
+  })
+
+  it("環境変数 VERSION が空文字の場合は package.json のバージョンを返す", () => {
+    // VERSION= のように空で渡された場合
+    expect(resolveVersion("", "0.1.1")).toBe("0.1.1")
+  })
+
+  it("環境変数 VERSION が未設定かつ package.json バージョンも未定義の場合は dev を返す", () => {
+    // 異常系: package.json の version が取得できない場合
+    expect(resolveVersion(undefined, undefined)).toBe("dev")
+  })
+})


### PR DESCRIPTION
## 概要

`bun run build` で生成したバイナリの `--version` が常に `dev` を返す問題を修正した。

## 原因

`scripts/build.ts` は `VERSION` 環境変数が設定されていない場合に `"dev"` にフォールバックする実装だったが、`package.json` の `version` フィールドを読み取っていなかった。CIでは `VERSION=vX.Y.Z` を環境変数で渡すため問題が顕在化しないが、ローカルで `bun run build` を実行すると常に `"dev"` が埋め込まれてしまっていた。

## 修正内容

- `scripts/resolve-version.ts` を新規作成し、バージョン解決ロジックを分離した
  - 優先順位: 環境変数 `VERSION` > `package.json` の `version` > `"dev"` フォールバック
- `scripts/build.ts` を `resolveVersion` を使用するよう更新し、`package.json` から自動でバージョンを読み取るようにした

## テスト計画

- [x] `tests/unit/scripts/resolve-version.test.ts` を追加し TDD で実装
- [x] `bun run build` 後に `./dist/cos-darwin-arm64 --version` が `0.1.1` を返すことを確認
- [x] `VERSION=v1.2.3 bun run build` 後に `1.2.3` を返すことを確認
- [x] 全テスト 703 件パス
- [x] Biome lint 警告ゼロ
- [x] 型チェックエラーゼロ

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * バージョン解決ロジックのユニットテストを追加し、環境変数・package.json・デフォルト値の優先順や、空白のみの値が未設定扱いになる挙動を検証しました。

* **Chores**
  * ビルド時のバージョン決定を改善しました。環境変数→package.json→"dev"の優先順位と空白トリムの扱いを明確化し、より堅牢にしました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/54)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->