### PR TITLE
fix(keychain): FileTokenStore のアトミック書き込み・ディレクトリ権限・JSON 破損時の処理を修正

### DIFF
--- a/src/infra/keychain/file.ts
+++ b/src/infra/keychain/file.ts
@@ -61,7 +61,18 @@ export class FileTokenStore implements TokenStore {
   private read(): Record<string, string> {
     if (!existsSync(this.filePath)) return {}
     // 破損ファイルの上書きによるデータ消失を防ぐため、パース失敗は呼び出し元に伝播する
-    return JSON.parse(readFileSync(this.filePath, "utf-8")) as Record<string, string>
+    const parsed: unknown = JSON.parse(readFileSync(this.filePath, "utf-8"))
+    // プレーンオブジェクト + 値がすべて string 以外は不正形式として弾く
+    // ([] は string キーを stringify で落とすため save が成功に見えてデータ消失する)
+    if (
+      parsed === null ||
+      Array.isArray(parsed) ||
+      typeof parsed !== "object" ||
+      Object.values(parsed).some((value) => typeof value !== "string")
+    ) {
+      throw new Error("secrets.json の形式が不正です")
+    }
+    return parsed as Record<string, string>
   }
 
   private write(data: Record<string, string>): void {

--- a/src/infra/keychain/file.ts
+++ b/src/infra/keychain/file.ts
@@ -4,9 +4,22 @@
  * OS の keychain が利用できない環境向けに、
  * ~/.config/coscli/secrets.json にセッション ID を保存する。
  * このストアは平文保存なので --insecure-file-store フラグを明示した場合のみ使用する。
+ *
+ * セキュリティ対策:
+ * - ディレクトリを 0o700、ファイルを 0o600 で作成/更新する
+ * - アトミック書き込み (tmp→rename) でクラッシュによる部分書き込みを防ぐ
+ * - JSON 破損時は silent return せず throw して上書きによるデータ消失を防ぐ
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { TokenStore } from "@/core/auth/store"
@@ -16,14 +29,19 @@ export class FileTokenStore implements TokenStore {
   constructor(private readonly filePath: string = defaultSecretsPath()) {}
 
   async save(profile: string, sid: string): Promise<void> {
+    // read() は破損ファイルで throw する (上書きによるデータ消失を防ぐ)
     const data = this.read()
     data[profile] = sid
     this.write(data)
   }
 
   async load(profile: string): Promise<string | null> {
-    const data = this.read()
-    return data[profile] ?? null
+    try {
+      const data = this.read()
+      return data[profile] ?? null
+    } catch {
+      return null
+    }
   }
 
   async delete(profile: string): Promise<void> {
@@ -33,22 +51,46 @@ export class FileTokenStore implements TokenStore {
   }
 
   async list(): Promise<string[]> {
-    return Object.keys(this.read())
+    try {
+      return Object.keys(this.read())
+    } catch {
+      return []
+    }
   }
 
   private read(): Record<string, string> {
     if (!existsSync(this.filePath)) return {}
-    try {
-      return JSON.parse(readFileSync(this.filePath, "utf-8")) as Record<string, string>
-    } catch {
-      return {}
-    }
+    // 破損ファイルの上書きによるデータ消失を防ぐため、パース失敗は呼び出し元に伝播する
+    return JSON.parse(readFileSync(this.filePath, "utf-8")) as Record<string, string>
   }
 
   private write(data: Record<string, string>): void {
     const dir = dirname(this.filePath)
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-    writeFileSync(this.filePath, JSON.stringify(data, null, 2), { mode: 0o600 })
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+    } else {
+      // 既存ディレクトリのパーミッションを 0o700 に絞り込む (Windows では無視)
+      try {
+        chmodSync(dir, 0o700)
+      } catch {
+        // Windows では chmod は無効操作のため無視する
+      }
+    }
+    // アトミック書き込み: 一時ファイル経由で rename することでクラッシュによる部分書き込みを防ぐ
+    const rand = Math.random().toString(36).slice(2)
+    const tmp = `${this.filePath}.${process.pid}.${rand}.tmp`
+    writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 })
+    try {
+      renameSync(tmp, this.filePath)
+    } catch (err) {
+      // rename 失敗時は tmp を削除してエラーを再スロー
+      try {
+        unlinkSync(tmp)
+      } catch {
+        // ベストエフォート: 削除できなくても元のエラーを優先する
+      }
+      throw err
+    }
   }
 }
 

