### PR TITLE
fix(page/insert): --after に負値を渡したときエラーメッセージの値表示が空になる問題を修正

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -181,19 +181,20 @@ export function isStdinPath(path: string | undefined): boolean {
  *
  * citty が `--flag -N` の負数引数をフラグとして解析し、値が空文字になるバグの回避策。
  * `--flag value` と `--flag=value` の両形式を解析する。
+ * 同一フラグが複数回指定された場合は最後の値を返す（CLI の一般的な挙動）。
  */
 export function getRawFlagValue(argv: string[], flagName: string): string | undefined {
   const longFlag = `--${flagName}`
+  let result: string | undefined = undefined
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === longFlag && i + 1 < argv.length) {
-      return argv[i + 1]
-    }
-    if (arg?.startsWith(`${longFlag}=`)) {
-      return arg.slice(longFlag.length + 1)
+      result = argv[i + 1]
+    } else if (arg?.startsWith(`${longFlag}=`)) {
+      result = arg.slice(longFlag.length + 1)
     }
   }
-  return undefined
+  return result
 }
 
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -176,6 +176,26 @@ export function isStdinPath(path: string | undefined): boolean {
   return path === "-" || path === ""
 }
 
+/**
+ * getRawFlagValue は argv から指定フラグの生の値を返す。
+ *
+ * citty が `--flag -N` の負数引数をフラグとして解析し、値が空文字になるバグの回避策。
+ * `--flag value` と `--flag=value` の両形式を解析する。
+ */
+export function getRawFlagValue(argv: string[], flagName: string): string | undefined {
+  const longFlag = `--${flagName}`
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === longFlag && i + 1 < argv.length) {
+      return argv[i + 1]
+    }
+    if (arg?.startsWith(`${longFlag}=`)) {
+      return arg.slice(longFlag.length + 1)
+    }
+  }
+  return undefined
+}
+
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
 export async function requireSid(profile?: string): Promise<string> {
   // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -15,6 +15,7 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
+  getRawFlagValue,
   isStdinPath,
   requireProject,
 } from "@/commands/_shared"
