### PR TITLE
fix(page): --from-file - が citty のパースバグで空文字に変換される問題を修正

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -166,6 +166,16 @@ export function buildJsonOpts(args: CommonArgs): JsonOutputOptions {
   return opts
 }
 
+/**
+ * isStdinPath は --from-file の値が stdin を指すかどうかを判定する。
+ *
+ * citty が `--from-file -` の `-` を空文字列 `""` に変換するため、
+ * `""` も stdin (`"-"`) と同等に扱う。
+ */
+export function isStdinPath(path: string | undefined): boolean {
+  return path === "-" || path === ""
+}
+
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
 export async function requireSid(profile?: string): Promise<string> {
   // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -167,7 +167,7 @@ export function buildJsonOpts(args: CommonArgs): JsonOutputOptions {
 }
 
 /**
- * isStdinPath は --from-file の値が stdin を指すかどうかを判定する。
+ * isStdinPath は path が stdin を指すかどうかを示す boolean を返す。
  *
  * citty が `--from-file -` の `-` を空文字列 `""` に変換するため、
  * `""` も stdin (`"-"`) と同等に扱う。

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -14,6 +14,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  isStdinPath,
   requireProject,
 } from "@/commands/_shared"
 import { appendToPage } from "@/core/pages"
@@ -49,7 +50,7 @@ export const pageAppendCommand = defineCommand({
     let lines: string[] = []
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
-    } else if (a["from-file"] === "-") {
+    } else if (isStdinPath(a["from-file"])) {
       const content = readFileSync(0, "utf-8")
       lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
     } else if (a["from-file"]) {

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -16,6 +16,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  isStdinPath,
   requireProject,
 } from "@/commands/_shared"
 import { convert } from "@/core/format/index"
@@ -69,7 +70,8 @@ export const pageEditCommand = defineCommand({
     }
 
     let content: string
-    if (a["from-file"] === "-") {
+    if (isStdinPath(a["from-file"])) {
+      // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
       content = readFileSync(0, "utf-8")
     } else {
       content = readFileSync(a["from-file"], "utf-8")

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -15,6 +15,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  isStdinPath,
   requireProject,
 } from "@/commands/_shared"
 import { insertIntoPage } from "@/core/pages"
@@ -72,10 +73,12 @@ export const pageInsertCommand = defineCommand({
     let lines: string[] = []
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
-    } else if (a["from-file"]) {
+    } else if (a["from-file"] !== undefined) {
       try {
-        const content =
-          a["from-file"] === "-" ? readFileSync(0, "utf-8") : readFileSync(a["from-file"], "utf-8")
+        // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
+        const content = isStdinPath(a["from-file"])
+          ? readFileSync(0, "utf-8")
+          : readFileSync(a["from-file"], "utf-8")
         lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
       } catch {
         writeErrorJson(

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -14,6 +14,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  isStdinPath,
   requireProject,
 } from "@/commands/_shared"
 import { createPage } from "@/core/pages"
@@ -53,8 +54,8 @@ export const pageNewCommand = defineCommand({
     const startTime = Date.now()
 
     let lines: string[] = []
-    if (a["from-file"] === "-") {
-      // stdin から読み込む
+    if (isStdinPath(a["from-file"])) {
+      // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
       const content = readFileSync(0, "utf-8")
       lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
     } else if (a["from-file"]) {

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -14,6 +14,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  isStdinPath,
   requireProject,
 } from "@/commands/_shared"
 import { prependToPage } from "@/core/pages"
@@ -49,10 +50,12 @@ export const pagePrependCommand = defineCommand({
     let lines: string[] = []
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
-    } else if (a["from-file"]) {
+    } else if (a["from-file"] !== undefined) {
       try {
-        const content =
-          a["from-file"] === "-" ? readFileSync(0, "utf-8") : readFileSync(a["from-file"], "utf-8")
+        // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
+        const content = isStdinPath(a["from-file"])
+          ? readFileSync(0, "utf-8")
+          : readFileSync(a["from-file"], "utf-8")
         lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
       } catch {
         writeErrorJson(

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { commonArgs, dryRunArg } from "@/commands/_shared"
+import { commonArgs, dryRunArg, isStdinPath } from "@/commands/_shared"
 
 describe("commonArgs", () => {
   it("--dry-run キーを含まない (読み取り専用コマンド向け)", () => {
@@ -29,5 +29,29 @@ describe("dryRunArg", () => {
 
   it("dry-run フラグのデフォルト値は false", () => {
     expect(dryRunArg["dry-run"].default).toBe(false)
+  })
+})
+
+describe("isStdinPath", () => {
+  it('"-" はstdinパスとして認識される', () => {
+    // cos page new --from-file - のように明示的に - を渡したケース
+    expect(isStdinPath("-")).toBe(true)
+  })
+
+  it('"" (空文字) はstdinパスとして認識される (citty が --from-file - を空文字に変換するバグへの対応)', () => {
+    // citty のパースバグで --from-file - が "" として渡されるケース
+    expect(isStdinPath("")).toBe(true)
+  })
+
+  it('"somefile.txt" はstdinパスとして認識されない', () => {
+    expect(isStdinPath("somefile.txt")).toBe(false)
+  })
+
+  it('"/tmp/content.txt" はstdinパスとして認識されない', () => {
+    expect(isStdinPath("/tmp/content.txt")).toBe(false)
+  })
+
+  it("undefined はstdinパスとして認識されない", () => {
+    expect(isStdinPath(undefined)).toBe(false)
   })
 })

--- a/tests/unit/commands/page/append.test.ts
+++ b/tests/unit/commands/page/append.test.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   capturedAppendCalls.splice(0)
 })
 

--- a/tests/unit/commands/page/append.test.ts
+++ b/tests/unit/commands/page/append.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  capturedAppendCalls.length = 0
+  capturedAppendCalls.splice(0)
 })
 
 afterEach(() => {
@@ -137,6 +137,22 @@ describe("pageAppendCommand", () => {
     }
     expect(exitMock).toHaveBeenCalledWith(5)
     expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
+  })
+
+  it("--line を指定した場合は appendToPage に行が渡される", async () => {
+    await runAppend({
+      title: "テストページ",
+      line: "追加行テキスト",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // --line の内容が appendToPage に渡されること
+    expect(capturedAppendCalls).toHaveLength(1)
+    expect(capturedAppendCalls[0]?.lines).toEqual(["追加行テキスト"])
   })
 
   it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {

--- a/tests/unit/commands/page/append.test.ts
+++ b/tests/unit/commands/page/append.test.ts
@@ -1,7 +1,7 @@
 /**
  * page/append.test.ts — `cos page append <title>` コマンドのテスト。
  *
- * 基本的な append 動作と --line の実改行展開を検証する。
+ * --line 指定、--from-file での stdin 読み込み (- と "" の両対応) を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
@@ -11,6 +11,19 @@ import { pageAppendCommand } from "@/commands/page/append"
 const capturedAppendCalls: { lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
+mock.module("node:fs", () => ({
+  readFileSync: (pathOrFd: number | string, encoding: string) => {
+    if (pathOrFd === 0) return "stdinの行1\nstdinの行2\n"
+    // "fs" は "node:fs" と Bun のモックレジストリ上で別エントリのためモックの影響外
+    // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+    return (require("fs") as typeof import("node:fs")).readFileSync(
+      pathOrFd as Parameters<typeof import("node:fs").readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  },
+}))
+
 mock.module("@/core/pages", () => ({
   appendToPage: mock(
     async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
@@ -24,7 +37,6 @@ let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
 let stderrMock: ReturnType<typeof spyOn>
 
-/** コマンド run ヘルパー */
 async function runAppend(args: Record<string, unknown>) {
   await (
     pageAppendCommand.run as (ctx: {
@@ -46,9 +58,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  // 各テスト前にキャプチャを初期化する
   capturedAppendCalls.length = 0
 })
 
@@ -127,5 +137,41 @@ describe("pageAppendCommand", () => {
     }
     expect(exitMock).toHaveBeenCalledWith(5)
     expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("CONTENT_REQUIRED"))
+  })
+
+  it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {
+    // citty が正しく "-" を渡したケース
+    await runAppend({
+      title: "テストページ",
+      "from-file": "-",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    expect(capturedAppendCalls).toHaveLength(1)
+    expect(capturedAppendCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedAppendCalls[0]?.lines).toContain("stdinの行2")
+  })
+
+  it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
+    // citty が --from-file - を "" に変換するバグへの対応
+    await runAppend({
+      title: "テストページ",
+      "from-file": "",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // "" もstdinとして扱われ、CONTENT_REQUIRED にならずコンテンツが渡されること
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(capturedAppendCalls).toHaveLength(1)
+    expect(capturedAppendCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedAppendCalls[0]?.lines).toContain("stdinの行2")
   })
 })

