### PR TITLE
feat(page/context): Smart Context API 対応 — cos page context コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ cos page new --project myproject --title "新しいページ" --body "本文"
 cos page list     ページ一覧を取得
 cos page get      ページ本文を取得
 cos page text     ページのテキスト (コードブロックなし) を取得
+cos page context  ページ起点の Smart Context (リンク先本文) を取得
 cos page code     ページのコードブロックを取得
 cos page url      ページの URL を表示
 cos page new      ページを作成
@@ -189,6 +190,21 @@ cos convert --from=scrapbox --to=md --from-file page.txt --to-file page.md
 - `code:filename` のファイル名情報は ` ```filename ``` ` で保持するが、一部の Markdown パーサで認識されない可能性がある
 
 ## AI エージェント向け使い方
+
+### Smart Context でリンク先ページの文脈を取得
+
+`cos page context` は Cosense の [Smart Context](https://cosen.se/) 機能を使い、指定ページを起点に 1hop / 2hop 先のリンク先ページ本文を LLM が読みやすい形式でまとめて取得します。
+
+```bash
+# 1hop 先 (デフォルト) — 関連ページの直接リンクを取得
+cos page context "ページタイトル" --project myproject
+
+# 2hop 先 — さらに広い文脈を取得
+cos page context "ページタイトル" --project myproject --hops 2
+
+# JSON 出力 (エージェント向け)
+cos page context "ページタイトル" --project myproject --json
+```
 
 ### JSON 出力
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ declare const VERSION: string
 
 import { pageAppendCommand } from "@/commands/page/append"
 import { pageCodeCommand } from "@/commands/page/code"
+import { pageContextCommand } from "@/commands/page/context"
 import { pageDeleteCommand } from "@/commands/page/delete"
 import { pageEditCommand } from "@/commands/page/edit"
 import { pageGetCommand } from "@/commands/page/get"
@@ -100,6 +101,7 @@ const pageCommand = defineCommand({
     delete: pageDeleteCommand,
     rm: pageDeleteCommand,
     watch: pageWatchCommand,
+    context: pageContextCommand,
   },
 })
 

--- a/src/commands/page/context.ts
+++ b/src/commands/page/context.ts
@@ -54,6 +54,8 @@ export const pageContextCommand = defineCommand({
         `有効な値: ${VALID_HOPS.join(", ")}`,
       )
       process.exit(5)
+      // process.exit がモックされるテスト環境でも後続処理を止める (_shared.ts exitWithError と同パターン)
+      throw new Error("VALIDATION_ERROR")
     }
     const hops = hopsNum as Hops
 

