### PR TITLE
fix(cli): --color never/always が無効でプレーン出力に ANSI コードが混入する問題を修正

### DIFF
--- a/src/infra/color.ts
+++ b/src/infra/color.ts
@@ -3,6 +3,10 @@
  *
  * --color=auto|always|never フラグと TTY 検出に基づき、
  * 色付け関数を提供する。
+ *
+ * picocolors はモジュールロード時に TTY を判定するため、
+ * always/never モードでは createColors(boolean) で明示的に
+ * ANSI 有効/無効のインスタンスを生成して使用する。
  */
 
 import pc from "picocolors"
@@ -18,7 +22,7 @@ let _enabled: boolean | null = null
 export function initColor(mode: ColorMode): void {
   if (mode === "always") _enabled = true
   else if (mode === "never") _enabled = false
-  else _enabled = process.stdout.isTTY // auto
+  else _enabled = process.stdout.isTTY ?? false // auto
 }
 
 /** isColorEnabled は現在の色付け設定を返す。 */
@@ -27,14 +31,27 @@ export function isColorEnabled(): boolean {
   return process.stdout.isTTY ?? false
 }
 
+/**
+ * _pc は現在の色付け設定に応じた picocolors インスタンスを返す。
+ *
+ * picocolors はモジュールロード時に isColorSupported を評価するため、
+ * TTY でない環境 (CI・パイプ等) で `always` を指定した場合でも
+ * デフォルトの pc では ANSI が出力されない。
+ * createColors(boolean) で明示的に enabled を指定したインスタンスを使うことで
+ * --color always/never を確実に反映する。
+ */
+function _pc(): ReturnType<typeof pc.createColors> {
+  return pc.createColors(isColorEnabled())
+}
+
 /** color は色付け関数のラッパーオブジェクト。 */
 export const color = {
-  bold: (s: string) => (isColorEnabled() ? pc.bold(s) : s),
-  dim: (s: string) => (isColorEnabled() ? pc.dim(s) : s),
-  red: (s: string) => (isColorEnabled() ? pc.red(s) : s),
-  green: (s: string) => (isColorEnabled() ? pc.green(s) : s),
-  yellow: (s: string) => (isColorEnabled() ? pc.yellow(s) : s),
-  blue: (s: string) => (isColorEnabled() ? pc.blue(s) : s),
-  cyan: (s: string) => (isColorEnabled() ? pc.cyan(s) : s),
-  gray: (s: string) => (isColorEnabled() ? pc.gray(s) : s),
+  bold: (s: string) => _pc().bold(s),
+  dim: (s: string) => _pc().dim(s),
+  red: (s: string) => _pc().red(s),
+  green: (s: string) => _pc().green(s),
+  yellow: (s: string) => _pc().yellow(s),
+  blue: (s: string) => _pc().blue(s),
+  cyan: (s: string) => _pc().cyan(s),
+  gray: (s: string) => _pc().gray(s),
 }

--- a/src/presenter/plain.ts
+++ b/src/presenter/plain.ts
@@ -4,8 +4,13 @@
  * cli-table3 でボーダー付きテーブルを描画するか、
  * タブ区切り (TSV) で出力するかを選択できる。
  * AI エージェントやスクリプトには TSV が扱いやすい。
+ *
+ * cli-table3 は独自に ANSI エスケープコードを出力するため、
+ * isColorEnabled() の値を style オプションとして渡すことで
+ * --color never/always フラグを確実に反映する。
  */
 
+import { isColorEnabled } from "@/infra/color"
 import Table from "cli-table3"
 
 /** PlainOutputOptions はテキスト出力のオプション。 */
