### PR TITLE
chore: v0.2.0 リリース準備

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coscli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI",
   "bin": {
     "cos": "./dist/cos"


### PR DESCRIPTION
## Summary

- `package.json` バージョンを `0.1.1` → `0.2.0` に更新

## v0.1.1 以降の変更内容

### Features
- feat(cli): `--json` 等の出力制御フラグをルートレベルに登録しサブコマンドへ伝播する (#71)
- feat(page/context): Smart Context API 対応 — `cos page context` コマンドを追加 (#64)
- feat(dry-run): `--dry-run` レスポンスに書き込み予定行を `previewLines` として含める (#55)
- feat(schema): スキーマ出力に位置引数情報を追加 (#52)

### Bug Fixes
- fix(page/insert): `--after` に負値を渡したときエラーメッセージの値表示が空になる問題を修正 (#70)
- fix(page): `--from-file -` が citty のパースバグで空文字に変換される問題を修正 (#69)
- fix(cli): `--color never/always` が無効でプレーン出力に ANSI コードが混入する問題を修正 (#68)
- fix(page/rename): `persistent:false` のスタブページを重複と誤判定しないよう修正 (#67)
- fix(page/append,prepend,insert): `--line` でシェル実改行が展開されず1行扱いになる問題を修正 (#66)
- fix(page/list): `--limit` / `--skip` の無効値をサイレントフォールバックせず `VALIDATION_ERROR` で弾く (#65)
- fix(build): リリースバイナリに package.json のバージョンを正しく埋め込む (#54)
- fix(page/text): `--format=scrapbox` を `txt` の alias として受け付ける (#53)
- fix(page/new): `--line` を複数指定するとクラッシュする問題を修正 (#51)
- fix(cli): ルートフラグをスペース区切りで渡すとサブコマンドと誤認識される問題を修正 (#50)
- fix(page/delete): non-TTY / `COS_NO_INPUT=1` 時にハングする問題を修正 (#49)
- fix(auth,page): `--no-input` が citty の `--no-X` negation で無視されてハングする問題を修正 (#48)
- fix(page/new): `--line` の `\n` 展開漏れと `--dry-run` 時の success メッセージ抑制漏れを修正 (#36)
- fix(cli): citty `runMain` を自前ラッパに置き換えてエラー出力1回化・exit code 分類・JSON envelope 化 (#35)
- fix(schema): 実 API レスポンスに合わせて zod スキーマを修正 (#34)

## Test plan

- [x] `bun test` 全件 pass (785 pass / 16 skip / 0 fail)
- [x] `./dist/cos-darwin-arm64 --version` で `0.2.0` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * バージョンを0.2.0にアップデートしました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->