### PR TITLE
fix(page/list): --limit / --skip の無効値をサイレントフォールバックせず VALIDATION_ERROR で弾く

### DIFF
--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -47,10 +47,19 @@ export const pageListCommand = defineCommand({
 
     const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
 
-    // --limit バリデーション: 1 以上の整数のみ許可 (認証前に弾く)
+    // --limit バリデーション: 10進数整数のみ許可 (指数表記・16進数を除外、認証前に弾く)
     if (commonArgs.limit !== undefined) {
+      if (!/^\d+$/.test(commonArgs.limit)) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--limit の値が無効です: "${commonArgs.limit}"`,
+          "1 以上の整数を指定してください",
+        )
+        process.exit(5)
+        return
+      }
       const limit = Number(commonArgs.limit)
-      if (!Number.isInteger(limit) || limit < 1) {
+      if (limit < 1) {
         writeErrorJson(
           "VALIDATION_ERROR",
           `--limit の値が無効です: "${commonArgs.limit}"`,
@@ -62,10 +71,9 @@ export const pageListCommand = defineCommand({
       listOpts.limit = limit
     }
 
-    // --skip バリデーション: 0 以上の整数のみ許可 (0 はスキップなしとして有効、認証前に弾く)
+    // --skip バリデーション: 10進数整数のみ許可 (0 はスキップなしとして有効、認証前に弾く)
     if (commonArgs.skip !== undefined) {
-      const skip = Number(commonArgs.skip)
-      if (!Number.isInteger(skip) || skip < 0) {
+      if (!/^\d+$/.test(commonArgs.skip)) {
         writeErrorJson(
           "VALIDATION_ERROR",
           `--skip の値が無効です: "${commonArgs.skip}"`,
@@ -74,7 +82,7 @@ export const pageListCommand = defineCommand({
         process.exit(5)
         return
       }
-      listOpts.skip = skip
+      listOpts.skip = Number(commonArgs.skip)
     }
 
     if (commonArgs.sort) listOpts.sort = commonArgs.sort

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -45,10 +45,9 @@ export const pageListCommand = defineCommand({
 
     logger.info(`${project} のページ一覧を取得中...`)
 
-    const client = await buildRestClient(commonArgs)
     const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
 
-    // --limit バリデーション: 1 以上の整数のみ許可
+    // --limit バリデーション: 1 以上の整数のみ許可 (認証前に弾く)
     if (commonArgs.limit !== undefined) {
       const limit = Number(commonArgs.limit)
       if (!Number.isInteger(limit) || limit < 1) {
@@ -63,7 +62,7 @@ export const pageListCommand = defineCommand({
       listOpts.limit = limit
     }
 
-    // --skip バリデーション: 0 以上の整数のみ許可 (0 はスキップなしとして有効)
+    // --skip バリデーション: 0 以上の整数のみ許可 (0 はスキップなしとして有効、認証前に弾く)
     if (commonArgs.skip !== undefined) {
       const skip = Number(commonArgs.skip)
       if (!Number.isInteger(skip) || skip < 0) {
@@ -79,6 +78,7 @@ export const pageListCommand = defineCommand({
     }
 
     if (commonArgs.sort) listOpts.sort = commonArgs.sort
+    const client = await buildRestClient(commonArgs)
     const result = await listPages(client, listOpts)
 
     if (commonArgs.json) {

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -15,7 +15,7 @@ import {
   requireProject,
 } from "@/commands/_shared"
 import { listPages } from "@/core/pages"
-import { writeJson } from "@/presenter/json"
+import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writePlainTable, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
@@ -47,8 +47,37 @@ export const pageListCommand = defineCommand({
 
     const client = await buildRestClient(commonArgs)
     const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
-    if (commonArgs.limit) listOpts.limit = Number(commonArgs.limit)
-    if (commonArgs.skip) listOpts.skip = Number(commonArgs.skip)
+
+    // --limit バリデーション: 1 以上の整数のみ許可
+    if (commonArgs.limit !== undefined) {
+      const limit = Number(commonArgs.limit)
+      if (!Number.isInteger(limit) || limit < 1) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--limit の値が無効です: "${commonArgs.limit}"`,
+          "1 以上の整数を指定してください",
+        )
+        process.exit(5)
+        return
+      }
+      listOpts.limit = limit
+    }
+
+    // --skip バリデーション: 0 以上の整数のみ許可 (0 はスキップなしとして有効)
+    if (commonArgs.skip !== undefined) {
+      const skip = Number(commonArgs.skip)
+      if (!Number.isInteger(skip) || skip < 0) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--skip の値が無効です: "${commonArgs.skip}"`,
+          "0 以上の整数を指定してください",
+        )
+        process.exit(5)
+        return
+      }
+      listOpts.skip = skip
+    }
+
     if (commonArgs.sort) listOpts.sort = commonArgs.sort
     const result = await listPages(client, listOpts)
 

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -210,6 +210,45 @@ describe("pageListCommand", () => {
       expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
     })
 
+    it("--skip abc (文字列) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: "abc",
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("abc"))
+    })
+
+    it("--skip 1.5 (小数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: "1.5",
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
     it("--skip 0 (ゼロ) は有効値として正常動作し API が呼び出される", async () => {
       try {
         await runList({

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -147,6 +147,44 @@ describe("pageListCommand", () => {
       expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
     })
 
+    it("--limit 1e3 (指数表記) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "1e3",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit 0x10 (16進数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "0x10",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
     it("--limit 1 (最小有効値) は正常動作し API が呼び出される", async () => {
       try {
         await runList({

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -1,0 +1,234 @@
+/**
+ * page/list.test.ts — `cos page list` コマンドのテスト。
+ *
+ * --limit / --skip に無効値を渡した場合の VALIDATION_ERROR (exit 5) と、
+ * 有効値を渡した場合に正常動作することを検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { pageListCommand } from "@/commands/page/list"
+import pageListFixture from "../../../fixtures/page-list.json"
+
+/** listPages に渡された opts をキャプチャする */
+const capturedListPagesCalls: { limit?: number; skip?: number }[] = []
+
+// Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+mock.module("@/core/pages", () => ({
+  listPages: mock(
+    async (
+      _client: unknown,
+      opts: { project: string; limit?: number; skip?: number; sort?: string },
+    ) => {
+      // exactOptionalPropertyTypes: true のためオプショナルプロパティへは条件付き代入を使う
+      const captured: { limit?: number; skip?: number } = {}
+      if (opts.limit !== undefined) captured.limit = opts.limit
+      if (opts.skip !== undefined) captured.skip = opts.skip
+      capturedListPagesCalls.push(captured)
+      return pageListFixture
+    },
+  ),
+}))
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runList(args: Record<string, unknown>) {
+  await (
+    pageListCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // buildRestClient がキーチェーン呼び出しをスキップできるようダミー SID を設定する
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  // 各テスト前にキャプチャを初期化する
+  capturedListPagesCalls.length = 0
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageListCommand", () => {
+  describe("--limit のバリデーション", () => {
+    it("--limit -1 (負数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "-1",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("-1"))
+    })
+
+    it("--limit 0 (ゼロ) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "0",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit abc (文字列) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "abc",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit 1.5 (小数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "1.5",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit 1 (最小有効値) は正常動作し API が呼び出される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "1",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      // exitMock が呼ばれていない = VALIDATION_ERROR ではない
+      expect(exitMock).not.toHaveBeenCalled()
+      // listPages が limit=1 で呼び出されている
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.limit).toBe(1)
+    })
+
+    it("--limit 100 (通常の有効値) は正常動作し API が呼び出される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "100",
+          skip: undefined,
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.limit).toBe(100)
+    })
+  })
+
+  describe("--skip のバリデーション", () => {
+    it("--skip -1 (負数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: "-1",
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--skip 0 (ゼロ) は有効値として正常動作し API が呼び出される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: "0",
+          sort: undefined,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      // skip=0 はスキップなしとして有効なので exit しない
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.skip).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## 概要

`cos page list` の `--limit` / `--skip` に負数・0・文字列・小数を渡した場合に、API デフォルト値にサイレントフォールバックしていた問題を修正します。

## 変更内容

- `src/commands/page/list.ts`: `--limit`（1 以上の整数）と `--skip`（0 以上の整数）のバリデーションを追加
- `tests/unit/commands/page/list.test.ts`: 新規作成（各無効値ケースと正常ケースを網羅）

## テストケース

| 入力 | 期待結果 |
|---|---|
| `--limit -1` | VALIDATION_ERROR exit 5 |
| `--limit 0` | VALIDATION_ERROR exit 5 |
| `--limit abc` | VALIDATION_ERROR exit 5 |
| `--limit 1.5` | VALIDATION_ERROR exit 5 |
| `--skip -1` | VALIDATION_ERROR exit 5 |
| `--limit 1` | 正常 |
| `--skip 0` | 正常 |

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ページ一覧コマンドで `--limit` と `--skip` の入力検証を強化。無効な値を指定した場合は検証エラーが表示され一覧取得は行われません。`--skip 0` は有効として受け付けられます。

* **Tests**
  * ページ一覧コマンドの包括的なユニットテストスイートを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/65)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/65)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->