@@ -19,6 +24,9 @@ export interface PlainOutputOptions {
 /**
  * writePlainTable は cli-table3 を使ってボーダー付きテーブルを出力する。
  * TTY 環境での人間向け表示に適する。
+ *
+ * cli-table3 は style.head / style.border で色付けを行う。
+ * isColorEnabled() が false の場合は空配列を渡して ANSI コードを抑制する。
  */
 export function writePlainTable(
   headers: string[],
@@ -26,7 +34,12 @@ export function writePlainTable(
   opts: PlainOutputOptions = {},
 ): void {
   const stream = opts.stream ?? process.stdout
-  const table = new Table({ head: headers })
+  // 色無効時は head/border スタイルを空にして ANSI コードを抑制する。
+  // exactOptionalPropertyTypes のため、undefined を渡さずスプレッドで条件付きマージする。
+  const tableOpts = isColorEnabled()
+    ? { head: headers }
+    : { head: headers, style: { head: [] as string[], border: [] as string[] } }
+  const table = new Table(tableOpts)
   for (const row of rows) {
     table.push(row)
   }

--- a/src/presenter/plain.ts
+++ b/src/presenter/plain.ts
@@ -5,12 +5,12 @@
  * タブ区切り (TSV) で出力するかを選択できる。
  * AI エージェントやスクリプトには TSV が扱いやすい。
  *
- * cli-table3 は独自に ANSI エスケープコードを出力するため、
- * isColorEnabled() の値を style オプションとして渡すことで
- * --color never/always フラグを確実に反映する。
+ * cli-table3 は @colors/colors の TTY 検出に依存するため --color always/never を直接制御できない。
+ * ヘッダーを picocolors で色付けし、cli-table3 のネイティブスタイルは常に無効化することで
+ * isColorEnabled() の設定を確実に反映する。
  */
 
-import { isColorEnabled } from "@/infra/color"
+import { color, isColorEnabled } from "@/infra/color"
 import Table from "cli-table3"
 
 /** PlainOutputOptions はテキスト出力のオプション。 */
@@ -25,8 +25,8 @@ export interface PlainOutputOptions {
  * writePlainTable は cli-table3 を使ってボーダー付きテーブルを出力する。
  * TTY 環境での人間向け表示に適する。
  *
- * cli-table3 は style.head / style.border で色付けを行う。
- * isColorEnabled() が false の場合は空配列を渡して ANSI コードを抑制する。
+ * cli-table3 のネイティブスタイルは常に無効化し、ヘッダーを picocolors で色付けする。
+ * これにより --color never/always の設定が非 TTY 環境でも確実に反映される。
  */
 export function writePlainTable(
   headers: string[],
@@ -34,12 +34,14 @@ export function writePlainTable(
   opts: PlainOutputOptions = {},
 ): void {
   const stream = opts.stream ?? process.stdout
-  // 色無効時は head/border スタイルを空にして ANSI コードを抑制する。
-  // exactOptionalPropertyTypes のため、undefined を渡さずスプレッドで条件付きマージする。
-  const tableOpts = isColorEnabled()
-    ? { head: headers }
-    : { head: headers, style: { head: [] as string[], border: [] as string[] } }
-  const table = new Table(tableOpts)
+  // cli-table3 は @colors/colors の TTY 検出に依存するため --color always でも
+  // 非 TTY 環境では ANSI を出力しない。ヘッダーを picocolors で色付けすることで
+  // isColorEnabled() の設定を確実に反映する。
+  const styledHeaders = isColorEnabled() ? headers.map((h) => color.bold(h)) : headers
+  const table = new Table({
+    head: styledHeaders,
+    style: { head: [] as string[], border: [] as string[] },
+  })
   for (const row of rows) {
     table.push(row)
   }

--- a/tests/unit/infra/color.test.ts
+++ b/tests/unit/infra/color.test.ts
@@ -29,10 +29,10 @@ describe("color.ts", () => {
 
     test("always モードで color.red が ANSI コードを含む", () => {
       initColor("always")
-      const 結果 = color.red("テスト文字列")
-      expect(結果).toContain("テスト文字列")
+      const result = color.red("テスト文字列")
+      expect(result).toContain("テスト文字列")
       // ANSI コード付きのため元の文字列とは異なるはず
-      expect(結果).not.toBe("テスト文字列")
+      expect(result).not.toBe("テスト文字列")
     })
 
     test("never モードで color.gray が ANSI なしを返す", () => {
@@ -42,9 +42,9 @@ describe("color.ts", () => {
 
     test("always モードで color.gray が ANSI コードを含む", () => {
       initColor("always")
-      const 結果 = color.gray("グレー文字")
-      expect(結果).toContain("グレー文字")
-      expect(結果).not.toBe("グレー文字")
+      const result = color.gray("グレー文字")
+      expect(result).toContain("グレー文字")
+      expect(result).not.toBe("グレー文字")
     })
   })
 })

--- a/tests/unit/infra/color.test.ts
+++ b/tests/unit/infra/color.test.ts
@@ -1,0 +1,50 @@
+/**
+ * src/infra/color.ts のユニットテスト。
+ *
+ * initColor(mode) で色付けを初期化し、isColorEnabled() で状態を確認できること、
+ * color.* ラッパーが never モードで ANSI なし・always モードで ANSI ありを返すことを検証する。
+ */
+
+import { describe, expect, test } from "bun:test"
+import { color, initColor, isColorEnabled } from "@/infra/color"
+
+describe("color.ts", () => {
+  describe("initColor", () => {
+    test("never モードで isColorEnabled が false を返す", () => {
+      initColor("never")
+      expect(isColorEnabled()).toBe(false)
+    })
+
+    test("always モードで isColorEnabled が true を返す", () => {
+      initColor("always")
+      expect(isColorEnabled()).toBe(true)
+    })
+  })
+
+  describe("color wrapper", () => {
+    test("never モードで color.red が ANSI なしを返す", () => {
+      initColor("never")
+      expect(color.red("テスト文字列")).toBe("テスト文字列")
+    })
+
+    test("always モードで color.red が ANSI コードを含む", () => {
+      initColor("always")
+      const 結果 = color.red("テスト文字列")
+      expect(結果).toContain("テスト文字列")
+      // ANSI コード付きのため元の文字列とは異なるはず
+      expect(結果).not.toBe("テスト文字列")
+    })
+
+    test("never モードで color.gray が ANSI なしを返す", () => {
+      initColor("never")
+      expect(color.gray("グレー文字")).toBe("グレー文字")
+    })
+
+    test("always モードで color.gray が ANSI コードを含む", () => {
+      initColor("always")
+      const 結果 = color.gray("グレー文字")
+      expect(結果).toContain("グレー文字")
+      expect(結果).not.toBe("グレー文字")
+    })
+  })
+})

--- a/tests/unit/presenter/plain.test.ts
+++ b/tests/unit/presenter/plain.test.ts
@@ -3,9 +3,13 @@
  *
  * cli-table3 を使ったテーブル出力と TSV 出力を検証する。
  * 出力先 stream を差し替えて副作用なしにテストする。
+ *
+ * writePlainTable は initColor(mode) の設定に従い、
+ * never モードでは ANSI コードなし、always モードでは ANSI コードありで出力する。
  */
 
 import { describe, expect, it } from "bun:test"
+import { initColor } from "@/infra/color"
 import { writePlainList, writePlainTable, writeTsv } from "@/presenter/plain"
 
 /** WritableStream の代わりに文字列を収集するモックストリーム */
@@ -19,6 +23,12 @@ function createMockStream() {
       return buffer
     },
   }
+}
+
+/** containsAnsi は文字列に ANSI エスケープコード (ESC + '[') が含まれるか判定する。 */
+function containsAnsi(s: string): boolean {
+  // ESC (0x1B) の文字コードで判定する（正規表現の制御文字を避けるため）
+  return s.split("").some((c) => c.charCodeAt(0) === 0x1b)
 }
 
 describe("writePlainTable", () => {
@@ -44,6 +54,26 @@ describe("writePlainTable", () => {
       stream: stream as unknown as NodeJS.WritableStream,
     })
     expect(stream.output).toContain("タイトル")
+  })
+
+  it("never モードで ANSI コードが含まれない", () => {
+    // --color never 時はテーブルの罫線・ヘッダーに ANSI コードが含まれないこと
+    initColor("never")
+    const stream = createMockStream()
+    writePlainTable(["タイトル", "件数"], [["ホームページ", "100"]], {
+      stream: stream as unknown as NodeJS.WritableStream,
+    })
+    expect(containsAnsi(stream.output)).toBe(false)
+  })
+
+  it("always モードで ANSI コードが含まれる", () => {
+    // --color always 時はテーブルの罫線・ヘッダーに ANSI コードが含まれること
+    initColor("always")
+    const stream = createMockStream()
+    writePlainTable(["タイトル", "件数"], [["ホームページ", "100"]], {
+      stream: stream as unknown as NodeJS.WritableStream,
+    })
+    expect(containsAnsi(stream.output)).toBe(true)
   })
 })
 

--- a/tests/unit/presenter/plain.test.ts
+++ b/tests/unit/presenter/plain.test.ts
@@ -25,7 +25,7 @@ function createMockStream() {
   }
 }
 
-/** containsAnsi は文字列に ANSI エスケープコード (ESC + '[') が含まれるか判定する。 */
+/** containsAnsi は文字列に ANSI エスケープコード (ESC: 0x1B) が含まれるか判定する。 */
 function containsAnsi(s: string): boolean {
   // ESC (0x1B) の文字コードで判定する（正規表現の制御文字を避けるため）
   return s.split("").some((c) => c.charCodeAt(0) === 0x1b)


### PR DESCRIPTION
## 概要

`--color never` / `--color always` が機能せず、どちらも ANSI コード付きの出力を返していた問題を修正します。

## 根本原因

根本原因は2つありました:

1. **picocolors の TTY 固定判定**: picocolors はモジュールロード時に `isColorSupported` を一度だけ評価するため、非 TTY 環境（パイプ、CI）では `--color always` を指定しても ANSI が出力されなかった。
2. **cli-table3 の独立した ANSI 出力**: `writePlainTable` が使用する cli-table3 は `style.head` / `style.border` で独自に色を適用するため、`isColorEnabled()` の制御が届かず `--color never` 指定時も ANSI コードが出力されていた。

## 変更内容

- `src/infra/color.ts`: `color.*` ラッパーを `pc.createColors(isColorEnabled())` で動的生成したインスタンス経由に変更。`always` モードで非 TTY 環境でも正しく ANSI を出力し、`never` モードで確実に ANSI を抑制する。
- `src/presenter/plain.ts`: `isColorEnabled()` の値に応じて cli-table3 の `style` オプションを制御するよう修正。`never` モード時は `style: { head: [], border: [] }` を渡して ANSI を抑制する。
- `tests/unit/infra/color.test.ts`: 新規作成。never/always モードの unit test（6 件）
- `tests/unit/presenter/plain.test.ts`: never/always モードの ANSI 有無を検証するテストを追加（2 件）

## テスト

- `initColor("never")` → `isColorEnabled()` が `false`
- `initColor("always")` → `isColorEnabled()` が `true`
- `color.red("x")` が never モードで ANSI なし、always モードで ANSI あり
- `writePlainTable` が never モードで ANSI なし、always モードで ANSI あり

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * `--color`（always/never）が非TTY環境でも確実に反映されるようになりました
  * プレーンテーブル出力で `--color never` 指定時にANSIエスケープコードが抑制され、出力の装飾が無効化されます

* **テスト**
  * 色出力制御に関するユニットテストを追加しました
  * プレーンテーブル出力のANSI挙動を検証するテストを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/68)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->