### PR TITLE
feat(dry-run): --dry-run レスポンスに書き込み予定行を previewLines として含める

### DIFF
--- a/src/core/api/ws.ts
+++ b/src/core/api/ws.ts
@@ -42,6 +42,8 @@ export interface PatchOptions {
   title: string
   update: (lines: Line[]) => string[] | Promise<string[]>
   maxRetry?: number
+  /** dry-run 時に出力するプレビュー行 (書き込み予定の内容)。 */
+  previewLines?: string[]
 }
 
 /** InsertLinesOptions は insertLines() に渡すオプション。 */
@@ -106,11 +108,13 @@ export class CosenseWriter implements ScrapboxWriter {
     patchOpts: PatchOptions,
   ): Promise<{ commitId: string; pageId: string } | DryRunResult> {
     if (this.opts.dryRun) {
-      return {
+      const result: DryRunResult = {
         dryRun: true,
         project: patchOpts.project,
         title: patchOpts.title,
       }
+      if (patchOpts.previewLines !== undefined) result.previewLines = patchOpts.previewLines
+      return result
     }
 
     const patchOptions: { sid?: string; maxRetry?: number } = {}
@@ -134,7 +138,7 @@ export class CosenseWriter implements ScrapboxWriter {
 
   async insertLines(opts: InsertLinesOptions): Promise<{ commitId: string } | DryRunResult> {
     if (this.opts.dryRun) {
-      return { dryRun: true, project: opts.project, title: opts.title }
+      return { dryRun: true, project: opts.project, title: opts.title, previewLines: opts.lines }
     }
 
     // insertLines は patch の特殊ケース: 現在の末尾に行を追加する
@@ -191,11 +195,13 @@ export class CosenseWriter implements ScrapboxWriter {
  */
 export class DryRunWriter implements ScrapboxWriter {
   async patch(opts: PatchOptions): Promise<DryRunResult> {
-    return { dryRun: true, project: opts.project, title: opts.title }
+    const result: DryRunResult = { dryRun: true, project: opts.project, title: opts.title }
+    if (opts.previewLines !== undefined) result.previewLines = opts.previewLines
+    return result
   }
 
   async insertLines(opts: InsertLinesOptions): Promise<DryRunResult> {
-    return { dryRun: true, project: opts.project, title: opts.title }
+    return { dryRun: true, project: opts.project, title: opts.title, previewLines: opts.lines }
   }
 
   async deletePage(opts: DeletePageOptions): Promise<DryRunResult> {

--- a/src/core/api/ws.ts
+++ b/src/core/api/ws.ts
@@ -201,7 +201,13 @@ export class DryRunWriter implements ScrapboxWriter {
   }
 
   async insertLines(opts: InsertLinesOptions): Promise<DryRunResult> {
-    return { dryRun: true, project: opts.project, title: opts.title, previewLines: opts.lines }
+    const result: DryRunResult = {
+      dryRun: true,
+      project: opts.project,
+      title: opts.title,
+      previewLines: opts.lines,
+    }
+    return result
   }
 
   async deletePage(opts: DeletePageOptions): Promise<DryRunResult> {

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -47,6 +47,7 @@ export async function createPage(
     project: opts.project,
     title: opts.title,
     update: () => [opts.title, ...opts.lines],
+    previewLines: opts.lines,
   })
 }
 
@@ -71,6 +72,7 @@ export async function editPage(
     project: opts.project,
     title: opts.title,
     update: () => [opts.title, ...opts.lines],
+    previewLines: opts.lines,
   })
 }
 
@@ -88,6 +90,7 @@ export async function renamePage(
     project: opts.project,
     title: opts.title,
     update: (lines) => [opts.newTitle, ...lines.slice(1).map((l) => l.text)],
+    previewLines: [opts.newTitle],
   })
 }
 
@@ -104,6 +107,7 @@ export async function prependToPage(
       ...opts.lines,
       ...existing.slice(1).map((l) => l.text),
     ],
+    previewLines: opts.lines,
   })
 }
 
