### PR TITLE
docs: タグラインを英語ベースに刷新し gogcli クレジットを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # coscli
 
-AI エージェント親和的な [Cosense](https://cosen.se/) (旧 Scrapbox) CLI。バイナリ名 `cos`。
+**Cosense in your terminal.**
+
+[Cosense](https://cosen.se/) (旧 Scrapbox) を端末・スクリプト・AI エージェントから操作するための CLI。バイナリ名 `cos`。
 
 ## 特徴
 
@@ -258,6 +260,10 @@ cos auth login --no-input --sid "$COS_SID"
 | 6 | 楽観ロック競合 |
 | 7 | sandbox 違反 |
 | 124 | タイムアウト |
+
+## Credits
+
+Inspired by [gogcli](https://github.com/openclaw/gogcli) — Google Workspace in your terminal.
 
 ## ライセンス
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coscli",
   "version": "0.2.0",
-  "description": "Cosense (旧 Scrapbox) 向け AI エージェント親和的 CLI",
+  "description": "Cosense in your terminal — CLI for pages, projects, search, sync, and AI agents.",
   "bin": {
     "cos": "./dist/cos"
   },


### PR DESCRIPTION
## Summary

- `README.md` のタグラインを `AI エージェント親和的な Cosense CLI` から **`Cosense in your terminal.`** に刷新
- `package.json` の `description` フィールドを同方針で英語ベースに統一
- `README.md` 末尾に `## Credits` 節を新設し、インスパイア元 [gogcli](https://github.com/openclaw/gogcli) を明記

## Test plan

- [x] `bunx biome check src tests` — 指摘なし
- [x] `bun run typecheck` — エラーなし
- [x] `bun test` — 785 pass / 0 fail
- [x] CodeRabbit — No findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * README.mdのブランディングテキストを「Cosense in your terminal」として更新しました。
  * README.mdにCreditsセクションを追加しました。
  * パッケージの説明文を「Cosense in your terminal — CLI for pages, projects, search, sync, and AI agents.」に更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->