### PR TITLE
feat(cli): --json 等の出力制御フラグをルートレベルに登録しサブコマンドへ伝播する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -169,6 +169,27 @@ const main = defineCommand({
       description: "色設定 (auto/always/never)",
       default: process.env["COS_COLOR"] ?? "auto",
     },
+    json: {
+      type: "boolean",
+      alias: "J",
+      description: "JSON 出力 (すべてのサブコマンドへ伝播)",
+      default: false,
+    },
+    plain: {
+      type: "boolean",
+      alias: "P",
+      description: "プレーンテキスト出力 (すべてのサブコマンドへ伝播)",
+      default: false,
+    },
+    "results-only": {
+      type: "boolean",
+      description: "--json 時に data のみ返す (すべてのサブコマンドへ伝播)",
+      default: false,
+    },
+    select: {
+      type: "string",
+      description: "出力セレクタ (例: pages[].title) (すべてのサブコマンドへ伝播)",
+    },
   },
   setup({ args }) {
     // 色初期化
@@ -183,6 +204,13 @@ const main = defineCommand({
     if (args["disable-commands"]) {
       process.env["COS_DISABLE_COMMANDS"] = args["disable-commands"]
     }
+
+    // 出力制御フラグを環境変数経由でサブコマンドへ伝播する
+    // buildLogger / buildJsonOpts がこれらの環境変数を参照する
+    if (args.json) process.env["COS_JSON"] = "1"
+    if (args.plain) process.env["COS_PLAIN"] = "1"
+    if (args["results-only"]) process.env["COS_RESULTS_ONLY"] = "1"
+    if (args.select) process.env["COS_SELECT"] = args.select
   },
   subCommands: {
     page: pageCommand,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,11 +205,17 @@ const main = defineCommand({
       process.env["COS_DISABLE_COMMANDS"] = args["disable-commands"]
     }
 
+    // --json と --plain は相互排他なのでいずれも指定された場合はエラー
+    if (args.json === true && args.plain === true) {
+      process.stderr.write("error: --json と --plain は同時に指定できません\n")
+      process.exit(5)
+    }
+
     // 出力制御フラグを環境変数経由でサブコマンドへ伝播する
     // buildLogger / buildJsonOpts がこれらの環境変数を参照する
-    if (args.json) process.env["COS_JSON"] = "1"
-    if (args.plain) process.env["COS_PLAIN"] = "1"
-    if (args["results-only"]) process.env["COS_RESULTS_ONLY"] = "1"
+    if (args.json === true) process.env["COS_JSON"] = "1"
+    if (args.plain === true) process.env["COS_PLAIN"] = "1"
+    if (args["results-only"] === true) process.env["COS_RESULTS_ONLY"] = "1"
     if (args.select) process.env["COS_SELECT"] = args.select
   },
   subCommands: {

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -119,10 +119,11 @@ export function buildLogger(args: CommonArgs): Logger {
       : args.verbose === "v" || args.verbose === "1"
         ? 1
         : 0
+  // ルートフラグから環境変数経由で伝播した値を優先マージする
   return new Logger({
     quiet: args.quiet,
-    json: args.json,
-    plain: args.plain,
+    json: args.json || process.env["COS_JSON"] === "1",
+    plain: args.plain || process.env["COS_PLAIN"] === "1",
     verbose: verboseLevel,
   })
 }
@@ -159,10 +160,14 @@ export function checkSandbox(commandName: string, args: CommonArgs): void {
 /**
  * buildJsonOpts は CommonArgs から JsonOutputOptions を安全に生成する。
  * exactOptionalPropertyTypes に対応するため undefined を持つプロパティを除外する。
+ * ルートフラグから環境変数経由で伝播した COS_RESULTS_ONLY / COS_SELECT もフォールバックとして参照する。
  */
 export function buildJsonOpts(args: CommonArgs): JsonOutputOptions {
-  const opts: JsonOutputOptions = { resultsOnly: args["results-only"] }
-  if (args.select !== undefined) opts.select = args.select
+  const resultsOnly = args["results-only"] || process.env["COS_RESULTS_ONLY"] === "1"
+  const opts: JsonOutputOptions = { resultsOnly }
+  // args.select が明示指定された場合はそちらを優先する
+  const select = args.select ?? process.env["COS_SELECT"]
+  if (select !== undefined) opts.select = select
   return opts
 }
 

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -86,9 +86,12 @@ describe("buildLogger - 環境変数伝播 (COS_JSON / COS_PLAIN)", () => {
     process.env["COS_JSON"] = "1"
     const logger = buildLogger(makeArgs({ json: false }))
     const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
-    logger.info("テスト出力")
-    expect(writeSpy).not.toHaveBeenCalled()
-    writeSpy.mockRestore()
+    try {
+      logger.info("テスト出力")
+      expect(writeSpy).not.toHaveBeenCalled()
+    } finally {
+      writeSpy.mockRestore()
+    }
   })
 
   it("COS_PLAIN=1 が設定されている場合、args.plain=false でも info() を stderr へ出力しない (plain モード)", () => {
@@ -96,18 +99,24 @@ describe("buildLogger - 環境変数伝播 (COS_JSON / COS_PLAIN)", () => {
     process.env["COS_PLAIN"] = "1"
     const logger = buildLogger(makeArgs({ plain: false }))
     const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
-    logger.info("テスト出力")
-    expect(writeSpy).not.toHaveBeenCalled()
-    writeSpy.mockRestore()
+    try {
+      logger.info("テスト出力")
+      expect(writeSpy).not.toHaveBeenCalled()
+    } finally {
+      writeSpy.mockRestore()
+    }
   })
 
   it("環境変数が未設定かつ args.json=false の場合、info() を stderr へ出力する (通常モード)", () => {
     // 環境変数もフラグも指定されていない場合は通常通り出力する
     const logger = buildLogger(makeArgs({ json: false }))
     const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
-    logger.info("テスト出力")
-    expect(writeSpy).toHaveBeenCalled()
-    writeSpy.mockRestore()
+    try {
+      logger.info("テスト出力")
+      expect(writeSpy).toHaveBeenCalled()
+    } finally {
+      writeSpy.mockRestore()
+    }
   })
 })
 

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -5,8 +5,27 @@
  * 書き込み系コマンドは commonArgs に加えて dryRunArg をスプレッドし --dry-run を持つ。
  */
 
-import { describe, expect, it } from "bun:test"
-import { commonArgs, dryRunArg, getRawFlagValue, isStdinPath } from "@/commands/_shared"
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  commonArgs,
+  dryRunArg,
+  getRawFlagValue,
+  isStdinPath,
+} from "@/commands/_shared"
+
+/** テスト用デフォルト CommonArgs を生成するヘルパー */
+function makeArgs(overrides: Partial<CommonArgs> = {}): CommonArgs {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: false,
+    ...overrides,
+  }
+}
 
 describe("commonArgs", () => {
   it("--dry-run キーを含まない (読み取り専用コマンド向け)", () => {
@@ -53,6 +72,76 @@ describe("isStdinPath", () => {
 
   it("undefined はstdinパスとして認識されない", () => {
     expect(isStdinPath(undefined)).toBe(false)
+  })
+})
+
+describe("buildLogger - 環境変数伝播 (COS_JSON / COS_PLAIN)", () => {
+  afterEach(() => {
+    process.env["COS_JSON"] = undefined
+    process.env["COS_PLAIN"] = undefined
+  })
+
+  it("COS_JSON=1 が設定されている場合、args.json=false でも info() を stderr へ出力しない (json モード)", () => {
+    // cos --json page list のように、ルートフラグから COS_JSON=1 が伝播するケース
+    process.env["COS_JSON"] = "1"
+    const logger = buildLogger(makeArgs({ json: false }))
+    const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
+    logger.info("テスト出力")
+    expect(writeSpy).not.toHaveBeenCalled()
+    writeSpy.mockRestore()
+  })
+
+  it("COS_PLAIN=1 が設定されている場合、args.plain=false でも info() を stderr へ出力しない (plain モード)", () => {
+    // cos --plain page list のように、ルートフラグから COS_PLAIN=1 が伝播するケース
+    process.env["COS_PLAIN"] = "1"
+    const logger = buildLogger(makeArgs({ plain: false }))
+    const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
+    logger.info("テスト出力")
+    expect(writeSpy).not.toHaveBeenCalled()
+    writeSpy.mockRestore()
+  })
+
+  it("環境変数が未設定かつ args.json=false の場合、info() を stderr へ出力する (通常モード)", () => {
+    // 環境変数もフラグも指定されていない場合は通常通り出力する
+    const logger = buildLogger(makeArgs({ json: false }))
+    const writeSpy = spyOn(process.stderr, "write").mockImplementation(() => true)
+    logger.info("テスト出力")
+    expect(writeSpy).toHaveBeenCalled()
+    writeSpy.mockRestore()
+  })
+})
+
+describe("buildJsonOpts - 環境変数伝播 (COS_RESULTS_ONLY / COS_SELECT)", () => {
+  afterEach(() => {
+    process.env["COS_RESULTS_ONLY"] = undefined
+    process.env["COS_SELECT"] = undefined
+  })
+
+  it("COS_RESULTS_ONLY=1 が設定されている場合、args['results-only']=false でも resultsOnly が true になる", () => {
+    // cos --results-only page list のように、ルートフラグから伝播するケース
+    process.env["COS_RESULTS_ONLY"] = "1"
+    const opts = buildJsonOpts(makeArgs({ "results-only": false }))
+    expect(opts.resultsOnly).toBe(true)
+  })
+
+  it("COS_SELECT が設定されている場合、args.select が未指定でも select が適用される", () => {
+    // cos --select 'pages[].title' page list のように、ルートフラグから伝播するケース
+    process.env["COS_SELECT"] = "pages[].title"
+    const opts = buildJsonOpts(makeArgs())
+    expect(opts.select).toBe("pages[].title")
+  })
+
+  it("args.select と COS_SELECT の両方が設定されている場合、args.select が優先される", () => {
+    // サブコマンドレベルのフラグはルートフラグより優先する
+    process.env["COS_SELECT"] = "pages[].title"
+    const opts = buildJsonOpts(makeArgs({ select: "pages[].id" }))
+    expect(opts.select).toBe("pages[].id")
+  })
+
+  it("環境変数が未設定かつ args['results-only']=false の場合、resultsOnly が false のまま", () => {
+    // 環境変数もフラグも指定されていない場合は既定値を維持する
+    const opts = buildJsonOpts(makeArgs())
+    expect(opts.resultsOnly).toBe(false)
   })
 })
 

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -77,8 +77,8 @@ describe("isStdinPath", () => {
 
 describe("buildLogger - 環境変数伝播 (COS_JSON / COS_PLAIN)", () => {
   afterEach(() => {
-    process.env["COS_JSON"] = undefined
-    process.env["COS_PLAIN"] = undefined
+    Reflect.deleteProperty(process.env, "COS_JSON")
+    Reflect.deleteProperty(process.env, "COS_PLAIN")
   })
 
   it("COS_JSON=1 が設定されている場合、args.json=false でも info() を stderr へ出力しない (json モード)", () => {
@@ -113,8 +113,8 @@ describe("buildLogger - 環境変数伝播 (COS_JSON / COS_PLAIN)", () => {
 
 describe("buildJsonOpts - 環境変数伝播 (COS_RESULTS_ONLY / COS_SELECT)", () => {
   afterEach(() => {
-    process.env["COS_RESULTS_ONLY"] = undefined
-    process.env["COS_SELECT"] = undefined
+    Reflect.deleteProperty(process.env, "COS_RESULTS_ONLY")
+    Reflect.deleteProperty(process.env, "COS_SELECT")
   })
 
   it("COS_RESULTS_ONLY=1 が設定されている場合、args['results-only']=false でも resultsOnly が true になる", () => {


### PR DESCRIPTION
## Summary

- `cos --json page list` のようにルートレベルで `--json` / `--plain` / `--results-only` / `--select` を指定できるようにした
- ルートの `setup()` 内でフラグ値を `COS_JSON` / `COS_PLAIN` / `COS_RESULTS_ONLY` / `COS_SELECT` 環境変数へ書き出す
- `buildLogger` / `buildJsonOpts` がこれらの環境変数をフォールバックとして参照するよう修正した
- `--json` と `--plain` の同時指定は exit 5 でエラーとする相互排他チェックを追加した

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/cli.ts` | ルートフラグ追加・`setup()` での環境変数伝播 |
| `src/commands/_shared.ts` | `buildLogger`/`buildJsonOpts` が環境変数を参照するよう修正 |
| `tests/unit/commands/_shared.test.ts` | 環境変数伝播を検証するテストを追加 |

## Test plan

- [x] `buildLogger` が `COS_JSON=1` / `COS_PLAIN=1` を反映する (unit test)
- [x] `buildJsonOpts` が `COS_RESULTS_ONLY=1` / `COS_SELECT` を反映する (unit test)
- [x] `bun test` 全件パス (785 pass, 0 fail)
- [x] `bun run typecheck` エラーなし
- [x] `bunx biome check src tests` エラーなし

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CLIに出力制御オプションを追加しました：--json/-J、--plain/-P、--results-only、--select。サブコマンドへも自動適用されます。
* **動作改善**
  * 出力設定はCLIフラグが優先されつつ、環境変数（COS_JSON/COS_PLAIN/COS_RESULTS_ONLY/COS_SELECT）からも取得され、ログ出力や結果のフォーマットに反映されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/71)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->