### PR TITLE
fix(sandbox): ワイルドカード・大文字小文字正規化・Unicode空白文字対応

### DIFF
--- a/src/core/sandbox.ts
+++ b/src/core/sandbox.ts
@@ -68,7 +68,7 @@ export function createPolicy(opts: PolicyOptions): Policy {
  * case-sensitive bypass や不可視文字混入による sandbox 迂回を防ぐ。
  */
 function normalizeCommand(s: string): string {
-  return s.replace(/[\p{White_Space}​-‏]/gu, "").toLowerCase()
+  return s.replace(/[\p{White_Space}\u200B-\u200F]/gu, "").toLowerCase()
 }
 
 /** mergeList は配列とカンマ区切り文字列をマージして正規化する。 */

--- a/src/core/sandbox.ts
+++ b/src/core/sandbox.ts
@@ -62,6 +62,15 @@ export function createPolicy(opts: PolicyOptions): Policy {
   }
 }
 
+/**
+ * normalizeCommand はコマンド/パターン文字列を正規化する。
+ * Unicode 空白文字 (\p{White_Space}) およびゼロ幅文字 (U+200B–U+200F) を除去して小文字化することで、
+ * case-sensitive bypass や不可視文字混入による sandbox 迂回を防ぐ。
+ */
+function normalizeCommand(s: string): string {
+  return s.replace(/[\p{White_Space}​-‏]/gu, "").toLowerCase()
+}
+
 /** mergeList は配列とカンマ区切り文字列をマージして正規化する。 */
 function mergeList(list: string[] | undefined, str: string | undefined): string[] {
   const fromList = list ?? []
@@ -76,13 +85,30 @@ function mergeList(list: string[] | undefined, str: string | undefined): string[
 
 /**
  * isAllowed はコマンドがパターンリストにマッチするか判定する。
- * パターンが "page" のように noun のみの場合、"page.*" 全体にマッチする。
+ *
+ * - `*` / `all`: 全コマンドにマッチ
+ * - `page.*`: page ドメインのすべてのコマンドにマッチ
+ * - `page`: page.* 全体にマッチ (後方互換)
+ * - `page.list`: 完全一致のみマッチ
+ *
+ * 比較前に両辺を normalizeCommand で正規化するため、大文字小文字・Unicode 空白文字を区別しない。
  */
 function isAllowed(command: string, patterns: string[]): boolean {
+  const normalizedCmd = normalizeCommand(command)
   return patterns.some((pattern) => {
-    if (pattern === command) return true
-    // "page" は "page.list", "page.delete" 等にマッチ
-    if (!pattern.includes(".") && command.startsWith(`${pattern}.`)) return true
+    const normalizedPattern = normalizeCommand(pattern)
+    // ワイルドカード: * または all は全コマンドにマッチ
+    if (normalizedPattern === "*" || normalizedPattern === "all") return true
+    // 完全一致
+    if (normalizedPattern === normalizedCmd) return true
+    // "page.*" glob: page.* 全体にマッチ
+    if (normalizedPattern.endsWith(".*")) {
+      const prefix = normalizedPattern.slice(0, -2)
+      if (normalizedCmd.startsWith(`${prefix}.`)) return true
+    }
+    // "page" ワイルドカード: page.list, page.delete 等にマッチ (後方互換)
+    if (!normalizedPattern.includes(".") && normalizedCmd.startsWith(`${normalizedPattern}.`))
+      return true
     return false
   })
 }

--- a/tests/unit/core/sandbox.test.ts
+++ b/tests/unit/core/sandbox.test.ts
@@ -144,15 +144,15 @@ describe("大文字小文字の正規化", () => {
 
 describe("Unicode 空白文字の正規化", () => {
   it("パターンに Unicode 空白文字が含まれていても正しくマッチする", () => {
-    // ゼロ幅スペース (​) や全角スペース (　) を含むパターン
-    const policy = createPolicy({ enableStr: "page.list​,page.get　" })
+    // ゼロ幅スペース (U+200B) や全角スペース (U+3000) を含むパターン
+    const policy = createPolicy({ enableStr: "page.list\u200B,page.get\u3000" })
     expect(policy.allow("page.list")).toBeUndefined()
     expect(policy.allow("page.get")).toBeUndefined()
     expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
   })
 
-  it("ノーブレークスペース ( ) を含むパターンを正規化する", () => {
-    const policy = createPolicy({ disable: ["page.delete "] })
+  it("ノーブレークスペース (U+00A0) を含むパターンを正規化する", () => {
+    const policy = createPolicy({ disable: ["page.delete\u00A0"] })
     expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
     expect(policy.allow("page.list")).toBeUndefined()
   })

--- a/tests/unit/core/sandbox.test.ts
+++ b/tests/unit/core/sandbox.test.ts
@@ -89,3 +89,71 @@ describe("PolicyOptions のパース", () => {
     expect(policy.allow("page.delete")).toBeUndefined()
   })
 })
+
+describe("ワイルドカード '*' / 'all'", () => {
+  it("disable: ['*'] で全コマンドを拒否する", () => {
+    const policy = createPolicy({ disable: ["*"] })
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+
+  it("disable: ['all'] で全コマンドを拒否する", () => {
+    const policy = createPolicy({ disable: ["all"] })
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+
+  it("disableStr '*' で全コマンドを拒否する (CLI フラグ形式)", () => {
+    const policy = createPolicy({ disableStr: "*" })
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+})
+
+describe("'page.*' glob パターン", () => {
+  it("disable: ['page.*'] で page.* 全体を拒否し他ドメインは通す", () => {
+    const policy = createPolicy({ disable: ["page.*"] })
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("project.info")).toBeUndefined()
+  })
+
+  it("enable: ['page.*'] で page.* のみ許可する", () => {
+    const policy = createPolicy({ enable: ["page.*"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeUndefined()
+    expect(policy.allow("project.info")).toBeInstanceOf(PolicyError)
+  })
+})
+
+describe("大文字小文字の正規化", () => {
+  it("パターンの大文字を小文字に正規化してマッチする", () => {
+    const policy = createPolicy({ enableStr: "PAGE.LIST,Page.Get" })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.get")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+
+  it("disable パターンの大文字を正規化して拒否する", () => {
+    const policy = createPolicy({ disable: ["PAGE.DELETE"] })
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.list")).toBeUndefined()
+  })
+})
+
+describe("Unicode 空白文字の正規化", () => {
+  it("パターンに Unicode 空白文字が含まれていても正しくマッチする", () => {
+    // ゼロ幅スペース (​) や全角スペース (　) を含むパターン
+    const policy = createPolicy({ enableStr: "page.list​,page.get　" })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.get")).toBeUndefined()
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+
+  it("ノーブレークスペース ( ) を含むパターンを正規化する", () => {
+    const policy = createPolicy({ disable: ["page.delete "] })
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.list")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **High #5** に対応。

`--enable-commands` / `--disable-commands` の sandbox ポリシーに 3 つのセキュリティ問題を修正。

### 変更内容

**`normalizeCommand()` の追加**
- `\p{White_Space}` + U+200B–U+200F (ゼロ幅文字) を除去
- `toLowerCase()` で小文字化
- `isAllowed()` 内でコマンド名とパターンの両方を正規化

**`*` / `all` ワイルドカード対応**
- `disable: ["*"]` または `disable: ["all"]` で全コマンドを拒否できるようになった
- `cos --disable-commands "*" page list` が exit 7 で終了する

**`page.*` glob パターン対応**
- `page.*` で `page.list`、`page.delete` 等 page ドメイン全体をマッチできる
- 既存の `page` 形式 (後方互換) も引き続き動作する

## テスト計画

- [x] `*` / `all` で全コマンドを拒否できること
- [x] `page.*` で page ドメイン全体をマッチできること
- [x] `PAGE.LIST` などの大文字パターンが正規化されてマッチすること
- [x] ゼロ幅スペースや全角スペースを含むパターンが正規化されてマッチすること
- [x] `bun run typecheck` / `bunx biome check` / `bun test` 全件 pass

Refs docs/security-audit-2026-05.md#High5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * コマンド認可の検証を強化。Unicode空白やゼロ幅文字、大文字小文字の違いを考慮した正規化を導入し、パターンマッチングの回避を防止します（ワイルドカードや名前空間パターン含む）。

* **Tests**
  * コマンドマッチング動作の包括的なユニットテストを追加。グローバル設定、グロブパターン、正規化処理が期待通りに機能することを検証します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/78)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/78)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->