### PR TITLE
security: --from-file の無制限ファイル読込とサイズ制限を修正 (Critical #1, #2)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -91,6 +91,20 @@ export const dryRunArg = {
   },
 } as const
 
+/**
+ * unsafeReadArg は --from-file を持つコマンドが追加スプレッドする安全読み込みバイパスフラグ定義。
+ *
+ * 通常はセキュリティ上の理由で禁止されているパス (.env, ~/.ssh, /etc 等) も読み込みたい
+ * 場合に明示的に指定する。
+ */
+export const unsafeReadArg = {
+  "allow-unsafe-read": {
+    type: "boolean" as const,
+    description: "--from-file のセキュリティチェックをバイパスする (危険: 注意して使用すること)",
+    default: false,
+  },
+} as const
+
 /** CommonArgs は --dry-run を除く読み書き共通フラグの型。WriteCommonArgs の基底型。 */
 export type CommonArgs = {
   project?: string

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -5,7 +5,6 @@
  * --line で直接テキスト指定、- で stdin から読み込む。
  */
 
-import { readFileSync } from "node:fs"
 import {
   type WriteCommonArgs,
   buildJsonOpts,
@@ -16,8 +15,10 @@ import {
   dryRunArg,
   isStdinPath,
   requireProject,
+  unsafeReadArg,
 } from "@/commands/_shared"
 import { appendToPage } from "@/core/pages"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -26,6 +27,7 @@ export const pageAppendCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...unsafeReadArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -41,7 +43,12 @@ export const pageAppendCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & { title: string; line?: string; "from-file"?: string }
+    const a = args as WriteCommonArgs & {
+      title: string
+      line?: string
+      "from-file"?: string
+      "allow-unsafe-read": boolean
+    }
     checkSandbox("page.append", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
@@ -51,11 +58,27 @@ export const pageAppendCommand = defineCommand({
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
     } else if (isStdinPath(a["from-file"])) {
-      const content = readFileSync(0, "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      try {
+        const content = readStdinBounded()
+        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message)
+          process.exit(5)
+        }
+        throw err
+      }
     } else if (a["from-file"]) {
-      const content = readFileSync(a["from-file"], "utf-8")
-      lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      try {
+        const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+          process.exit(5)
+        }
+        throw err
+      }
     }
 
     if (lines.length === 0) {

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -73,20 +73,30 @@ export const pageEditCommand = defineCommand({
     }
 
     let content: string
-    try {
-      if (isStdinPath(a["from-file"])) {
+    if (isStdinPath(a["from-file"])) {
+      try {
         // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
         content = readStdinBounded()
-      } else {
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
+          writeErrorJson("UNSAFE_PATH", err.message)
+          process.exit(5)
+          return
+        }
+        throw err
+      }
+    } else {
+      try {
         content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+          process.exit(5)
+          return
+        }
+        throw err
       }
-    } catch (err) {
-      if (err instanceof UnsafePathError) {
-        writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-        process.exit(5)
-        return
-      }
-      throw err
     }
 
     // MD フォーマットの場合は Scrapbox 記法に変換する

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -7,7 +7,6 @@
  * --dry-run で変更内容のプレビューのみ表示する。
  */
 
-import { readFileSync } from "node:fs"
 import {
   type WriteCommonArgs,
   buildJsonOpts,
@@ -18,9 +17,11 @@ import {
   dryRunArg,
   isStdinPath,
   requireProject,
+  unsafeReadArg,
 } from "@/commands/_shared"
 import { convert } from "@/core/format/index"
 import { editPage } from "@/core/pages"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -31,6 +32,7 @@ export const pageEditCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...unsafeReadArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -52,6 +54,7 @@ export const pageEditCommand = defineCommand({
       title: string
       "from-file": string
       "input-format": string
+      "allow-unsafe-read": boolean
     }
     checkSandbox("page.edit", a)
     const logger = buildLogger(a)
@@ -70,11 +73,20 @@ export const pageEditCommand = defineCommand({
     }
 
     let content: string
-    if (isStdinPath(a["from-file"])) {
-      // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
-      content = readFileSync(0, "utf-8")
-    } else {
-      content = readFileSync(a["from-file"], "utf-8")
+    try {
+      if (isStdinPath(a["from-file"])) {
+        // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
+        content = readStdinBounded()
+      } else {
+        content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+      }
+    } catch (err) {
+      if (err instanceof UnsafePathError) {
+        writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+        process.exit(5)
+        return
+      }
+      throw err
     }
 
     // MD フォーマットの場合は Scrapbox 記法に変換する

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -6,7 +6,6 @@
  * --after 0 以下または lines 数超の値は VALIDATION_ERROR (exit 5) で終了する。
  */
 
-import { readFileSync } from "node:fs"
 import {
   type WriteCommonArgs,
   buildJsonOpts,
@@ -18,8 +17,10 @@ import {
   getRawFlagValue,
   isStdinPath,
   requireProject,
+  unsafeReadArg,
 } from "@/commands/_shared"
 import { insertIntoPage } from "@/core/pages"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -28,6 +29,7 @@ export const pageInsertCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...unsafeReadArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -53,6 +55,7 @@ export const pageInsertCommand = defineCommand({
       after: string
       line?: string
       "from-file"?: string
+      "allow-unsafe-read": boolean
     }
     checkSandbox("page.insert", a)
     const logger = buildLogger(a)
@@ -81,10 +84,15 @@ export const pageInsertCommand = defineCommand({
       try {
         // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
         const content = isStdinPath(a["from-file"])
-          ? readFileSync(0, "utf-8")
-          : readFileSync(a["from-file"], "utf-8")
+          ? readStdinBounded()
+          : readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
         lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch {
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+          process.exit(5)
+          return
+        }
         writeErrorJson(
           "VALIDATION_ERROR",
           `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -81,25 +81,38 @@ export const pageInsertCommand = defineCommand({
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"] !== undefined) {
-      try {
-        // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
-        const content = isStdinPath(a["from-file"])
-          ? readStdinBounded()
-          : readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+      // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
+      if (isStdinPath(a["from-file"])) {
+        try {
+          const content = readStdinBounded()
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
+            writeErrorJson("UNSAFE_PATH", err.message)
+            process.exit(5)
+            return
+          }
+          throw err
+        }
+      } else {
+        try {
+          const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+            process.exit(5)
+            return
+          }
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
+            "ファイルパスが正しいか確認してください",
+          )
           process.exit(5)
           return
         }
-        writeErrorJson(
-          "VALIDATION_ERROR",
-          `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
-          "ファイルパスが正しいか確認してください",
-        )
-        process.exit(5)
-        return
       }
     }
 

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -5,7 +5,6 @@
  * --from-file でファイルから、- で stdin から本文を読み込む。
  */
 
-import { readFileSync } from "node:fs"
 import {
   type WriteCommonArgs,
   buildJsonOpts,
@@ -16,8 +15,10 @@ import {
   dryRunArg,
   isStdinPath,
   requireProject,
+  unsafeReadArg,
 } from "@/commands/_shared"
 import { createPage } from "@/core/pages"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -26,6 +27,7 @@ export const pageNewCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...unsafeReadArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -45,6 +47,7 @@ export const pageNewCommand = defineCommand({
     const a = args as WriteCommonArgs & {
       title: string
       "from-file"?: string
+      "allow-unsafe-read": boolean
       /** citty が --line を複数回受け取ると string[] になる */
       line?: string | string[]
     }
@@ -56,11 +59,27 @@ export const pageNewCommand = defineCommand({
     let lines: string[] = []
     if (isStdinPath(a["from-file"])) {
       // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
-      const content = readFileSync(0, "utf-8")
-      lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
+      try {
+        const content = readStdinBounded()
+        lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message)
+          process.exit(5)
+        }
+        throw err
+      }
     } else if (a["from-file"]) {
-      const content = readFileSync(a["from-file"], "utf-8")
-      lines = content.split("\n")
+      try {
+        const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+        lines = content.split("\n")
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+          process.exit(5)
+        }
+        throw err
+      }
     } else if (a.line !== undefined) {
       // citty は --line を複数回渡すと配列になるため、string と string[] の両方に対応する
       // 実改行（\n, \r\n）とエスケープシーケンス（\\n）の両方を展開する

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -5,7 +5,6 @@
  * --line で直接テキスト指定、- で stdin から読み込む。
  */
 
-import { readFileSync } from "node:fs"
 import {
   type WriteCommonArgs,
   buildJsonOpts,
@@ -16,8 +15,10 @@ import {
   dryRunArg,
   isStdinPath,
   requireProject,
+  unsafeReadArg,
 } from "@/commands/_shared"
 import { prependToPage } from "@/core/pages"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -26,6 +27,7 @@ export const pagePrependCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...unsafeReadArg,
     title: {
       type: "positional",
       description: "ページタイトル",
@@ -41,7 +43,12 @@ export const pagePrependCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & { title: string; line?: string; "from-file"?: string }
+    const a = args as WriteCommonArgs & {
+      title: string
+      line?: string
+      "from-file"?: string
+      "allow-unsafe-read": boolean
+    }
     checkSandbox("page.prepend", a)
     const logger = buildLogger(a)
     const project = requireProject(a)
@@ -54,10 +61,15 @@ export const pagePrependCommand = defineCommand({
       try {
         // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
         const content = isStdinPath(a["from-file"])
-          ? readFileSync(0, "utf-8")
-          : readFileSync(a["from-file"], "utf-8")
+          ? readStdinBounded()
+          : readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
         lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch {
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+          process.exit(5)
+          return
+        }
         writeErrorJson(
           "VALIDATION_ERROR",
           `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -58,25 +58,38 @@ export const pagePrependCommand = defineCommand({
     if (a.line !== undefined) {
       lines = a.line.split(/\r?\n|\\n/)
     } else if (a["from-file"] !== undefined) {
-      try {
-        // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
-        const content = isStdinPath(a["from-file"])
-          ? readStdinBounded()
-          : readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+      // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
+      if (isStdinPath(a["from-file"])) {
+        try {
+          const content = readStdinBounded()
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
+            writeErrorJson("UNSAFE_PATH", err.message)
+            process.exit(5)
+            return
+          }
+          throw err
+        }
+      } else {
+        try {
+          const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+            process.exit(5)
+            return
+          }
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
+            "ファイルパスが正しいか確認してください",
+          )
           process.exit(5)
           return
         }
-        writeErrorJson(
-          "VALIDATION_ERROR",
-          `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
-          "ファイルパスが正しいか確認してください",
-        )
-        process.exit(5)
-        return
       }
     }
 

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -25,6 +25,7 @@ export type ErrorCode =
   | "VALIDATION_ERROR"
   | "POLICY_DENIED"
   | "INVALID_JSON"
+  | "BODY_TOO_LARGE"
   | "PROXY_AUTH_REQUIRED"
   | "WRITE_DISABLED"
   | "ROUTE_NOT_FOUND"
@@ -83,6 +84,10 @@ export function toHttpResponse(err: unknown): Response {
   }
   if (err instanceof SyntaxError) {
     return buildErrorResponse(400, "INVALID_JSON", err.message)
+  }
+  // parseJsonBody がスローする BODY_TOO_LARGE エラー
+  if (err instanceof Error && (err as Error & { code?: string }).code === "BODY_TOO_LARGE") {
+    return buildErrorResponse(413, "BODY_TOO_LARGE", err.message)
   }
   // 内部エラーの詳細はクライアントに漏洩させず、汎用メッセージを返す
   return buildErrorResponse(500, "INTERNAL_ERROR", "予期しないエラーが発生しました")

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -89,32 +89,50 @@ const MAX_BODY_BYTES = 5 * 1024 * 1024
 /**
  * parseJsonBody は JSON リクエストボディをパースする。
  * ボディサイズが MAX_BODY_BYTES を超える場合は 413 エラーをスローする。
+ * Content-Length による事前チェック後、ストリーミング読み込みで逐次サイズを検証する。
  * パースに失敗した場合は SyntaxError をスローし、toHttpResponse で 400 に変換される。
  */
 async function parseJsonBody(req: Request): Promise<unknown> {
+  const createBodyTooLargeError = () =>
+    Object.assign(new Error("リクエストボディが大きすぎます"), {
+      code: "BODY_TOO_LARGE",
+      status: 413,
+    })
+
   // Content-Length ヘッダによる事前チェック
   const contentLength = req.headers.get("content-length")
   if (contentLength !== null) {
     const len = Number(contentLength)
     if (!Number.isNaN(len) && len > MAX_BODY_BYTES) {
-      const err = Object.assign(new Error("リクエストボディが大きすぎます"), {
-        code: "BODY_TOO_LARGE",
-        status: 413,
-      })
-      throw err
+      throw createBodyTooLargeError()
     }
   }
 
-  const buf = new Uint8Array(await req.arrayBuffer())
-  if (buf.byteLength > MAX_BODY_BYTES) {
-    const err = Object.assign(new Error("リクエストボディが大きすぎます"), {
-      code: "BODY_TOO_LARGE",
-      status: 413,
-    })
-    throw err
+  // ストリーミング読み込みで受信中にサイズ超過を検出して即時中断する
+  const reader = req.body?.getReader()
+  if (!reader) return JSON.parse("")
+
+  const chunks: Uint8Array[] = []
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+    total += value.byteLength
+    if (total > MAX_BODY_BYTES) {
+      await reader.cancel()
+      throw createBodyTooLargeError()
+    }
+    chunks.push(value)
   }
 
-  return JSON.parse(new TextDecoder().decode(buf))
+  const merged = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return JSON.parse(new TextDecoder().decode(merged))
 }
 
 /**

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -83,13 +83,38 @@ function checkPolicy(ctx: ServerContext, command: string): Response | null {
   return null
 }
 
+/** serve が受け付けるリクエストボディの最大サイズ (5 MiB) */
+const MAX_BODY_BYTES = 5 * 1024 * 1024
+
 /**
  * parseJsonBody は JSON リクエストボディをパースする。
+ * ボディサイズが MAX_BODY_BYTES を超える場合は 413 エラーをスローする。
  * パースに失敗した場合は SyntaxError をスローし、toHttpResponse で 400 に変換される。
  */
 async function parseJsonBody(req: Request): Promise<unknown> {
-  const text = await req.text()
-  return JSON.parse(text)
+  // Content-Length ヘッダによる事前チェック
+  const contentLength = req.headers.get("content-length")
+  if (contentLength !== null) {
+    const len = Number(contentLength)
+    if (!Number.isNaN(len) && len > MAX_BODY_BYTES) {
+      const err = Object.assign(new Error("リクエストボディが大きすぎます"), {
+        code: "BODY_TOO_LARGE",
+        status: 413,
+      })
+      throw err
+    }
+  }
+
+  const buf = new Uint8Array(await req.arrayBuffer())
+  if (buf.byteLength > MAX_BODY_BYTES) {
+    const err = Object.assign(new Error("リクエストボディが大きすぎます"), {
+      code: "BODY_TOO_LARGE",
+      status: 413,
+    })
+    throw err
+  }
+
+  return JSON.parse(new TextDecoder().decode(buf))
 }
 
 /**

--- a/src/infra/safe-read.ts
+++ b/src/infra/safe-read.ts
@@ -5,9 +5,10 @@
  * を Cosense プロジェクトへ送信してしまう経路を防ぐ。
  *
  * 禁止ルール:
- *   - /etc, /proc, /sys, /dev, /root, /boot 等のシステムディレクトリ
+ *   - Unix: /etc, /proc, /sys, /dev, /root, /boot 等のシステムディレクトリ
+ *   - Windows: C:\Windows\System32, C:\ProgramData, %USERPROFILE%\.ssh 等
  *   - *.pem, *.key, *.env, *_rsa, *_ed25519, *_ecdsa, *_dsa の機密拡張子
- *   - .ssh, .aws, .gnupg, coscli/secrets.json の機密ディレクトリ/ファイル
+ *   - .ssh, .aws, .gnupg, coscli/secrets.json の機密ディレクトリ/ファイル (大文字小文字を区別しない)
  *   - シンボリックリンク解決後に上記に該当するパス
  *   - 10 MiB を超えるファイル
  *
@@ -17,6 +18,7 @@
 import { readFileSync, statSync } from "node:fs"
 import { realpathSync } from "node:fs"
 import { sep } from "node:path"
+import { platform } from "node:process"
 
 /** ファイルの最大読み込みサイズ (10 MiB) */
 const MAX_FROM_FILE_BYTES = 10 * 1024 * 1024
@@ -24,8 +26,31 @@ const MAX_FROM_FILE_BYTES = 10 * 1024 * 1024
 /** stdin の最大読み込みサイズ (10 MiB) */
 const MAX_STDIN_BYTES = 10 * 1024 * 1024
 
-/** 禁止されたシステムディレクトリプレフィックスの一覧 (macOS の /etc → /private/etc も含む) */
-const DENY_DIRS = ["/etc", "/proc", "/sys", "/dev", "/root", "/boot", "/run/secrets"].flatMap(
+/** Unix 向け禁止システムディレクトリの一覧 */
+const UNIX_DENY_DIRS = ["/etc", "/proc", "/sys", "/dev", "/root", "/boot", "/run/secrets"]
+
+/** Windows 向け禁止システムディレクトリの一覧 (環境変数を展開して生成) */
+function buildWindowsDenyDirs(): string[] {
+  const userProfile = process.env["USERPROFILE"] ?? ""
+  const systemRoot = process.env["SystemRoot"] ?? "C:\\Windows"
+  const programData = process.env["ProgramData"] ?? "C:\\ProgramData"
+  const dirs = [
+    systemRoot,
+    `${systemRoot}\\System32`,
+    programData,
+    `${userProfile}\\.ssh`,
+    `${userProfile}\\.aws`,
+    `${userProfile}\\AppData`,
+  ]
+  return dirs.filter((d) => d !== "" && d !== "\\.ssh" && d !== "\\.aws" && d !== "\\AppData")
+}
+
+/**
+ * 禁止されたシステムディレクトリプレフィックスの一覧。
+ * macOS の /etc → /private/etc のような OS レベルのシンボリックリンクも解決して追加する。
+ * Windows 環境ではシステムディレクトリと機密ディレクトリを追加する。
+ */
+const DENY_DIRS = (platform === "win32" ? buildWindowsDenyDirs() : UNIX_DENY_DIRS).flatMap(
   (dir) => {
     try {
       const real = realpathSync(dir)
@@ -142,11 +167,12 @@ function assertSafePath(originalPath: string, realPath: string): void {
     }
   }
 
-  // 禁止ディレクトリセグメントのチェック
+  // 禁止ディレクトリセグメントのチェック (大文字小文字を区別しない)
   const segments = realPath.split(sep)
   for (const segment of segments) {
+    const lowerSegment = segment.toLowerCase()
     for (const denySegment of DENY_DIR_SEGMENTS) {
-      if (segment === denySegment) {
+      if (lowerSegment === denySegment) {
         throw new UnsafePathError(
           originalPath,
           `禁止ディレクトリ ${denySegment} 配下のファイルは読み込めません`,
@@ -155,8 +181,11 @@ function assertSafePath(originalPath: string, realPath: string): void {
     }
   }
 
-  // coscli 自身の secrets.json のチェック
-  if (segments.at(-1) === COSCLI_SECRETS_FILENAME && segments.at(-2) === COSCLI_CONFIG_DIRNAME) {
+  // coscli 自身の secrets.json のチェック (大文字小文字を区別しない)
+  if (
+    segments.at(-1)?.toLowerCase() === COSCLI_SECRETS_FILENAME &&
+    segments.at(-2)?.toLowerCase() === COSCLI_CONFIG_DIRNAME
+  ) {
     throw new UnsafePathError(originalPath, "coscli の認証ファイルは読み込めません")
   }
 }

--- a/src/infra/safe-read.ts
+++ b/src/infra/safe-read.ts
@@ -1,0 +1,181 @@
+/**
+ * safe-read.ts — --from-file / stdin 向けの安全なファイル読み取りユーティリティ。
+ *
+ * AI エージェントや一般ユーザーが意図せず機密ファイル (~/.ssh/id_rsa, /etc/passwd 等)
+ * を Cosense プロジェクトへ送信してしまう経路を防ぐ。
+ *
+ * 禁止ルール:
+ *   - /etc, /proc, /sys, /dev, /root, /boot 等のシステムディレクトリ
+ *   - *.pem, *.key, *.env, *_rsa, *_ed25519, *_ecdsa, *_dsa の機密拡張子
+ *   - .ssh, .aws, .gnupg, coscli/secrets.json の機密ディレクトリ/ファイル
+ *   - シンボリックリンク解決後に上記に該当するパス
+ *   - 10 MiB を超えるファイル
+ *
+ * allowUnsafe: true で禁止ルールをバイパスできる (--allow-unsafe-read フラグ向け)。
+ */
+
+import { readFileSync, statSync } from "node:fs"
+import { realpathSync } from "node:fs"
+import { sep } from "node:path"
+
+/** ファイルの最大読み込みサイズ (10 MiB) */
+const MAX_FROM_FILE_BYTES = 10 * 1024 * 1024
+
+/** stdin の最大読み込みサイズ (10 MiB) */
+const MAX_STDIN_BYTES = 10 * 1024 * 1024
+
+/** 禁止されたシステムディレクトリプレフィックスの一覧 (macOS の /etc → /private/etc も含む) */
+const DENY_DIRS = ["/etc", "/proc", "/sys", "/dev", "/root", "/boot", "/run/secrets"].flatMap(
+  (dir) => {
+    try {
+      const real = realpathSync(dir)
+      return real !== dir ? [dir, real] : [dir]
+    } catch {
+      return [dir]
+    }
+  },
+)
+
+/** 禁止されたファイルサフィックスの一覧 */
+const DENY_SUFFIXES = [".pem", ".key", ".env", "_rsa", "_ed25519", "_ecdsa", "_dsa"]
+
+/** 禁止されたディレクトリ名の一覧 (パスのセグメントとして検索) */
+const DENY_DIR_SEGMENTS = [".ssh", ".aws", ".gnupg"]
+
+/** coscli 自身の認証ファイルのファイル名 */
+const COSCLI_SECRETS_FILENAME = "secrets.json"
+
+/** coscli の設定ディレクトリ名 */
+const COSCLI_CONFIG_DIRNAME = "coscli"
+
+/**
+ * UnsafePathError は安全でないファイルパスへのアクセスを示すエラー。
+ */
+export class UnsafePathError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly reason: string,
+  ) {
+    super(`--from-file が許可されないパスです: ${filePath} (${reason})`)
+    this.name = "UnsafePathError"
+  }
+}
+
+/** readFromFileOpts は readFromFile のオプション。 */
+export interface ReadFromFileOpts {
+  /** true のとき禁止ルールをバイパスする (--allow-unsafe-read フラグ向け) */
+  allowUnsafe?: boolean
+}
+
+/**
+ * readFromFile は --from-file 引数で指定されたファイルを安全に読み込む。
+ *
+ * 元のパスとシンボリックリンクを解決した実パスの両方で禁止ルールを評価し、
+ * 機密ファイルへのアクセスを防ぐ。
+ * (macOS では /etc → /private/etc のような OS レベルのシンボリックリンクがあるため
+ *  元パスと実パスの両方をチェックする)
+ */
+export function readFromFile(rawPath: string, opts: ReadFromFileOpts = {}): string {
+  if (!opts.allowUnsafe) {
+    const realPath = resolveRealPath(rawPath)
+    // 元のパスでチェック (ユーザーが入力した文字列に禁止パターンが含まれる場合を検出)
+    assertSafePath(rawPath, rawPath)
+    // 実パスでチェック (シンボリックリンク解決後の行き先を検出)
+    if (realPath !== rawPath) {
+      assertSafePath(rawPath, realPath)
+    }
+    assertFileSize(rawPath, realPath)
+  }
+
+  return readFileSync(rawPath, "utf-8")
+}
+
+/**
+ * readStdinBounded は stdin から安全にデータを読み込む。
+ *
+ * stdin の入力サイズを MAX_STDIN_BYTES に制限し、
+ * メモリ枯渇や意図しない巨大データの Cosense 書き込みを防ぐ。
+ */
+export function readStdinBounded(): string {
+  const buf = readFileSync(0)
+  if (buf.byteLength > MAX_STDIN_BYTES) {
+    throw new UnsafePathError("<stdin>", `stdin 入力が上限 ${MAX_STDIN_BYTES} バイトを超えています`)
+  }
+  return buf.toString("utf-8")
+}
+
+/**
+ * resolveRealPath はシンボリックリンクを解決した実パスを返す。
+ * 解決に失敗した場合 (ファイルが存在しない等) は元のパスを返す。
+ */
+function resolveRealPath(rawPath: string): string {
+  try {
+    return realpathSync(rawPath)
+  } catch {
+    return rawPath
+  }
+}
+
+/**
+ * assertSafePath は実パスが安全かどうかを検証し、
+ * 禁止ルールに該当する場合は UnsafePathError をスローする。
+ */
+function assertSafePath(originalPath: string, realPath: string): void {
+  // システムディレクトリのチェック
+  for (const dir of DENY_DIRS) {
+    if (realPath === dir || realPath.startsWith(`${dir}${sep}`) || realPath.startsWith(`${dir}/`)) {
+      throw new UnsafePathError(
+        originalPath,
+        `禁止ディレクトリ ${dir} 配下のファイルは読み込めません`,
+      )
+    }
+  }
+
+  // 禁止サフィックスのチェック
+  const lowerPath = realPath.toLowerCase()
+  for (const suffix of DENY_SUFFIXES) {
+    if (lowerPath.endsWith(suffix)) {
+      throw new UnsafePathError(
+        originalPath,
+        `禁止された拡張子/サフィックス ${suffix} のファイルは読み込めません`,
+      )
+    }
+  }
+
+  // 禁止ディレクトリセグメントのチェック
+  const segments = realPath.split(sep)
+  for (const segment of segments) {
+    for (const denySegment of DENY_DIR_SEGMENTS) {
+      if (segment === denySegment) {
+        throw new UnsafePathError(
+          originalPath,
+          `禁止ディレクトリ ${denySegment} 配下のファイルは読み込めません`,
+        )
+      }
+    }
+  }
+
+  // coscli 自身の secrets.json のチェック
+  if (segments.at(-1) === COSCLI_SECRETS_FILENAME && segments.at(-2) === COSCLI_CONFIG_DIRNAME) {
+    throw new UnsafePathError(originalPath, "coscli の認証ファイルは読み込めません")
+  }
+}
+
+/**
+ * assertFileSize は実パスのファイルサイズを検証し、
+ * 上限を超えている場合は UnsafePathError をスローする。
+ */
+function assertFileSize(originalPath: string, realPath: string): void {
+  try {
+    const st = statSync(realPath)
+    if (st.size > MAX_FROM_FILE_BYTES) {
+      throw new UnsafePathError(
+        originalPath,
+        `ファイルサイズ ${st.size} バイトが上限 ${MAX_FROM_FILE_BYTES} バイトを超えています`,
+      )
+    }
+  } catch (err) {
+    if (err instanceof UnsafePathError) throw err
+    // stat 失敗 (ファイルなし等) は readFileSync のエラーに委ねる
+  }
+}

--- a/tests/unit/infra/safe-read.test.ts
+++ b/tests/unit/infra/safe-read.test.ts
@@ -161,6 +161,42 @@ describe("readFromFile", () => {
     })
   })
 
+  describe("大文字小文字を含むパスのブロック", () => {
+    it(".SSH ディレクトリ内のファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const sshDir = join(tmpDir, ".SSH")
+      mkdirSync(sshDir)
+      const filePath = join(sshDir, "authorized_keys")
+      writeFileSync(filePath, "ssh-rsa AAAA... ユーザー名@ホスト名")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it(".Aws ディレクトリ内のファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const awsDir = join(tmpDir, ".Aws")
+      mkdirSync(awsDir)
+      const filePath = join(awsDir, "credentials")
+      writeFileSync(filePath, "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it("Secrets.json という名前のファイルは coscli/Secrets.json でブロックされる", () => {
+      tmpDir = makeTempDir()
+      const configDir = join(tmpDir, "coscli")
+      mkdirSync(configDir)
+      const secretsPath = join(configDir, "Secrets.json")
+      writeFileSync(secretsPath, '{"default":"s%3A秘密のsid"}')
+      expect(() => readFromFile(secretsPath)).toThrow(UnsafePathError)
+    })
+
+    it(".PEM 拡張子のファイルはブロックされる (サフィックスチェックは既に小文字対応済み)", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "証明書.PEM")
+      writeFileSync(filePath, "-----BEGIN CERTIFICATE-----")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+  })
+
   describe("allowUnsafe フラグ", () => {
     it("allowUnsafe: true で禁止パスも読み込める", () => {
       tmpDir = makeTempDir()

--- a/tests/unit/infra/safe-read.test.ts
+++ b/tests/unit/infra/safe-read.test.ts
@@ -1,0 +1,191 @@
+/**
+ * safe-read.test.ts — readFromFile / readStdinBounded のセキュリティテスト。
+ *
+ * --from-file で任意の機密ファイルが読まれないことを確認する。
+ */
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
+
+/** テスト用の一時ディレクトリを作成するヘルパ */
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "coscli-safe-read-test-"))
+}
+
+describe("readFromFile", () => {
+  let tmpDir: string
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  describe("通常ファイルの読み込み", () => {
+    it("通常のテキストファイルを読み込める", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "ブログ下書き.txt")
+      writeFileSync(filePath, "Cosense に書き込む内容\n2行目")
+      expect(readFromFile(filePath)).toBe("Cosense に書き込む内容\n2行目")
+    })
+
+    it("空ファイルは空文字列を返す", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "空ファイル.txt")
+      writeFileSync(filePath, "")
+      expect(readFromFile(filePath)).toBe("")
+    })
+  })
+
+  describe("禁止ディレクトリのブロック", () => {
+    it("/etc/passwd 相当のパスは UnsafePathError をスローする", () => {
+      expect(() => readFromFile("/etc/passwd")).toThrow(UnsafePathError)
+    })
+
+    it("/etc ディレクトリ直下のファイルはブロックされる", () => {
+      expect(() => readFromFile("/etc/hosts")).toThrow(UnsafePathError)
+    })
+
+    it("/proc/self/environ はブロックされる", () => {
+      expect(() => readFromFile("/proc/self/environ")).toThrow(UnsafePathError)
+    })
+  })
+
+  describe("禁止サフィックスのブロック", () => {
+    it(".env ファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, ".env")
+      writeFileSync(filePath, "SECRET_KEY=秘密の値")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it(".pem ファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "証明書.pem")
+      writeFileSync(filePath, "-----BEGIN CERTIFICATE-----")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it(".key ファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "秘密鍵.key")
+      writeFileSync(filePath, "-----BEGIN PRIVATE KEY-----")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it("id_rsa ファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "id_rsa")
+      writeFileSync(filePath, "-----BEGIN RSA PRIVATE KEY-----")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it("id_ed25519 ファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "id_ed25519")
+      writeFileSync(filePath, "-----BEGIN OPENSSH PRIVATE KEY-----")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+  })
+
+  describe("禁止ディレクトリ名のブロック", () => {
+    it(".ssh ディレクトリ内のファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const sshDir = join(tmpDir, ".ssh")
+      mkdirSync(sshDir)
+      const filePath = join(sshDir, "authorized_keys")
+      writeFileSync(filePath, "ssh-rsa AAAA... ユーザー名@ホスト名")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it(".aws ディレクトリ内のファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const awsDir = join(tmpDir, ".aws")
+      mkdirSync(awsDir)
+      const filePath = join(awsDir, "credentials")
+      writeFileSync(filePath, "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it(".gnupg ディレクトリ内のファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const gnupgDir = join(tmpDir, ".gnupg")
+      mkdirSync(gnupgDir)
+      const filePath = join(gnupgDir, "私の秘密鍵.gpg")
+      writeFileSync(filePath, "GPG秘密鍵データ")
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+  })
+
+  describe("シンボリックリンク経由のブロック", () => {
+    it("禁止パスへのシンボリックリンクはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const linkPath = join(tmpDir, "システムファイルへのリンク.txt")
+      // /etc/hosts へのシンボリックリンクを作成
+      symlinkSync("/etc/hosts", linkPath)
+      expect(() => readFromFile(linkPath)).toThrow(UnsafePathError)
+    })
+  })
+
+  describe("ファイルサイズ制限", () => {
+    it("10 MiB を超えるファイルはブロックされる", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "巨大ファイル.txt")
+      // 10 MiB + 1 バイトのファイルを作成
+      const oversized = Buffer.alloc(10 * 1024 * 1024 + 1, "あ")
+      writeFileSync(filePath, oversized)
+      expect(() => readFromFile(filePath)).toThrow(UnsafePathError)
+    })
+
+    it("10 MiB ちょうどは読み込める", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, "ちょうどのサイズ.txt")
+      const content = Buffer.alloc(10 * 1024 * 1024, "a")
+      writeFileSync(filePath, content)
+      // サイズが 10 MiB ちょうどなら成功する
+      expect(() => readFromFile(filePath)).not.toThrow()
+    })
+  })
+
+  describe("secrets.json のブロック", () => {
+    it("coscli/secrets.json はブロックされる", () => {
+      tmpDir = makeTempDir()
+      const configDir = join(tmpDir, "coscli")
+      mkdirSync(configDir)
+      const secretsPath = join(configDir, "secrets.json")
+      writeFileSync(secretsPath, '{"default":"s%3A秘密のsid"}')
+      expect(() => readFromFile(secretsPath)).toThrow(UnsafePathError)
+    })
+  })
+
+  describe("allowUnsafe フラグ", () => {
+    it("allowUnsafe: true で禁止パスも読み込める", () => {
+      tmpDir = makeTempDir()
+      const filePath = join(tmpDir, ".env")
+      writeFileSync(filePath, "TEST_KEY=テスト値")
+      // allowUnsafe オプションで bypass できる
+      expect(readFromFile(filePath, { allowUnsafe: true })).toBe("TEST_KEY=テスト値")
+    })
+  })
+})
+
+describe("readStdinBounded", () => {
+  it("UnsafePathError クラスが正しく定義されている", () => {
+    // UnsafePathError のコンストラクタが正しく動作することを確認
+    const err = new UnsafePathError("/etc/passwd", "テスト用の理由")
+    expect(err.filePath).toBe("/etc/passwd")
+    expect(err.reason).toBe("テスト用の理由")
+    expect(err.message).toContain("/etc/passwd")
+    expect(err.message).toContain("テスト用の理由")
+    expect(err.name).toBe("UnsafePathError")
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it("readStdinBounded は関数としてエクスポートされている", () => {
+    // readStdinBounded が存在することを確認 (stdin に書き込めないため動作テストは省略)
+    expect(typeof readStdinBounded).toBe("function")
+  })
+})


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の項目 **Critical #1, #2** に対応します。

AI エージェントやユーザーが意図せず機密ファイル (`~/.ssh/id_rsa`, `/etc/passwd` 等) を Cosense プロジェクトへ書き込む経路を防ぎます。

## 変更内容

### 新設: `src/infra/safe-read.ts`

- `readFromFile(path, opts)` — `--from-file` 向けの安全なファイル読み取り
- `readStdinBounded()` — stdin の安全な読み取り (10 MiB 上限)
- `UnsafePathError` — 安全でないパスへのアクセスエラー

**禁止ルール**:
- システムディレクトリ: `/etc`, `/proc`, `/sys`, `/dev`, `/root`, `/boot`
- 機密サフィックス: `.pem`, `.key`, `.env`, `_rsa`, `_ed25519`
- 機密ディレクトリセグメント: `.ssh`, `.aws`, `.gnupg`
- coscli 自身の `secrets.json`
- シンボリックリンク解決後のパスも評価 (macOS の `/etc → /private/etc` も対応)
- 上限 10 MiB

**bypass**: `--allow-unsafe-read` フラグで無効化可能

### 変更: `page/{new,append,prepend,insert,edit}.ts`

`readFileSync` を `readFromFile` / `readStdinBounded` に置き換え。

### 変更: `src/core/server/rest.ts`

`parseJsonBody` に 5 MiB ボディサイズ制限を追加。超過時 HTTP 413 を返す。

## テスト

`tests/unit/infra/safe-read.test.ts` を新設 (20 テスト):
- 通常ファイル・空ファイルの正常ケース
- 禁止ディレクトリ・サフィックス・セグメントのブロック
- シンボリックリンク経由のブロック
- サイズ超過のブロック
- `allowUnsafe: true` による bypass

## 動作確認

```bash
# 禁止パスで exit 5 + UNSAFE_PATH JSON が返ること
bun src/cli.ts page new テスト --from-file /etc/passwd --json
```

Refs docs/security-audit-2026-05.md #1 #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ページ操作コマンド群に --allow-unsafe-read フラグを追加し、必要時に安全チェックを明示的に許可可能に。
  * 安全な読み取りユーティリティを導入し、stdin/ファイル読み込みの扱いを統一。

* **バグ修正**
  * リクエストボディを5MiBで制限し超過時はHTTP 413を返すように。
  * stdin/ファイル読み込みに10MiB上限を導入し、危険なパスは構造化されたエラーで報告。

* **テスト**
  * 新しい安全読み取りユーティリティの単体テストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/75)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->