--- a/tests/unit/infra/keychain-file.test.ts
+++ b/tests/unit/infra/keychain-file.test.ts
@@ -1,11 +1,22 @@
 /**
  * keychain-file.test.ts — ファイルベース TokenStore のテスト。
+ *
+ * アトミック書き込み・ディレクトリ権限・JSON 破損時の挙動を含む。
  */
 
 import { afterEach, describe, expect, it } from "bun:test"
-import { existsSync, unlinkSync } from "node:fs"
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { FileTokenStore } from "@/infra/keychain/file"
 
 const tmpFile = join(tmpdir(), `coscli-test-secrets-${Date.now()}.json`)
@@ -54,5 +65,80 @@ describe("FileTokenStore", () => {
     const store = new FileTokenStore(tmpFile)
     const profiles = await store.list()
     expect(profiles).toHaveLength(0)
+  })
+
+  describe("ディレクトリ権限", () => {
+    it("新規ディレクトリを 0o700 で作成する", async () => {
+      const base = mkdtempSync(join(tmpdir(), "cos-file-test-"))
+      const storePath = join(base, "newsubdir", "secrets.json")
+      try {
+        const store = new FileTokenStore(storePath)
+        await store.save("テストプロファイル", "sid-abcdef")
+
+        if (process.platform !== "win32") {
+          const stat = statSync(join(base, "newsubdir"))
+          // 新規作成ディレクトリのパーミッションが 0o700 であることを確認する
+          expect(stat.mode & 0o777).toBe(0o700)
+        }
+      } finally {
+        rmSync(base, { recursive: true, force: true })
+      }
+    })
+
+    it("既存ディレクトリを 0o700 に絞り込む", async () => {
+      const base = mkdtempSync(join(tmpdir(), "cos-file-test-"))
+      try {
+        // 意図的に緩い権限で作成されているディレクトリを対象にする
+        chmodSync(base, 0o755)
+        const storePath = join(base, "secrets.json")
+        const store = new FileTokenStore(storePath)
+        await store.save("テストプロファイル", "sid-abcdef")
+
+        if (process.platform !== "win32") {
+          const stat = statSync(base)
+          // 既存ディレクトリのパーミッションが 0o700 に更新されることを確認する
+          expect(stat.mode & 0o777).toBe(0o700)
+        }
+      } finally {
+        rmSync(base, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe("アトミック書き込み", () => {
+    it("書き込み後に対象ファイル由来の .tmp ファイルが残らない", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await store.save("テストプロファイル", "sid-abcdef")
+
+      // tmpFile のベース名に由来する .tmp ファイルが残っていないことを確認する
+      const dir = dirname(tmpFile)
+      const base = tmpFile.split("/").pop() ?? ""
+      const tmpFiles = readdirSync(dir).filter((f) => f.startsWith(base) && f.endsWith(".tmp"))
+      expect(tmpFiles).toHaveLength(0)
+    })
+  })
+
+  describe("JSON 破損ファイルの処理", () => {
+    it("破損ファイルに対する save は throw する (上書きによるデータ消失を防ぐ)", async () => {
+      // 前提: 破損した JSON ファイルが存在する
+      writeFileSync(tmpFile, "{ invalid json {{{", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: save が throw することで上書きによる他プロファイルの消失を防ぐ
+      await expect(store.save("テストプロファイル", "sid-abcdef")).rejects.toThrow()
+    })
+
+    it("破損ファイルに対する load は null を返す", async () => {
+      writeFileSync(tmpFile, "{ invalid json {{{", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: load はエラーなく null を返す (read を試みて失敗→安全なデフォルト)
+      expect(await store.load("テストプロファイル")).toBeNull()
+    })
+
+    it("破損ファイルに対する list は空配列を返す", async () => {
+      writeFileSync(tmpFile, "{ invalid json {{{", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: list はエラーなく空配列を返す
+      expect(await store.list()).toEqual([])
+    })
   })
 })

--- a/tests/unit/infra/keychain-file.test.ts
+++ b/tests/unit/infra/keychain-file.test.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { basename, dirname, join } from "node:path"
 import { FileTokenStore } from "@/infra/keychain/file"
 
 const tmpFile = join(tmpdir(), `coscli-test-secrets-${Date.now()}.json`)
@@ -112,7 +112,7 @@ describe("FileTokenStore", () => {
 
       // tmpFile のベース名に由来する .tmp ファイルが残っていないことを確認する
       const dir = dirname(tmpFile)
-      const base = tmpFile.split("/").pop() ?? ""
+      const base = basename(tmpFile)
       const tmpFiles = readdirSync(dir).filter((f) => f.startsWith(base) && f.endsWith(".tmp"))
       expect(tmpFiles).toHaveLength(0)
     })
@@ -139,6 +139,30 @@ describe("FileTokenStore", () => {
       const store = new FileTokenStore(tmpFile)
       // 検証: list はエラーなく空配列を返す
       expect(await store.list()).toEqual([])
+    })
+
+    it("破損ファイルに対する delete は throw する", async () => {
+      // 前提: 破損した JSON ファイルが存在する
+      writeFileSync(tmpFile, "{ invalid json {{{", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: delete が throw することで上書きによる他プロファイルの消失を防ぐ
+      await expect(store.delete("テストプロファイル")).rejects.toThrow()
+    })
+
+    it("配列形式の JSON ファイルに対する save は throw する", async () => {
+      // 前提: プレーンオブジェクト以外の JSON (配列) が保存されている
+      writeFileSync(tmpFile, "[]", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: save が throw することで配列への代入による永続化失敗を防ぐ
+      await expect(store.save("テストプロファイル", "sid-abcdef")).rejects.toThrow()
+    })
+
+    it("null の JSON ファイルに対する save は throw する", async () => {
+      // 前提: null が保存されている不正なファイル
+      writeFileSync(tmpFile, "null", { mode: 0o600 })
+      const store = new FileTokenStore(tmpFile)
+      // 検証: save が throw することでデータ消失を防ぐ
+      await expect(store.save("テストプロファイル", "sid-abcdef")).rejects.toThrow()
     })
   })
 })


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **Critical #4** に対応。

`FileTokenStore` (`src/infra/keychain/file.ts`) に3つのセキュリティ問題を修正。

### 変更内容

**ディレクトリ権限の強化**
- `mkdirSync` に `mode: 0o700` を追加して新規ディレクトリを厳格な権限で作成
- 既存ディレクトリに対して `chmodSync(dir, 0o700)` を呼び出し、後から緩められた場合も修正する
- Windows では `chmodSync` を try/catch で無視

**アトミック書き込み**
- `writeFileSync` で直接上書きする代わりに `<path>.<pid>.<rand>.tmp` に書き出してから `renameSync` でアトミックに置換
- クラッシュや割り込みによる部分書き込みでファイルが壊れる経路を塞ぐ
- `renameSync` 失敗時は tmp ファイルを削除してエラーを再スロー

**JSON 破損時の動作変更**
- `read()` の `catch { return {} }` を廃止し、parse エラーを呼び出し元に伝播
- `save()` / `delete()`: parse エラーを throw して上書きによる他プロファイルのデータ消失を防ぐ
- `load()` / `list()`: try/catch で安全なデフォルト値 (null / []) を返す

## テスト計画

- [x] 新規ディレクトリの mode が 0o700 であることを確認 (非 Windows)
- [x] 既存の 0o755 ディレクトリが 0o700 に更新されることを確認 (非 Windows)
- [x] 書き込み後に `.tmp` ファイルが残らないことを確認
- [x] 破損 JSON に対する `save` が throw すること
- [x] 破損 JSON に対する `load` が null を返すこと
- [x] 破損 JSON に対する `list` が空配列を返すこと
- [x] `bun run typecheck` / `bunx biome check` / `bun test` 全件 pass

Refs docs/security-audit-2026-05.md#Critical4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * トークン永続化の安全性を強化しました。保存処理は原子置換を使用し、一時ファイルの残存を防ぎます。
  * ディレクトリ/ファイルの権限を厳格化し、読み書き失敗時は安全な復帰（読み込み失敗でnull/空配列）を返すようにしました。
  * 破損した永続データは明示的に例外を投げて検出可能にしました。

* **テスト**
  * 権限設定、原子書き込み、破損データ耐性を含む包括的なテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/77)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->