@@ -125,6 +129,7 @@ export async function insertIntoPage(
       const txt = existing.map((l) => l.text)
       return [...txt.slice(0, opts.after), ...opts.lines, ...txt.slice(opts.after)]
     },
+    previewLines: opts.lines,
   })
 }
 

--- a/tests/unit/core/api/ws.test.ts
+++ b/tests/unit/core/api/ws.test.ts
@@ -60,6 +60,26 @@ describe("CosenseWriter", () => {
     expect(result).toMatchObject({ dryRun: true, project: "テストプロジェクト" })
   })
 
+  it("--dry-run モードで previewLines を渡すと DryRunResult に含まれる", async () => {
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+      { dryRun: true },
+    )
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[]) => ["行1", "行2"],
+      previewLines: ["プレビュー行1", "プレビュー行2"],
+    })
+    expect(mockPatch).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "テストページ",
+      previewLines: ["プレビュー行1", "プレビュー行2"],
+    })
+  })
+
   it("pinPage を呼ぶと stdClient.pin を正しい引数で呼ぶ", async () => {
     const writer = new CosenseWriter(
       mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
@@ -134,14 +154,35 @@ describe("DryRunWriter", () => {
     })
   })
 
-  it("insertLines を呼んでも何もしない", async () => {
+  it("patch に previewLines を渡すと DryRunResult に含まれる", async () => {
+    const writer = new DryRunWriter()
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[]) => ["行1", "行2"],
+      previewLines: ["プレビュー行1", "プレビュー行2"],
+    })
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "テストページ",
+      previewLines: ["プレビュー行1", "プレビュー行2"],
+    })
+  })
+
+  it("insertLines は opts.lines を previewLines として DryRunResult に含める", async () => {
     const writer = new DryRunWriter()
     const result = await writer.insertLines({
       project: "テストプロジェクト",
       title: "テストページ",
-      lines: ["新しい行"],
+      lines: ["追加行1", "追加行2"],
     })
-    expect(result).toMatchObject({ dryRun: true })
+    expect(result).toMatchObject({
+      dryRun: true,
+      project: "テストプロジェクト",
+      title: "テストページ",
+      previewLines: ["追加行1", "追加行2"],
+    })
   })
 
   it("deletePage を呼んでも何もしない", async () => {

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -145,6 +145,18 @@ describe("createPage", () => {
     expect(writer.patch).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ commitId: "commit1" })
   })
