### PR TITLE
fix(keychain): save() で connect.sid が ps argv に露出しないよう変更

### DIFF
--- a/src/infra/keychain/macos.ts
+++ b/src/infra/keychain/macos.ts
@@ -8,6 +8,14 @@ import { type SpawnOptions, type Spawner, type SubprocessLike, defaultSpawner } 
 
 const SERVICE = "coscli"
 
+/**
+ * shellQuote は security -i コマンド行に渡す引数を single-quote でエスケープする。
+ * シングルクォートは `'\''` に変換して安全に埋め込む。
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
 /** MacOSKeychainStore は macOS の security コマンド経由で Keychain にアクセスする。 */
 export class MacOSKeychainStore implements TokenStore {
   private readonly spawn: Spawner
@@ -19,18 +27,10 @@ export class MacOSKeychainStore implements TokenStore {
 
   async save(profile: string, sid: string): Promise<void> {
     validateProfile(profile)
-    // すでに存在する場合は update、なければ add
-    const result = await this.run([
-      "security",
-      "add-generic-password",
-      "-s",
-      SERVICE,
-      "-a",
-      profile,
-      "-w",
-      sid,
-      "-U",
-    ])
+    // security -i モードでコマンドを stdin 経由で渡す。
+    // argv は ["security", "-i"] のみで sid が ps に露出しない。
+    const cmd = `add-generic-password -s ${shellQuote(SERVICE)} -a ${shellQuote(profile)} -w ${shellQuote(sid)} -U\n`
+    const result = await this.run(["security", "-i"], { stdin: new TextEncoder().encode(cmd) })
     if (!result.success) {
       throw new Error(`Keychain への保存に失敗しました: ${result.stderr}`)
     }

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -48,20 +48,31 @@ export class WindowsKeychainStore implements TokenStore {
 
   async save(profile: string, sid: string): Promise<void> {
     validateProfile(profile)
+    // /pass: argv にトークンを乗せない。profile は COS_TARGET、sid は COS_SID 経由で渡す
+    const script = `
+      if (-not (Get-Command New-StoredCredential -ErrorAction SilentlyContinue)) {
+        Write-Error 'CredentialManager module not found. Install it with: Install-Module CredentialManager -Scope CurrentUser'
+        exit 2
+      }
+      New-StoredCredential -Target $env:${ENV_TARGET} -UserName 'cos' -Password $env:COS_SID -Type Generic -Persist LocalMachine | Out-Null
+    `
     let proc: SubprocessLike
     try {
-      proc = this.spawn(["cmdkey", `/generic:${SERVICE}:${profile}`, "/user:cos", `/pass:${sid}`], {
+      proc = this.spawn(["powershell", "-NoProfile", "-Command", script], {
         stdout: "pipe",
         stderr: "pipe",
+        env: { ...process.env, [ENV_TARGET]: `${SERVICE}:${profile}`, COS_SID: sid },
       })
     } catch (e) {
-      if (isENOENT(e)) throw new Error(CMDKEY_NOT_FOUND_MESSAGE)
+      if (isENOENT(e)) throw new Error(POWERSHELL_NOT_FOUND_MESSAGE)
       throw e
     }
-    const exitCode = await proc.exited
+    const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    if (exitCode === 2) {
+      throw new Error(`${CREDENTIAL_MANAGER_INSTALL_MESSAGE}\n詳細: ${stderr.trim()}`)
+    }
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text()
-      throw new Error(`cmdkey への保存に失敗しました: ${stderr}`)
+      throw new Error(`Windows Credential Manager への保存に失敗しました: ${stderr}`)
     }
   }
 

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -23,8 +23,14 @@ const POWERSHELL_NOT_FOUND_MESSAGE =
   "PowerShell は Windows に標準インストールされています。\n" +
   "または cos auth login --insecure-file-store でファイル代替ストアを使用してください。"
 
-const CREDENTIAL_MANAGER_INSTALL_MESSAGE =
+const CREDENTIAL_MANAGER_LOAD_INSTALL_MESSAGE =
   "Windows Credential Manager の読み出しに失敗しました。\n" +
+  "PowerShell で次を実行してモジュールをインストールしてください:\n" +
+  "  Install-Module CredentialManager -Scope CurrentUser\n" +
+  "または cos auth login --insecure-file-store で代替ストアを使用してください。"
+
+const CREDENTIAL_MANAGER_SAVE_INSTALL_MESSAGE =
+  "Windows Credential Manager への保存に失敗しました。\n" +
   "PowerShell で次を実行してモジュールをインストールしてください:\n" +
   "  Install-Module CredentialManager -Scope CurrentUser\n" +
   "または cos auth login --insecure-file-store で代替ストアを使用してください。"
@@ -69,7 +75,7 @@ export class WindowsKeychainStore implements TokenStore {
     }
     const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
     if (exitCode === 2) {
-      throw new Error(`${CREDENTIAL_MANAGER_INSTALL_MESSAGE}\n詳細: ${stderr.trim()}`)
+      throw new Error(`${CREDENTIAL_MANAGER_SAVE_INSTALL_MESSAGE}\n詳細: ${stderr.trim()}`)
     }
     if (exitCode !== 0) {
       throw new Error(`Windows Credential Manager への保存に失敗しました: ${stderr}`)
@@ -105,7 +111,7 @@ export class WindowsKeychainStore implements TokenStore {
       proc.exited,
     ])
     if (exitCode === 2) {
-      throw new Error(`${CREDENTIAL_MANAGER_INSTALL_MESSAGE}\n詳細: ${stderr.trim()}`)
+      throw new Error(`${CREDENTIAL_MANAGER_LOAD_INSTALL_MESSAGE}\n詳細: ${stderr.trim()}`)
     }
     if (exitCode !== 0) return null
     return stdout.trim() || null

--- a/tests/unit/infra/keychain-macos.test.ts
+++ b/tests/unit/infra/keychain-macos.test.ts
@@ -44,6 +44,21 @@ describe("MacOSKeychainStore", () => {
         "Keychain への保存に失敗しました",
       )
     })
+
+    it("sid にシングルクォートを含む場合も正しくエスケープして stdin に渡す", async () => {
+      // shellQuote の回帰テスト: sid にシングルクォートが含まれてもコマンドインジェクションが起きないことを確認する
+      // (profile はバリデーションでシングルクォートが禁止されているため sid のみを対象とする)
+      const { spawner, getCall } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await store.save("通常プロファイル", "sid'123")
+
+      const stdin = getCall(0).options?.stdin
+      expect(stdin).toBeInstanceOf(Uint8Array)
+      const decoded = new TextDecoder().decode(stdin as Uint8Array)
+      expect(decoded).toContain("add-generic-password")
+      // ' は '\'' にエスケープされ、全体が ' で囲まれる ('sid'\''123')
+      expect(decoded).toContain("'sid'\\''123'")
+    })
   })
 
   describe("load", () => {

--- a/tests/unit/infra/keychain-macos.test.ts
+++ b/tests/unit/infra/keychain-macos.test.ts
@@ -11,23 +11,30 @@ import { captureSpawner } from "./_keychain-test-helpers"
 
 describe("MacOSKeychainStore", () => {
   describe("save", () => {
-    it("security add-generic-password -U を呼び出す", async () => {
+    it("security -i を argv に sid を含めずに呼び出す", async () => {
       const { spawner, calls, getCall } = captureSpawner("", "", 0)
       const store = new MacOSKeychainStore(spawner)
       await store.save("個人アカウント", "sid-test-12345")
 
       expect(calls).toHaveLength(1)
-      expect(getCall(0).cmd).toEqual([
-        "security",
-        "add-generic-password",
-        "-s",
-        "coscli",
-        "-a",
-        "個人アカウント",
-        "-w",
-        "sid-test-12345",
-        "-U",
-      ])
+      // argv は ["security", "-i"] のみで sid が ps に露出しない
+      expect(getCall(0).cmd).toEqual(["security", "-i"])
+      expect(getCall(0).cmd).not.toContain("sid-test-12345")
+    })
+
+    it("save で add-generic-password コマンドが stdin 経由で渡される", async () => {
+      const { spawner, getCall } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await store.save("個人アカウント", "sid-test-12345")
+
+      // stdin に add-generic-password コマンドが含まれることを確認する
+      const stdin = getCall(0).options?.stdin
+      expect(stdin).toBeInstanceOf(Uint8Array)
+      const decoded = new TextDecoder().decode(stdin as Uint8Array)
+      expect(decoded).toContain("add-generic-password")
+      expect(decoded).toContain("coscli")
+      expect(decoded).toContain("個人アカウント")
+      expect(decoded).toContain("sid-test-12345")
     })
 
     it("exit code 非 0 のときエラーを throw する", async () => {

--- a/tests/unit/infra/keychain-windows.test.ts
+++ b/tests/unit/infra/keychain-windows.test.ts
@@ -59,6 +59,15 @@ describe("WindowsKeychainStore", () => {
       const store = new WindowsKeychainStore(spawner)
       await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow("Install-Module")
     })
+
+    it("exit code 2 のエラーメッセージが保存操作を示している", async () => {
+      // save() 専用のメッセージ (「保存に失敗しました」) が返ること。load() 用の「読み出しに失敗しました」ではないことを確認する
+      const { spawner } = captureSpawner("", "", 2)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow(
+        "保存に失敗しました",
+      )
+    })
   })
 
   describe("load", () => {

--- a/tests/unit/infra/keychain-windows.test.ts
+++ b/tests/unit/infra/keychain-windows.test.ts
@@ -11,26 +11,53 @@ import { captureSpawner, enoentSpawner } from "./_keychain-test-helpers"
 
 describe("WindowsKeychainStore", () => {
   describe("save", () => {
-    it("cmdkey /generic:coscli:<profile> を正しい引数で呼び出す", async () => {
+    it("powershell New-StoredCredential を使って保存する (sid は argv に含めない)", async () => {
       const { spawner, calls, getCall } = captureSpawner("", "", 0)
       const store = new WindowsKeychainStore(spawner)
       await store.save("個人アカウント", "sid-test-12345")
 
       expect(calls).toHaveLength(1)
-      expect(getCall(0).cmd).toEqual([
-        "cmdkey",
-        "/generic:coscli:個人アカウント",
-        "/user:cos",
-        "/pass:sid-test-12345",
-      ])
+      // powershell を使う (cmdkey の /pass: argv に sid を乗せない)
+      expect(getCall(0).cmd[0]).toBe("powershell")
+      // sid が argv のどこにも含まれない
+      expect(getCall(0).cmd.join(" ")).not.toContain("sid-test-12345")
+    })
+
+    it("save で sid が COS_SID 環境変数経由で渡される", async () => {
+      const { spawner, getCall } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await store.save("個人アカウント", "sid-test-12345")
+
+      // COS_SID 環境変数に sid が設定されることを確認する
+      const env = getCall(0).options?.env
+      expect(env).toBeDefined()
+      expect(env?.["COS_SID"]).toBe("sid-test-12345")
+    })
+
+    it("save で profile が COS_TARGET 環境変数経由で渡される", async () => {
+      const { spawner, getCall } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await store.save("個人アカウント", "sid-test-12345")
+
+      // COS_TARGET 環境変数に profile が設定されることを確認する
+      const env = getCall(0).options?.env
+      expect(env?.["COS_TARGET"]).toBe("coscli:個人アカウント")
     })
 
     it("exit code 非 0 のときエラーを throw する", async () => {
-      const { spawner } = captureSpawner("", "cmdkey エラー", 1)
+      const { spawner } = captureSpawner("", "PowerShell エラー", 1)
       const store = new WindowsKeychainStore(spawner)
       await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow(
-        "cmdkey への保存に失敗しました",
+        "Windows Credential Manager への保存に失敗しました",
       )
+    })
+
+    it("exit code 2 のとき CredentialManager 未インストールのエラーを throw する", async () => {
+      const credManagerNotFoundStderr =
+        "CredentialManager module not found. Install it with: Install-Module CredentialManager -Scope CurrentUser"
+      const { spawner } = captureSpawner("", credManagerNotFoundStderr, 2)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow("Install-Module")
     })
   })
 
@@ -169,9 +196,9 @@ describe("WindowsKeychainStore", () => {
   })
 
   describe("未インストール検知 (ENOENT)", () => {
-    it("save で cmdkey が見つからないとき専用エラーを throw する", async () => {
+    it("save で powershell が見つからないとき専用エラーを throw する", async () => {
       const store = new WindowsKeychainStore(enoentSpawner())
-      await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow("cmdkey")
+      await expect(store.save("テストプロファイル", "sid-abc")).rejects.toThrow("PowerShell")
     })
 
     it("load で powershell が見つからないとき専用エラーを throw する", async () => {


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **Critical #3** に対応。

macOS と Windows の keychain save 経路で、connect.sid がサブプロセスの argv に乗り `ps auxww` から見えてしまう問題を修正。

### 変更内容

**macOS (`src/infra/keychain/macos.ts`)**
- `security add-generic-password -w <sid>` → `security -i` (stdin コマンドモード) に変更
- `security` プロセスの argv が `["security", "-i"]` のみになり、sid が `ps` から見えない
- `add-generic-password` コマンド全体を stdin 経由で渡す (`shellQuote()` でシングルクォートエスケープ)

**Windows (`src/infra/keychain/windows.ts`)**
- `cmdkey /generic:... /pass:<sid>` → PowerShell `New-StoredCredential` に変更
- sid は `COS_SID` 環境変数、profile は `COS_TARGET` 環境変数経由で渡す (load() と同じパターン)

## テスト計画

- [x] `tests/unit/infra/keychain-macos.test.ts`: argv に sid が含まれないこと / stdin にコマンドが含まれること
- [x] `tests/unit/infra/keychain-windows.test.ts`: powershell 呼び出し / COS_SID 環境変数渡し / COS_TARGET 渡し
- [x] `tests/integration/keychain-security.test.ts`: macOS 実 Keychain でのラウンドトリップ (save/load/list/delete)
- [x] `bun run typecheck` / `bunx biome check` / `bun test` 全件 pass

Refs docs/security-audit-2026-05.md#Critical3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * macOS: 認証情報保存時に入力を安全に渡す方式に変更し、特殊文字のエスケープを強化
  * Windows: 保存処理を PowerShell ベースに切替え、認証情報の取り扱いを見直し

* **エラーハンドリング**
  * Windows: PowerShell 未検出・モジュール未導入・その他失敗時の出力を区別して詳細なエラーを返すよう強化

* **テスト**
  * macOS/Windows の保存処理を検証する単体テストを更新・追加（エスケープ/環境変数の渡し方等）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->