--- a/src/commands/page/context.ts
+++ b/src/commands/page/context.ts
@@ -1,0 +1,72 @@
+/**
+ * page/context.ts — `cos page context <title>` コマンド。
+ *
+ * 指定ページを起点に Smart Context API を叩き、
+ * 1hop または 2hop 先までのリンク先ページ本文をテキストで取得して stdout に出力する。
+ * LLM への文脈投入やエージェントによるページ関連情報収集に使う。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { getSmartContext } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** 有効な hops 値 */
+const VALID_HOPS = [1, 2] as const
+type Hops = (typeof VALID_HOPS)[number]
+
+export const pageContextCommand = defineCommand({
+  meta: { name: "context", description: "ページ起点の Smart Context (リンク先本文) を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "起点となるページタイトル",
+      required: true,
+    },
+    hops: {
+      type: "string",
+      description: "取得するリンクの深さ (1 | 2)。デフォルト: 1",
+      default: "1",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; hops: string }
+    checkSandbox("page.context", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --hops バリデーション
+    const hopsNum = Number(a.hops)
+    if (!(VALID_HOPS as readonly number[]).includes(hopsNum)) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--hops=${a.hops} は無効な値です`,
+        `有効な値: ${VALID_HOPS.join(", ")}`,
+      )
+      process.exit(5)
+    }
+    const hops = hopsNum as Hops
+
+    logger.info(`"${a.title}" の Smart Context (${hops}hop) を取得中...`)
+
+    const client = await buildRestClient(a)
+    const text = await getSmartContext(client, { project, title: a.title, hops })
+
+    if (a.json) {
+      writeJson({ text }, { command: "page.context", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    process.stdout.write(`${text}\n`)
+  },
+})

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -118,6 +118,22 @@ export class CosenseRestClient {
     )
   }
 
+  /**
+   * getSmartContext は Smart Context API を叩いて指定ページ起点のリンク先本文テキストを返す。
+   *
+   * エンドポイント:
+   *   - hops=1: /api/smart-context/export-1hop-links/:project.txt?title=:title
+   *   - hops=2: /api/smart-context/export-2hop-links/:project.txt?title=:title
+   *
+   * title は encodePageTitle (slug変換) ではなく URLSearchParams (クエリ文字列) で渡す。
+   */
+  async getSmartContext(project: string, title: string, hops: 1 | 2): Promise<string> {
+    const params = new URLSearchParams({ title })
+    return this.fetchText(
+      `${BASE_URL}/api/smart-context/export-${hops}hop-links/${encodeURIComponent(project)}.txt?${params.toString()}`,
+    )
+  }
+
   /** getCodeBlock は /api/code/:project/:title/:filename を叩いてコードブロックを返す。 */
   async getCodeBlock(project: string, title: string, filename: string): Promise<string> {
     return this.fetchText(

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -30,6 +30,14 @@ export async function getPageText(
   return client.getPageText(opts.project, opts.title)
 }
 
+/** getSmartContext はページ起点の Smart Context テキストを取得する。 */
+export async function getSmartContext(
+  client: CosenseRestClient,
+  opts: { project: string; title: string; hops: 1 | 2 },
+) {
+  return client.getSmartContext(opts.project, opts.title, opts.hops)
+}
+
 /** getCodeBlock はページ内のコードブロックを取得する。 */
 export async function getCodeBlock(
   client: CosenseRestClient,

--- a/tests/unit/commands/page/context.test.ts
+++ b/tests/unit/commands/page/context.test.ts
@@ -1,0 +1,173 @@
+/**
+ * page/context.test.ts — `cos page context <title>` コマンドのテスト。
+ *
+ * --hops バリデーション、1hop/2hop エンドポイント切り替え、--json envelope 出力を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageContextCommand } from "@/commands/page/context"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_TITLE = "テストページ"
+const SMART_CONTEXT_1HOP = "1hop Smart Context テキスト"
+const SMART_CONTEXT_2HOP = "2hop Smart Context テキスト"
+
+const server = setupServer(
+  // Smart Context: 1hop
+  http.get(`${BASE_URL}/api/smart-context/export-1hop-links/:project`, ({ params, request }) => {
+    const projectParam = decodeURIComponent(params["project"] as string)
+    const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+    const url = new URL(request.url)
+    const title = url.searchParams.get("title")
+    if (project === TEST_PROJECT && title === TEST_TITLE) {
+      return new HttpResponse(SMART_CONTEXT_1HOP)
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+  // Smart Context: 2hop
+  http.get(`${BASE_URL}/api/smart-context/export-2hop-links/:project`, ({ params, request }) => {
+    const projectParam = decodeURIComponent(params["project"] as string)
+    const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+    const url = new URL(request.url)
+    const title = url.searchParams.get("title")
+    if (project === TEST_PROJECT && title === TEST_TITLE) {
+      return new HttpResponse(SMART_CONTEXT_2HOP)
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+  // 認証確認用
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({ id: "テストユーザーID", name: "テストユーザー" })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runContext(args: Record<string, unknown>) {
+  await (
+    pageContextCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  server.resetHandlers()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageContextCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runContext({
+        title: TEST_TITLE,
+        project: undefined,
+        hops: 1,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--hops に 1/2 以外の値を指定した場合は VALIDATION_ERROR で exit 5", async () => {
+    try {
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 3,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+  })
+
+  it("--hops=1 (デフォルト) で 1hop のテキストが stdout に出力される", async () => {
+    try {
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(calls).toContain(SMART_CONTEXT_1HOP)
+  })
+
+  it("--hops=2 で 2hop のテキストが stdout に出力される", async () => {
+    try {
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 2,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(calls).toContain(SMART_CONTEXT_2HOP)
+  })
+
+  it("--json 指定時に { text: ... } envelope が出力される", async () => {
+    try {
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        json: true,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    const parsed = JSON.parse(calls)
+    expect(parsed.data.text).toBe(SMART_CONTEXT_1HOP)
+  })
+})

--- a/tests/unit/commands/page/context.test.ts
+++ b/tests/unit/commands/page/context.test.ts
@@ -117,55 +117,43 @@ describe("pageContextCommand", () => {
   })
 
   it("--hops=1 (デフォルト) で 1hop のテキストが stdout に出力される", async () => {
-    try {
-      await runContext({
-        title: TEST_TITLE,
-        project: TEST_PROJECT,
-        hops: 1,
-        json: false,
-        plain: false,
-        "results-only": false,
-        quiet: false,
-      })
-    } catch {
-      // REST クライアント初期化中の throw は想定内
-    }
+    await runContext({
+      title: TEST_TITLE,
+      project: TEST_PROJECT,
+      hops: 1,
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: false,
+    })
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).toContain(SMART_CONTEXT_1HOP)
   })
 
   it("--hops=2 で 2hop のテキストが stdout に出力される", async () => {
-    try {
-      await runContext({
-        title: TEST_TITLE,
-        project: TEST_PROJECT,
-        hops: 2,
-        json: false,
-        plain: false,
-        "results-only": false,
-        quiet: false,
-      })
-    } catch {
-      // REST クライアント初期化中の throw は想定内
-    }
+    await runContext({
+      title: TEST_TITLE,
+      project: TEST_PROJECT,
+      hops: 2,
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: false,
+    })
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(calls).toContain(SMART_CONTEXT_2HOP)
   })
 
   it("--json 指定時に { text: ... } envelope が出力される", async () => {
-    try {
-      await runContext({
-        title: TEST_TITLE,
-        project: TEST_PROJECT,
-        hops: 1,
-        json: true,
-        plain: false,
-        "results-only": false,
-        quiet: false,
-      })
-    } catch {
-      // REST クライアント初期化中の throw は想定内
-    }
+    await runContext({
+      title: TEST_TITLE,
+      project: TEST_PROJECT,
+      hops: 1,
+      json: true,
+      plain: false,
+      "results-only": false,
+      quiet: false,
+    })
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     const parsed = JSON.parse(calls)
     expect(parsed.data.text).toBe(SMART_CONTEXT_1HOP)

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -67,6 +67,38 @@ const server = setupServer(
     return new HttpResponse("Not found", { status: 404 })
   }),
 
+  // Smart Context: 1hop リンクエクスポート
+  http.get(`${BASE_URL}/api/smart-context/export-1hop-links/:project`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return new HttpResponse("Unauthorized", { status: 401 })
+    }
+    const projectParam = decodeURIComponent(params["project"] as string)
+    const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+    const url = new URL(request.url)
+    const title = url.searchParams.get("title")
+    if (project === TEST_PROJECT && title === "テストページ") {
+      return new HttpResponse("1hop Smart Context テキスト")
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+
+  // Smart Context: 2hop リンクエクスポート
+  http.get(`${BASE_URL}/api/smart-context/export-2hop-links/:project`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return new HttpResponse("Unauthorized", { status: 401 })
+    }
+    const projectParam = decodeURIComponent(params["project"] as string)
+    const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+    const url = new URL(request.url)
+    const title = url.searchParams.get("title")
+    if (project === TEST_PROJECT && title === "テストページ") {
+      return new HttpResponse("2hop Smart Context テキスト")
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+
   http.get(`${BASE_URL}/api/pages/:project/search/query`, ({ request, params }) => {
     if (params["project"] === TEST_PROJECT) {
       const url = new URL(request.url)
@@ -167,6 +199,30 @@ describe("CosenseRestClient", () => {
       const text = await client.getPageText(TEST_PROJECT, "Hello World")
       expect(text).toContain("Hello World")
       expect(text).toContain("最初の行")
+    })
+  })
+
+  describe("getSmartContext", () => {
+    it("hops=1 のとき 1hop エンドポイントのテキストを返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const text = await client.getSmartContext(TEST_PROJECT, "テストページ", 1)
+      expect(text).toBe("1hop Smart Context テキスト")
+    })
+
+    it("hops=2 のとき 2hop エンドポイントのテキストを返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const text = await client.getSmartContext(TEST_PROJECT, "テストページ", 2)
+      expect(text).toBe("2hop Smart Context テキスト")
+    })
+
+    it("存在しないページは NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(client.getSmartContext(TEST_PROJECT, "存在しないページ", 1)).rejects.toThrow()
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.getSmartContext(TEST_PROJECT, "テストページ", 1)).rejects.toThrow()
     })
   })
 


### PR DESCRIPTION
## Summary

- `cos page context <title> [--hops 1|2]` コマンドを新規追加
- Cosense の Smart Context API (1hop/2hop リンク先本文テキスト取得) を CLI から呼び出せるようにする
- `--json` フラグで `{ text: "..." }` envelope として出力可能

## 変更ファイル

- `src/commands/page/context.ts` — `pageContextCommand` 実装
- `src/core/api/rest.ts` — `getSmartContext(project, title, hops)` メソッド追加
- `src/core/pages.ts` — ユースケースラッパー追加
- `src/cli.ts` — CLI 登録 (`page context`)
- `tests/unit/commands/page/context.test.ts` — コマンドテスト (5件)
- `tests/unit/core/api/rest.test.ts` — REST 層テスト (4件)

## Test plan

- [ ] `bun test tests/unit/core/api/rest.test.ts` — getSmartContext 4件 pass
- [ ] `bun test tests/unit/commands/page/context.test.ts` — 5件 pass
- [ ] `bunx biome check src tests` — エラーなし
- [ ] `bun run typecheck` — 型エラーなし
- [ ] `bun test` — 全725件 pass

## 手動 E2E (認証済み環境で)

```bash
# 1hop (デフォルト)
cos page context "CosenseのSmart Context API" -p mtane0412

# 2hop
cos page context "CosenseのSmart Context API" -p mtane0412 --hops 2

# JSON envelope
cos page context "CosenseのSmart Context API" -p mtane0412 --json

# sandbox 拒否確認
cos --disable-commands=page.context page context "CosenseのSmart Context API" -p mtane0412
```

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `cos page context` コマンドを追加。指定ページのスマートコンテキストを取得できます。`--hops` で1または2ホップを指定可能、`--json` でメタ情報付きJSON出力に対応。
  * `--hops` が1/2以外の場合はバリデーションエラーとなり終了コード5で終了します。

* **テスト**
  * コマンドとAPI挙動（1ホップ/2ホップ、認証、エラーケース、JSON出力）を検証するユニットテストを追加しました。

* **ドキュメント**
  * READMEに `cos page context` の使用例と挙動説明を追記しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/64)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->