@@ -59,16 +60,19 @@ export const pageInsertCommand = defineCommand({
     const startTime = Date.now()
 
     // --after バリデーション (1-indexed、正の整数のみ許可。"1abc" や "1.5" は弾く)
-    if (!/^[1-9]\d*$/.test(a.after)) {
+    // citty が負数引数をフラグとして解析し a.after が "" になるバグに対応するため、
+    // process.argv から実値を取得してエラーメッセージに表示する
+    const rawAfter = a.after !== "" ? a.after : (getRawFlagValue(process.argv, "after") ?? "")
+    if (!/^[1-9]\d*$/.test(rawAfter)) {
       writeErrorJson(
         "VALIDATION_ERROR",
-        `--after の値が無効です: "${a.after}"`,
+        `--after の値が無効です: "${rawAfter}"`,
         "1 以上の整数を指定してください (タイトル行=1)",
       )
       process.exit(5)
       return
     }
-    const afterN = Number.parseInt(a.after, 10)
+    const afterN = Number.parseInt(rawAfter, 10)
 
     let lines: string[] = []
     if (a.line !== undefined) {

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { commonArgs, dryRunArg, isStdinPath } from "@/commands/_shared"
+import { commonArgs, dryRunArg, getRawFlagValue, isStdinPath } from "@/commands/_shared"
 
 describe("commonArgs", () => {
   it("--dry-run キーを含まない (読み取り専用コマンド向け)", () => {
@@ -53,5 +53,29 @@ describe("isStdinPath", () => {
 
   it("undefined はstdinパスとして認識されない", () => {
     expect(isStdinPath(undefined)).toBe(false)
+  })
+})
+
+describe("getRawFlagValue", () => {
+  it('"--after -1" 形式でフラグ直後の負値を取得できる', () => {
+    // citty が --after -1 を "" に変換するバグへの回避策として process.argv から実値を取得する
+    expect(getRawFlagValue(["node", "cos", "--after", "-1"], "after")).toBe("-1")
+  })
+
+  it('"--after=5" 形式でイコール区切りの値を取得できる', () => {
+    expect(getRawFlagValue(["node", "cos", "--after=5"], "after")).toBe("5")
+  })
+
+  it("対象フラグが存在しない場合は undefined を返す", () => {
+    expect(getRawFlagValue(["node", "cos", "--other", "value"], "after")).toBe(undefined)
+  })
+
+  it("argv が空の場合は undefined を返す", () => {
+    expect(getRawFlagValue([], "after")).toBe(undefined)
+  })
+
+  it('"--after" の後に続く要素がない場合は undefined を返す', () => {
+    // フラグだけで値がない不完全な argv
+    expect(getRawFlagValue(["node", "cos", "--after"], "after")).toBe(undefined)
   })
 })

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -78,4 +78,9 @@ describe("getRawFlagValue", () => {
     // フラグだけで値がない不完全な argv
     expect(getRawFlagValue(["node", "cos", "--after"], "after")).toBe(undefined)
   })
+
+  it("同一フラグが複数回指定された場合は最後の値を返す (CLI の一般的な挙動に合わせる)", () => {
+    // --after 3 --after -1 のように複数回指定された場合、最後の -1 が優先される
+    expect(getRawFlagValue(["node", "cos", "--after", "3", "--after", "-1"], "after")).toBe("-1")
+  })
 })

--- a/tests/unit/commands/page/insert.test.ts
+++ b/tests/unit/commands/page/insert.test.ts
@@ -188,6 +188,34 @@ describe("pageInsertCommand", () => {
     expect(capturedInsertCalls[0]?.lines).toContain("stdinの行2")
   })
 
+  it("--after '' (citty のパースバグ: 負数が空文字になるケース) でエラーメッセージに process.argv の実値を表示する", async () => {
+    // citty が --after -1 を --after "" + flag -1 として解析するバグへの対応
+    // process.argv に実際のフラグ値が残っているため、そこから "-1" を取得してエラーメッセージに表示する
+    const originalArgv = process.argv
+    process.argv = ["bun", "cos", "--after", "-1"]
+    try {
+      await runInsert({
+        title: "テストページ",
+        after: "",
+        line: "挿入行",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    } finally {
+      process.argv = originalArgv
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    // JSON 出力では " が \" にエスケープされるため \"-1\" 形式で含まれることを確認する
+    // (空文字 \"\" ではなく実値 \"-1\" が表示されること)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringMatching(/\\"-1\\"/))
+  })
+
   it("--from-file '' (citty のパースバグで空文字になったケース) でstdinからコンテンツを読み込む", async () => {
     // citty が --from-file - を "" に変換するバグへの対応
     await runInsert({


### PR DESCRIPTION
## Summary

- citty が `--after -1` を `--after ""` + フラグ `-1` として解析するバグにより、エラーメッセージに `""` と表示されていた問題を修正
- `getRawFlagValue` ユーティリティを `_shared.ts` に追加し、`process.argv` から実際の値を取得してエラーメッセージに表示する
- `insert.ts` で `rawAfter` 変数を使い、バリデーションと `afterN` の算出に実値を使用

## Changes

- `src/commands/_shared.ts`: `getRawFlagValue(argv, flagName)` 追加 — `--flag value` / `--flag=value` 両形式を解析
- `src/commands/page/insert.ts`: `rawAfter` を使ってバリデーション・エラーメッセージを修正
- `tests/unit/commands/_shared.test.ts`: `getRawFlagValue` のユニットテスト追加
- `tests/unit/commands/page/insert.test.ts`: citty パースバグのエラーメッセージ表示テスト追加

## Test plan

- [ ] `bun test` 全 777 テスト pass 確認済み
- [ ] `bunx biome check src tests` Lint クリア確認済み
- [ ] `bun run typecheck` 型エラーゼロ確認済み
- [ ] `--after -1` でエラーメッセージに `"-1"` が表示されることを `process.argv` モックで検証済み

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * フラグの「生の値」を正しく取得する仕組みを追加し、負の数などの誤解析を回避します。

* **Bug Fixes**
  * `--after` フラグの検証とエラーメッセージを改善しました。
  * ファイル入力時のstdin検出と読み取りの信頼性を向上しました。

* **Tests**
  * フラグ値取得と`--after`処理のエッジケースを検証するユニットテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/70)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->