--- a/tests/unit/commands/page/edit-stdin.test.ts
+++ b/tests/unit/commands/page/edit-stdin.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import { pageEditCommand } from "@/commands/page/edit"
 
 /** editPage に渡された引数をキャプチャする */
-const capturedEditPageCalls: { lines: string[] }[] = []
+const capturedEditPageCalls: { project: string; title: string; lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
 // 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
@@ -29,7 +29,7 @@ mock.module("node:fs", () => ({
 mock.module("@/core/pages", () => ({
   editPage: mock(
     async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
-      capturedEditPageCalls.push({ lines: opts.lines })
+      capturedEditPageCalls.push({ project: opts.project, title: opts.title, lines: opts.lines })
       return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
     },
   ),
@@ -57,7 +57,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  capturedEditPageCalls.length = 0
+  capturedEditPageCalls.splice(0)
 })
 
 afterEach(() => {
@@ -84,6 +84,8 @@ describe("pageEditCommand stdin 読み込み", () => {
     // stdin からコンテンツが読み込まれ editPage に渡されること
     expect(exitMock).not.toHaveBeenCalledWith(5)
     expect(capturedEditPageCalls).toHaveLength(1)
+    expect(capturedEditPageCalls[0]?.project).toBe("テストプロジェクト")
+    expect(capturedEditPageCalls[0]?.title).toBe("テストページ")
     expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行1")
     expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行2")
   })
@@ -104,6 +106,8 @@ describe("pageEditCommand stdin 読み込み", () => {
     // "" もstdinとして扱われ、ENOENT にならず editPage にコンテンツが渡されること
     expect(exitMock).not.toHaveBeenCalledWith(5)
     expect(capturedEditPageCalls).toHaveLength(1)
+    expect(capturedEditPageCalls[0]?.project).toBe("テストプロジェクト")
+    expect(capturedEditPageCalls[0]?.title).toBe("テストページ")
     expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行1")
     expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行2")
   })

--- a/tests/unit/commands/page/edit-stdin.test.ts
+++ b/tests/unit/commands/page/edit-stdin.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   capturedEditPageCalls.splice(0)
 })
 

--- a/tests/unit/commands/page/edit-stdin.test.ts
+++ b/tests/unit/commands/page/edit-stdin.test.ts
@@ -1,0 +1,110 @@
+/**
+ * page/edit-stdin.test.ts — `cos page edit` コマンドの stdin 読み込みテスト。
+ *
+ * citty のパースバグで --from-file - が "" として渡される問題の修正を検証する。
+ * node:fs をモックして stdin (fd=0) から固定コンテンツを返す。
+ * 既存の edit.test.ts はファイル I/O を使うため分離している。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { pageEditCommand } from "@/commands/page/edit"
+
+/** editPage に渡された引数をキャプチャする */
+const capturedEditPageCalls: { lines: string[] }[] = []
+
+// Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
+mock.module("node:fs", () => ({
+  readFileSync: (pathOrFd: number | string, encoding: string) => {
+    if (pathOrFd === 0) return "stdinの行1\nstdinの行2\n"
+    // "fs" は "node:fs" と Bun のモックレジストリ上で別エントリのためモックの影響外
+    // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+    return (require("fs") as typeof import("node:fs")).readFileSync(
+      pathOrFd as Parameters<typeof import("node:fs").readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  },
+}))
+
+mock.module("@/core/pages", () => ({
+  editPage: mock(
+    async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
+      capturedEditPageCalls.push({ lines: opts.lines })
+      return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
+    },
+  ),
+}))
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+async function runEdit(args: Record<string, unknown>) {
+  await (
+    pageEditCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  capturedEditPageCalls.length = 0
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageEditCommand stdin 読み込み", () => {
+  it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {
+    // citty が正しく "-" を渡したケース
+    await runEdit({
+      title: "テストページ",
+      "from-file": "-",
+      "input-format": "txt",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // stdin からコンテンツが読み込まれ editPage に渡されること
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(capturedEditPageCalls).toHaveLength(1)
+    expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行2")
+  })
+
+  it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
+    // citty が --from-file - を "" に変換するバグへの対応
+    await runEdit({
+      title: "テストページ",
+      "from-file": "",
+      "input-format": "txt",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // "" もstdinとして扱われ、ENOENT にならず editPage にコンテンツが渡されること
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(capturedEditPageCalls).toHaveLength(1)
+    expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedEditPageCalls[0]?.lines).toContain("stdinの行2")
+  })
+})

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -63,7 +63,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  capturedInsertCalls.length = 0
+  capturedInsertCalls.splice(0)
 })
 
 afterEach(() => {

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -1,5 +1,7 @@
 /**
  * page/insert.test.ts — `cos page insert <title> --after <n>` コマンドのテスト。
+ *
+ * --from-file での stdin 読み込み (- と "" の両対応) を含む。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
@@ -9,6 +11,19 @@ import { pageInsertCommand } from "@/commands/page/insert"
 const capturedInsertCalls: { lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
+mock.module("node:fs", () => ({
+  readFileSync: (pathOrFd: number | string, encoding: string) => {
+    if (pathOrFd === 0) return "stdinの行1\nstdinの行2\n"
+    // "fs" は "node:fs" と Bun のモックレジストリ上で別エントリのためモックの影響外
+    // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+    return (require("fs") as typeof import("node:fs")).readFileSync(
+      pathOrFd as Parameters<typeof import("node:fs").readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  },
+}))
+
 mock.module("@/core/pages", () => ({
   insertIntoPage: mock(
     async (
@@ -47,9 +62,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
-  process.env["COS_SID"] = "s%3Atest-session-id"
-  // 各テスト前にキャプチャを初期化する
+  process.env["COS_SID"] = "ダミーセッションID-テスト用"
   capturedInsertCalls.length = 0
 })
 
@@ -155,5 +168,43 @@ describe("pageInsertCommand", () => {
     // 実改行（\n）が展開され、lines が ["挿入行A", "挿入行B"] の2行になること
     expect(capturedInsertCalls).toHaveLength(1)
     expect(capturedInsertCalls[0]?.lines).toEqual(["挿入行A", "挿入行B"])
+  })
+
+  it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {
+    // citty が正しく "-" を渡したケース
+    await runInsert({
+      title: "テストページ",
+      after: "1",
+      "from-file": "-",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    expect(capturedInsertCalls).toHaveLength(1)
+    expect(capturedInsertCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedInsertCalls[0]?.lines).toContain("stdinの行2")
+  })
+
+  it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
+    // citty が --from-file - を "" に変換するバグへの対応
+    await runInsert({
+      title: "テストページ",
+      after: "1",
+      "from-file": "",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // "" もstdinとして扱われ、CONTENT_REQUIRED にならずコンテンツが渡されること
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(capturedInsertCalls).toHaveLength(1)
+    expect(capturedInsertCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedInsertCalls[0]?.lines).toContain("stdinの行2")
   })
 })

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -62,7 +62,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   capturedInsertCalls.splice(0)
 })
 

--- a/tests/unit/commands/page/new.test.ts
+++ b/tests/unit/commands/page/new.test.ts
@@ -62,7 +62,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   // 各テスト前にキャプチャを初期化する
   capturedCreatePageCalls.length = 0
 })

--- a/tests/unit/commands/page/new.test.ts
+++ b/tests/unit/commands/page/new.test.ts
@@ -1,7 +1,8 @@
 /**
  * page/new.test.ts — `cos page new <title>` コマンドのテスト。
  *
- * --line の \n 展開、--line 複数指定、--dry-run 時の success メッセージ抑制を検証する。
+ * --line の \n 展開、--line 複数指定、--dry-run 時の success メッセージ抑制、
+ * --from-file - / "" での stdin 読み込みを検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
@@ -11,6 +12,20 @@ import { pageNewCommand } from "@/commands/page/new"
 const capturedCreatePageCalls: { lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// node:fs をモックして stdin (fd=0) から固定コンテンツを返す
+// 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
+mock.module("node:fs", () => ({
+  readFileSync: (pathOrFd: number | string, encoding: string) => {
+    if (pathOrFd === 0) return "stdinの行1\nstdinの行2\n"
+    // "fs" は "node:fs" と Bun のモックレジストリ上で別エントリのためモックの影響外
+    // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+    return (require("fs") as typeof import("node:fs")).readFileSync(
+      pathOrFd as Parameters<typeof import("node:fs").readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  },
+}))
+
 mock.module("@/core/pages", () => ({
   createPage: mock(
     async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
@@ -158,6 +173,42 @@ describe("pageNewCommand", () => {
     // 配列要素内の実改行（\n）も分割されること
     expect(capturedCreatePageCalls).toHaveLength(1)
     expect(capturedCreatePageCalls[0]?.lines).toEqual(["行1", "行2", "行3"])
+  })
+
+  it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {
+    // citty が正しく "-" を渡したケース
+    await runNew({
+      title: "テストページ",
+      "from-file": "-",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // stdin からコンテンツが読み込まれ createPage に渡されること
+    expect(capturedCreatePageCalls).toHaveLength(1)
+    expect(capturedCreatePageCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedCreatePageCalls[0]?.lines).toContain("stdinの行2")
+  })
+
+  it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
+    // citty が --from-file - を "" に変換するバグへの対応
+    await runNew({
+      title: "テストページ",
+      "from-file": "",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // "" もstdinとして扱われ、createPage にコンテンツが渡されること
+    expect(capturedCreatePageCalls).toHaveLength(1)
+    expect(capturedCreatePageCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedCreatePageCalls[0]?.lines).toContain("stdinの行2")
   })
 
   it("--dry-run 時は success メッセージが stderr に出力されない", async () => {

--- a/tests/unit/commands/page/prepend.test.ts
+++ b/tests/unit/commands/page/prepend.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  capturedPrependCalls.length = 0
+  capturedPrependCalls.splice(0)
 })
 
 afterEach(() => {

--- a/tests/unit/commands/page/prepend.test.ts
+++ b/tests/unit/commands/page/prepend.test.ts
@@ -1,5 +1,7 @@
 /**
  * page/prepend.test.ts — `cos page prepend <title>` コマンドのテスト。
+ *
+ * --from-file での stdin 読み込み (- と "" の両対応) を含む。
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
@@ -9,6 +11,19 @@ import { pagePrependCommand } from "@/commands/page/prepend"
 const capturedPrependCalls: { lines: string[] }[] = []
 
 // Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// 実ファイルは "fs" モジュール ("node:fs" と別レジストリ) 経由でパススルーする
+mock.module("node:fs", () => ({
+  readFileSync: (pathOrFd: number | string, encoding: string) => {
+    if (pathOrFd === 0) return "stdinの行1\nstdinの行2\n"
+    // "fs" は "node:fs" と Bun のモックレジストリ上で別エントリのためモックの影響外
+    // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+    return (require("fs") as typeof import("node:fs")).readFileSync(
+      pathOrFd as Parameters<typeof import("node:fs").readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  },
+}))
+
 mock.module("@/core/pages", () => ({
   prependToPage: mock(
     async (_writer: unknown, opts: { project: string; title: string; lines: string[] }) => {
@@ -44,9 +59,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
   process.env["COS_SID"] = "ダミーセッションID-テスト用"
-  // 各テスト前にキャプチャを初期化する
   capturedPrependCalls.length = 0
 })
 
@@ -109,5 +122,41 @@ describe("pagePrependCommand", () => {
     // 実改行（\n）が展開され、lines が ["先頭行A", "先頭行B"] の2行になること
     expect(capturedPrependCalls).toHaveLength(1)
     expect(capturedPrependCalls[0]?.lines).toEqual(["先頭行A", "先頭行B"])
+  })
+
+  it("--from-file '-' (明示的なstdin指定) でstdinからコンテンツを読み込む", async () => {
+    // citty が正しく "-" を渡したケース
+    await runPrepend({
+      title: "テストページ",
+      "from-file": "-",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    expect(capturedPrependCalls).toHaveLength(1)
+    expect(capturedPrependCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedPrependCalls[0]?.lines).toContain("stdinの行2")
+  })
+
+  it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
+    // citty が --from-file - を "" に変換するバグへの対応
+    await runPrepend({
+      title: "テストページ",
+      "from-file": "",
+      project: "テストプロジェクト",
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+    // "" もstdinとして扱われ、CONTENT_REQUIRED にならずコンテンツが渡されること
+    expect(exitMock).not.toHaveBeenCalledWith(5)
+    expect(capturedPrependCalls).toHaveLength(1)
+    expect(capturedPrependCalls[0]?.lines).toContain("stdinの行1")
+    expect(capturedPrependCalls[0]?.lines).toContain("stdinの行2")
   })
 })

--- a/tests/unit/commands/page/prepend.test.ts
+++ b/tests/unit/commands/page/prepend.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "s%3Atest-session-id"
   capturedPrependCalls.splice(0)
 })
 


### PR DESCRIPTION
## Summary

- `_shared.ts` に `isStdinPath(path)` ヘルパーを追加し、`"-"` と `""` の両方を stdin として判定するようにした
- `page/new`, `page/edit`, `page/append`, `page/prepend`, `page/insert` の 5 コマンドで `isStdinPath()` を使用するよう修正
- `prepend` と `insert` は `else if (a["from-file"])` (falsy チェック) を `else if (a["from-file"] !== undefined)` に変更し `""` が除外されないようにした

## Background

citty が `--from-file -` の `-` を空文字列 `""` にパースするバグにより、stdin からのコンテンツ読み込みが動作しなかった。

```bash
# 修正前: コンテンツが読み込まれず CONTENT_REQUIRED エラー
printf "行1\n行2" | cos page new "タイトル" -p my-project --from-file -

# 修正後: stdin からコンテンツを正常に読み込む
printf "行1\n行2" | cos page new "タイトル" -p my-project --from-file -
```

## Test plan

- [x] `isStdinPath("")` と `isStdinPath("-")` が `true` を返すことをユニットテストで確認
- [x] `page/new`, `page/edit`, `page/append`, `page/prepend`, `page/insert` の各コマンドで `from-file: ""` がstdinを読み込むことをテストで確認
- [x] Biome lint: 警告ゼロ
- [x] TypeScript 型チェック: エラーゼロ
- [x] `bun test`: 751 pass / 0 fail

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ページ関連コマンドの `--from-file` における標準入力判定を改善しました。"-" と空文字列の両方を標準入力として扱うようになり、外部ツールの変換による誤判定を回避します。

* **テスト**
  * 標準入力周りのユニットテストを大幅に拡充し、複数のエッジケースを検証しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/69)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->