### PR TITLE
fix(page/append,prepend,insert): --line でシェル実改行が展開されず1行扱いになる問題を修正

### DIFF
--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -47,7 +47,7 @@ export const pageAppendCommand = defineCommand({
     const startTime = Date.now()
 
     let lines: string[] = []
-    if (a.line) {
+    if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"] === "-") {
       const content = readFileSync(0, "utf-8")

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -48,7 +48,7 @@ export const pageAppendCommand = defineCommand({
 
     let lines: string[] = []
     if (a.line) {
-      lines = a.line.split("\\n")
+      lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"] === "-") {
       const content = readFileSync(0, "utf-8")
       lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -71,7 +71,7 @@ export const pageInsertCommand = defineCommand({
 
     let lines: string[] = []
     if (a.line !== undefined) {
-      lines = a.line.split("\\n")
+      lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"]) {
       try {
         const content =

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -48,7 +48,7 @@ export const pagePrependCommand = defineCommand({
 
     let lines: string[] = []
     if (a.line !== undefined) {
-      lines = a.line.split("\\n")
+      lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"]) {
       try {
         const content =

--- a/tests/unit/commands/page/append.test.ts
+++ b/tests/unit/commands/page/append.test.ts
@@ -1,18 +1,20 @@
 /**
- * page/prepend.test.ts — `cos page prepend <title>` コマンドのテスト。
+ * page/append.test.ts — `cos page append <title>` コマンドのテスト。
+ *
+ * 基本的な append 動作と --line の実改行展開を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { pagePrependCommand } from "@/commands/page/prepend"
+import { pageAppendCommand } from "@/commands/page/append"
 
-/** prependToPage に渡された引数をキャプチャする */
-const capturedPrependCalls: { lines: string[] }[] = []
+/** appendToPage に渡された引数をキャプチャする */
+const capturedAppendCalls: { lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
 mock.module("@/core/pages", () => ({
-  prependToPage: mock(
+  appendToPage: mock(
     async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
-      capturedPrependCalls.push({ lines: opts.lines })
+      capturedAppendCalls.push({ lines: opts.lines })
       return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
     },
   ),
@@ -23,9 +25,9 @@ let stdoutMock: ReturnType<typeof spyOn>
 let stderrMock: ReturnType<typeof spyOn>
 
 /** コマンド run ヘルパー */
-async function runPrepend(args: Record<string, unknown>) {
+async function runAppend(args: Record<string, unknown>) {
   await (
-    pagePrependCommand.run as (ctx: {
+    pageAppendCommand.run as (ctx: {
       args: unknown
       cmd: never
       rawArgs: string[]
@@ -47,7 +49,7 @@ beforeEach(() => {
   // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
   // 各テスト前にキャプチャを初期化する
-  capturedPrependCalls.length = 0
+  capturedAppendCalls.length = 0
 })
 
 afterEach(() => {
@@ -57,12 +59,45 @@ afterEach(() => {
   Reflect.deleteProperty(process.env, "COS_SID")
 })
 
-describe("pagePrependCommand", () => {
+describe("pageAppendCommand", () => {
+  it("--line で指定した文字列が appendToPage に1行で渡される", async () => {
+    // 基本的な append 動作: 1行テキストを渡すと appendToPage に1行で渡されること
+    await runAppend({
+      title: "テストページ",
+      line: "追記行テキスト",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    expect(capturedAppendCalls).toHaveLength(1)
+    expect(capturedAppendCalls[0]?.lines).toEqual(["追記行テキスト"])
+  })
+
+  it("--line に実改行を含む文字列を渡すと appendToPage に2行で渡される", async () => {
+    // $'追記行A\n追記行B' のようなシェル実改行を含む文字列を渡した場合の検証
+    await runAppend({
+      title: "テストページ",
+      line: "追記行A\n追記行B",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // 実改行（\n）が展開され、lines が ["追記行A", "追記行B"] の2行になること
+    expect(capturedAppendCalls).toHaveLength(1)
+    expect(capturedAppendCalls[0]?.lines).toEqual(["追記行A", "追記行B"])
+  })
+
   it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
     try {
-      await runPrepend({
+      await runAppend({
         title: "テストページ",
-        line: "追加行",
+        line: "追記行テキスト",
         project: undefined,
         json: false,
         plain: false,
@@ -78,7 +113,7 @@ describe("pagePrependCommand", () => {
 
   it("--line も --from-file も指定しない場合は CONTENT_REQUIRED で exit 5", async () => {
     try {
-      await runPrepend({
+      await runAppend({
         title: "テストページ",
         project: "テストプロジェクト",
         json: false,
@@ -92,22 +127,5 @@ describe("pagePrependCommand", () => {
     }
     expect(exitMock).toHaveBeenCalledWith(5)
     expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
-  })
-
-  it("--line に実改行を含む文字列を渡すと prependToPage に2行で渡される", async () => {
-    // $'先頭行A\n先頭行B' のようなシェル実改行を含む文字列を渡した場合の検証
-    await runPrepend({
-      title: "テストページ",
-      line: "先頭行A\n先頭行B",
-      project: "テストプロジェクト",
-      json: false,
-      plain: false,
-      "results-only": false,
-      "dry-run": false,
-      quiet: false,
-    })
-    // 実改行（\n）が展開され、lines が ["先頭行A", "先頭行B"] の2行になること
-    expect(capturedPrependCalls).toHaveLength(1)
-    expect(capturedPrependCalls[0]?.lines).toEqual(["先頭行A", "先頭行B"])
   })
 })

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -48,7 +48,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   // 各テスト前にキャプチャを初期化する
   capturedInsertCalls.length = 0
 })

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -2,11 +2,28 @@
  * page/insert.test.ts — `cos page insert <title> --after <n>` コマンドのテスト。
  */
 
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { pageInsertCommand } from "@/commands/page/insert"
+
+/** insertIntoPage に渡された引数をキャプチャする */
+const capturedInsertCalls: { lines: string[] }[] = []
+
+// Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+mock.module("@/core/pages", () => ({
+  insertIntoPage: mock(
+    async (
+      _writer: unknown,
+      opts: { project: string; title: string; after: number; lines: string[] },
+    ) => {
+      capturedInsertCalls.push({ lines: opts.lines })
+      return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
+    },
+  ),
+}))
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
 
 /** コマンド run ヘルパー */
 async function runInsert(args: Record<string, unknown>) {
@@ -26,14 +43,21 @@ async function runInsert(args: Record<string, unknown>) {
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
-  process.env["COS_PROJECT"] = undefined
-  process.env["COS_ENABLE_COMMANDS"] = undefined
-  process.env["COS_DISABLE_COMMANDS"] = undefined
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
+  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  // 各テスト前にキャプチャを初期化する
+  capturedInsertCalls.length = 0
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
 })
 
 describe("pageInsertCommand", () => {
@@ -113,5 +137,23 @@ describe("pageInsertCommand", () => {
     }
     expect(exitMock).toHaveBeenCalledWith(5)
     expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
+  })
+
+  it("--line に実改行を含む文字列を渡すと insertIntoPage に2行で渡される", async () => {
+    // $'挿入行A\n挿入行B' のようなシェル実改行を含む文字列を渡した場合の検証
+    await runInsert({
+      title: "テストページ",
+      after: "1",
+      line: "挿入行A\n挿入行B",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // 実改行（\n）が展開され、lines が ["挿入行A", "挿入行B"] の2行になること
+    expect(capturedInsertCalls).toHaveLength(1)
+    expect(capturedInsertCalls[0]?.lines).toEqual(["挿入行A", "挿入行B"])
   })
 })


### PR DESCRIPTION
## 概要

`page append` / `page prepend` / `page insert` で `--line` に実改行（`$'A\nB'`）を渡した場合に、`page new` と異なり展開されずに1行として扱われていた問題を修正します。

## 変更内容

- `src/commands/page/append.ts`: split を `"\\n"` から `/\r?\n|\\n/` に変更
- `src/commands/page/prepend.ts`: 同上
- `src/commands/page/insert.ts`: 同上
- `tests/unit/commands/page/append.test.ts`: 新規作成
- `tests/unit/commands/page/prepend.test.ts`: 実改行ケース追加
- `tests/unit/commands/page/insert.test.ts`: 実改行ケース追加

## テスト

`--line $'行A\n行B'`（実改行）を渡した際に `previewLines` が `["行A", "行B"]` の 2 行として展開されることを各コマンドで検証。

Closes #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * `page append`、`page insert`、`page prepend`コマンドの`--line`オプションで、実際の改行（CR を含む可）と文字列`\n`の両方を正しく解釈するようになりました。これにより、コマンドラインで渡したマルチライン入力が期待通りに分割・挿入されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/66)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->