### PR TITLE
fix(page/rename): persistent:false のスタブページを重複と誤判定しないよう修正

### DIFF
--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -60,16 +60,18 @@ export const pageRenameCommand = defineCommand({
       const client = await buildRestClient(a)
       try {
         const page = await client.getPage(project, a["new-title"])
-        // persistent:true の場合のみ実体ページが存在するとみなす。
+        // persistent !== false の場合のみ実体ページが存在するとみなす。
         // Cosense REST API は存在しないページに persistent:false のスタブとして 200 を返すため、
         // getPage の成功だけでは重複の証明にならない。(issue #57)
-        if (page.persistent === true) {
+        // persistent が undefined の場合も安全側に倒して実体ページ扱いにする。
+        if (page.persistent !== false) {
           writeErrorJson(
             "DUPLICATE_TITLE",
             `"${a["new-title"]}" は既に存在します`,
             "別のタイトルを指定するか、--force-fallback を使用してください",
           )
           process.exit(5)
+          return
         }
       } catch (err) {
         // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -59,14 +59,18 @@ export const pageRenameCommand = defineCommand({
     if (!a["dry-run"] && !a["force-fallback"] && a["new-title"] !== a.title) {
       const client = await buildRestClient(a)
       try {
-        await client.getPage(project, a["new-title"])
-        // 例外が発生しなければ同名ページが存在する
-        writeErrorJson(
-          "DUPLICATE_TITLE",
-          `"${a["new-title"]}" は既に存在します`,
-          "別のタイトルを指定するか、--force-fallback を使用してください",
-        )
-        process.exit(5)
+        const page = await client.getPage(project, a["new-title"])
+        // persistent:true の場合のみ実体ページが存在するとみなす。
+        // Cosense REST API は存在しないページに persistent:false のスタブとして 200 を返すため、
+        // getPage の成功だけでは重複の証明にならない。(issue #57)
+        if (page.persistent === true) {
+          writeErrorJson(
+            "DUPLICATE_TITLE",
+            `"${a["new-title"]}" は既に存在します`,
+            "別のタイトルを指定するか、--force-fallback を使用してください",
+          )
+          process.exit(5)
+        }
       } catch (err) {
         // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー
         const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -27,11 +27,13 @@ import { setupServer } from "msw/node"
 // @/core/pages の renamePage をモックして WebSocket 接続を回避する
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
 // ---------------------------------------------------------------------------
+const renamePageMock = mock(async () => ({
+  commitId: "ダミーコミットID",
+  pageId: "ダミーページID",
+}))
+
 mock.module("@/core/pages", () => ({
-  renamePage: mock(async () => ({
-    commitId: "ダミーコミットID",
-    pageId: "ダミーページID",
-  })),
+  renamePage: renamePageMock,
 }))
 
 const BASE_URL = "https://scrapbox.io"
@@ -84,6 +86,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   process.env["COS_SID"] = "s%3Atest-session-id"
+  renamePageMock.mockClear()
 })
 
 afterEach(() => {
@@ -168,6 +171,8 @@ describe("pageRenameCommand", () => {
     const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(stdoutOutput).not.toContain("DUPLICATE_TITLE")
     expect(exitMock).not.toHaveBeenCalledWith(5)
+    // persistent:false はスタブなので rename が実際に呼ばれることを確認する
+    expect(renamePageMock).toHaveBeenCalledTimes(1)
   })
 
   it("新タイトルが persistent:true のページを返す場合、DUPLICATE_TITLE エラー (exit 5) になる", async () => {
@@ -220,6 +225,8 @@ describe("pageRenameCommand", () => {
     expect(exitMock).toHaveBeenCalledWith(5)
     const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(stdoutOutput).toContain("DUPLICATE_TITLE")
+    // persistent:true は実体ページなので rename が呼ばれないことを確認する
+    expect(renamePageMock).not.toHaveBeenCalled()
   })
 
   it("新タイトルが 404 NotFoundError を返す場合、重複なしとして rename が継続する", async () => {
@@ -251,5 +258,60 @@ describe("pageRenameCommand", () => {
     const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     expect(stdoutOutput).not.toContain("DUPLICATE_TITLE")
     expect(exitMock).not.toHaveBeenCalledWith(5)
+    // 404 は重複なしなので rename が実際に呼ばれることを確認する
+    expect(renamePageMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("新タイトルが persistent フィールド欠落のページを返す場合、安全側に倒して DUPLICATE_TITLE エラー (exit 5) になる", async () => {
+    // 前提: persistent フィールドが欠落 (undefined) のレスポンスを返す。
+    // 期待: undefined は安全側 (実体ページ) として扱い DUPLICATE_TITLE エラーになる。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const project = decodeURIComponent(params["project"] as string)
+        const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "persistentなしページ") {
+          // persistent フィールドを含まないレスポンス
+          return HttpResponse.json({
+            id: "ambiguous-page-id",
+            title: "persistentなしページ",
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "persistentなしページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "変更元ページ",
+        "new-title": "persistentなしページ",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // persistent が undefined でも安全側に倒して DUPLICATE_TITLE になることを確認する
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).toContain("DUPLICATE_TITLE")
+    // 重複扱いなので rename は呼ばれない
+    expect(renamePageMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -1,9 +1,63 @@
 /**
  * page/rename.test.ts — `cos page rename <title> <new-title>` コマンドのテスト。
+ *
+ * 重複チェックにおける persistent フラグの判定ロジックを検証する。
+ * issue #57: persistent:false のスタブページを重複と誤判定しないよう修正。
+ *
+ * - REST getPage は msw でモックする。
+ * - WebSocket 書き込み (renamePage) は mock.module でモックして WS 接続を回避する。
  */
 
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test"
 import { pageRenameCommand } from "@/commands/page/rename"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+// ---------------------------------------------------------------------------
+// @/core/pages の renamePage をモックして WebSocket 接続を回避する
+// Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// ---------------------------------------------------------------------------
+mock.module("@/core/pages", () => ({
+  renamePage: mock(async () => ({
+    commitId: "ダミーコミットID",
+    pageId: "ダミーページID",
+  })),
+}))
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+
+// ---------------------------------------------------------------------------
+// msw サーバー設定
+// ---------------------------------------------------------------------------
+
+/**
+ * 基本モックハンドラ。
+ * getPage の挙動はテストごとに server.use() でオーバーライドする。
+ */
+const server = setupServer(
+  // 認証確認用
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({ id: "テストユーザーID", name: "テストユーザー" })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
@@ -26,15 +80,22 @@ async function runRename(args: Record<string, unknown>) {
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
-  process.env["COS_PROJECT"] = undefined
-  process.env["COS_ENABLE_COMMANDS"] = undefined
-  process.env["COS_DISABLE_COMMANDS"] = undefined
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
+  server.resetHandlers()
+  Reflect.deleteProperty(process.env, "COS_SID")
 })
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
 
 describe("pageRenameCommand", () => {
   it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
@@ -54,5 +115,141 @@ describe("pageRenameCommand", () => {
       // process.exit モック後の継続による throw は想定内
     }
     expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("新タイトルが persistent:false のスタブページを返す場合、重複なしとして rename が継続する (issue #57)", async () => {
+    // 前提: Cosense REST API は存在しないページに対して persistent:false のスタブとして 200 を返す。
+    // 期待: persistent:false はスタブであるため DUPLICATE_TITLE エラーにならず、rename が継続する。
+    // 検証: exit 5 が呼ばれないことと、DUPLICATE_TITLE が出力されないことを確認する。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const project = decodeURIComponent(params["project"] as string)
+        const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "存在しない新タイトル") {
+          // persistent:false のスタブページを返す (200 だが実体なし)
+          return HttpResponse.json({
+            id: "stub-page-id",
+            title: "存在しない新タイトル",
+            persistent: false,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "存在しない新タイトル",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "既存ページ",
+        "new-title": "存在しない新タイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // DUPLICATE_TITLE エラー (exit 5) が発生していないことを確認する
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).not.toContain("DUPLICATE_TITLE")
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+
+  it("新タイトルが persistent:true のページを返す場合、DUPLICATE_TITLE エラー (exit 5) になる", async () => {
+    // 前提: Cosense REST API が既存の実体ページ (persistent:true) を返す。
+    // 期待: 本当の重複なので DUPLICATE_TITLE エラー (exit 5) で終了する。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const project = decodeURIComponent(params["project"] as string)
+        const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "既存ページタイトル") {
+          // persistent:true の実体ページを返す
+          return HttpResponse.json({
+            id: "existing-page-id",
+            title: "既存ページタイトル",
+            persistent: true,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "既存ページタイトル",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "変更元ページ",
+        "new-title": "既存ページタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // DUPLICATE_TITLE エラー (exit 5) が発生することを確認する
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).toContain("DUPLICATE_TITLE")
+  })
+
+  it("新タイトルが 404 NotFoundError を返す場合、重複なしとして rename が継続する", async () => {
+    // 前提: Cosense REST API が 404 を返す (真のページなし)。
+    // 期待: NotFoundError は重複なしを意味するため、rename が継続する。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, () => {
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "既存ページ",
+        "new-title": "存在しないタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // DUPLICATE_TITLE エラー (exit 5) が発生していないことを確認する
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).not.toContain("DUPLICATE_TITLE")
+    expect(exitMock).not.toHaveBeenCalledWith(5)
   })
 })


### PR DESCRIPTION
## 概要

Cosense REST API が存在しないページに `persistent: false` のスタブとして 200 を返すため、`page rename` の重複チェックが常に偽陽性になっていた問題を修正します。

## 変更内容

- `src/commands/page/rename.ts`: `getPage` の返り値の `page.persistent === true` の場合のみ `DUPLICATE_TITLE` エラーを発生させるよう変更
- `tests/unit/commands/page/rename.test.ts`: `persistent: false` / `persistent: true` / `NotFoundError` の各ケースを追加

## テスト

- `persistent: false` のスタブページ → rename 成功（偽陽性修正の検証）
- `persistent: true` のページ → `DUPLICATE_TITLE` エラー（正常ケース）
- `NotFoundError` (404) → 重複なし（既存動作を維持）

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ページ名変更時の重複タイトル判定を改善。プレースホルダーページと実ページを区別して誤検出を防ぎ、既存の動作（ドライランや強制フォールバック）は維持します。

* **テスト**
  * ユニットテストを拡充し、重複検出の各ケース（実ページ・プレースホルダ・未検出・未指定フィールド等）を網羅しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->