+
+  it("patch に previewLines としてコンテンツ行を渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "create-commit", pageId: "page1" }
+      }),
+    })
+    await createPage(writer, { project: "proj", title: "新しいページ", lines: ["行1", "行2"] })
+    expect(capturedPreviewLines).toEqual(["行1", "行2"])
+  })
 })
 
 describe("appendToPage", () => {
@@ -191,6 +203,18 @@ describe("editPage", () => {
     await editPage(writer, { project: "proj", title: "既存ページ", lines: ["新しい内容"] })
     expect(writer.patch).toHaveBeenCalledTimes(1)
   })
+
+  it("patch に previewLines として新しいコンテンツ行を渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "edit-commit", pageId: "page1" }
+      }),
+    })
+    await editPage(writer, { project: "proj", title: "既存ページ", lines: ["新しい内容"] })
+    expect(capturedPreviewLines).toEqual(["新しい内容"])
+  })
 })
 
 describe("deletePage", () => {
@@ -202,6 +226,19 @@ describe("deletePage", () => {
 })
 
 describe("renamePage", () => {
+  it("patch に previewLines として新タイトルを渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "rename-commit", pageId: "page1" }
+      }),
+    })
+    await renamePage(writer, { project: "proj", title: "旧タイトル", newTitle: "新タイトル" })
+    // dry-run 時に変更後のタイトルが分かるよう、previewLines に新タイトルを設定する
+    expect(capturedPreviewLines).toEqual(["新タイトル"])
+  })
+
   it("patch の update 関数が新タイトルを先頭にした配列を返す", async () => {
     // update 関数の戻り値をキャプチャするためにモックを差し替える
     let capturedUpdate:
@@ -230,6 +267,22 @@ describe("renamePage", () => {
 })
 
 describe("prependToPage", () => {
+  it("patch に previewLines として挿入行を渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "prepend-commit", pageId: "page1" }
+      }),
+    })
+    await prependToPage(writer, {
+      project: "proj",
+      title: "既存ページ",
+      lines: ["先頭行1", "先頭行2"],
+    })
+    expect(capturedPreviewLines).toEqual(["先頭行1", "先頭行2"])
+  })
+
   it("patch の update 関数がタイトル直後に新行を挿入した配列を返す", async () => {
     let capturedUpdate:
       | ((
@@ -279,6 +332,23 @@ describe("prependToPage", () => {
 })
 
 describe("insertIntoPage", () => {
+  it("patch に previewLines として挿入行を渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "insert-commit", pageId: "page1" }
+      }),
+    })
+    await insertIntoPage(writer, {
+      project: "proj",
+      title: "挿入ページ",
+      after: 1,
+      lines: ["挿入行1", "挿入行2"],
+    })
+    expect(capturedPreviewLines).toEqual(["挿入行1", "挿入行2"])
+  })
+
   it("--after 2 で 2 行目の後ろに行を挿入する (1-indexed)", async () => {
     let capturedUpdate:
       | ((


### PR DESCRIPTION
## Summary

- `DryRunResult` の `previewLines?: string[]` フィールド（既定義）を実際に設定するよう実装した
- `PatchOptions` に `previewLines?: string[]` を追加し、dry-run 時に `DryRunResult` へ伝播する
- `DryRunWriter.patch()` / `CosenseWriter.patch()` (dry-run 分岐) が `previewLines` を含めて返すように修正
- `DryRunWriter.insertLines()` / `CosenseWriter.insertLines()` (dry-run 分岐) は `opts.lines` を `previewLines` として自動セット
- `core/pages.ts` の各書き込み関数が `previewLines` を `writer.patch()` に渡すよう修正:
  - `createPage`, `editPage`: 書き込み行をそのまま渡す
  - `prependToPage`, `insertIntoPage`: 挿入行を渡す
  - `renamePage`: `[opts.newTitle]` を渡し、変更後タイトルをプレビューに含める
  - `appendToPage`: `insertLines` 経由のため自動的に `previewLines` が設定される
  - `deletePage`: タイトルは既に結果に含まれるため変更なし

## Before / After

**Before**
```json
{ "data": { "dryRun": true, "project": "my-project", "title": "タイトル" } }
```

**After (page new/edit)**
```json
{ "data": { "dryRun": true, "project": "my-project", "title": "タイトル", "previewLines": ["行1", "行2"] } }
```

**After (page rename)**
```json
{ "data": { "dryRun": true, "project": "my-project", "title": "旧タイトル", "previewLines": ["新タイトル"] } }
```

## Test plan

- [x] `tests/unit/core/api/ws.test.ts`: `DryRunWriter.patch()` に `previewLines` 渡すと結果に含まれる
- [x] `tests/unit/core/api/ws.test.ts`: `DryRunWriter.insertLines()` が `opts.lines` を `previewLines` として含める
- [x] `tests/unit/core/api/ws.test.ts`: `CosenseWriter` dry-run モードで `previewLines` が伝播する
- [x] `tests/unit/core/pages.test.ts`: `createPage` / `editPage` / `prependToPage` / `insertIntoPage` / `renamePage` がそれぞれ正しい `previewLines` を渡す
- [x] `bun test`: 716件パス、0件失敗
- [x] `bunx biome check`: エラーなし
- [x] `bun run typecheck`: エラーなし

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ドライラン操作時にプレビューコンテンツの取得に対応しました。パッチ操作でプレビュー行が返されるようになり、変更内容を事前確認できます。

* **テスト**
  * プレビュー機能の動作検証テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->