### PR TITLE
fix(config): setConfigValue/getConfigValue の prototype 汚染を防ぐ

### DIFF
--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -77,9 +77,28 @@ export function saveConfig(config: CoscliConfig, filePath: string = defaultConfi
   writeFileSync(filePath, header + JSON.stringify(config, null, 2))
 }
 
+/** FORBIDDEN_KEYS は prototype 汚染を引き起こす危険なキー名の集合。 */
+const FORBIDDEN_KEYS = new Set(["__proto__", "prototype", "constructor"])
+
+/**
+ * assertSafeKey はキーが安全かどうかを検証する。
+ * 危険なキーが含まれている場合は Error を throw する。
+ */
+function assertSafeKeys(parts: string[]): void {
+  for (const part of parts) {
+    if (FORBIDDEN_KEYS.has(part)) {
+      throw new Error(`設定キーに不正な値が含まれています: "${part}"`)
+    }
+  }
+}
+
 /** getConfigValue は設定のネストしたキーを . 区切りで取得する。 */
 export function getConfigValue(config: CoscliConfig, key: string): unknown {
   const parts = key.split(".")
+  // 禁止キーへのアクセスは undefined を返して prototype 汚染を防ぐ
+  for (const part of parts) {
+    if (FORBIDDEN_KEYS.has(part)) return undefined
+  }
   let current: unknown = config
   for (const part of parts) {
     if (current === null || typeof current !== "object") return undefined
@@ -91,6 +110,8 @@ export function getConfigValue(config: CoscliConfig, key: string): unknown {
 /** setConfigValue は設定のネストしたキーを . 区切りで設定する。 */
 export function setConfigValue(config: CoscliConfig, key: string, value: unknown): CoscliConfig {
   const parts = key.split(".")
+  // 禁止キーが含まれていれば即座に throw して prototype 汚染を防ぐ
+  assertSafeKeys(parts)
   const updated = structuredClone(config) as Record<string, unknown>
   let current = updated
   for (const part of parts.slice(0, -1)) {

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -5,7 +5,7 @@
  * テスト終了後にクリーンアップする。
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { existsSync, unlinkSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -159,5 +159,45 @@ describe("setConfigValue", () => {
   it("sync.format に不正な値を設定するとエラーになる", () => {
     const config = {}
     expect(() => setConfigValue(config, "sync.format", "md")).toThrow()
+  })
+})
+
+describe("prototype 汚染への防御", () => {
+  afterAll(() => {
+    // RED フェーズで汚染が発生した場合に備えてクリーンアップする
+    ;(Object.prototype as Record<string, unknown>)["polluted"] = undefined
+  })
+
+  it("setConfigValue で __proto__ キーを指定すると throw する", () => {
+    expect(() => setConfigValue({}, "__proto__.polluted", true)).toThrow()
+  })
+
+  it("setConfigValue で prototype キーを指定すると throw する", () => {
+    expect(() => setConfigValue({}, "prototype.polluted", true)).toThrow()
+  })
+
+  it("setConfigValue で constructor キーを指定すると throw する", () => {
+    expect(() => setConfigValue({}, "constructor.name", "不正コード")).toThrow()
+  })
+
+  it("__proto__ への setConfigValue が失敗しても Object.prototype が汚染されない", () => {
+    try {
+      setConfigValue({}, "__proto__.polluted", true)
+    } catch {
+      // 期待通りの throw
+    }
+    // Object.prototype が汚染されていないことを確認する
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined()
+  })
+
+  it("getConfigValue で __proto__ キーを指定すると undefined を返す", () => {
+    const config = {}
+    expect(getConfigValue(config, "__proto__")).toBeUndefined()
+    expect(getConfigValue(config, "__proto__.polluted")).toBeUndefined()
+  })
+
+  it("getConfigValue で constructor キーを指定すると undefined を返す", () => {
+    const config = {}
+    expect(getConfigValue(config, "constructor")).toBeUndefined()
   })
 })

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -165,7 +165,7 @@ describe("setConfigValue", () => {
 describe("prototype 汚染への防御", () => {
   afterAll(() => {
     // RED フェーズで汚染が発生した場合に備えてクリーンアップする
-    ;(Object.prototype as Record<string, unknown>)["polluted"] = undefined
+    Reflect.deleteProperty(Object.prototype, "polluted")
   })
 
   it("setConfigValue で __proto__ キーを指定すると throw する", () => {
@@ -187,7 +187,7 @@ describe("prototype 汚染への防御", () => {
       // 期待通りの throw
     }
     // Object.prototype が汚染されていないことを確認する
-    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined()
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false)
   })
 
   it("getConfigValue で __proto__ キーを指定すると undefined を返す", () => {


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **High #6** に対応。

`setConfigValue(config, "__proto__.polluted", true)` が `Object.prototype` を汚染できる脆弱性を修正。

### 攻撃シナリオ

`cos config set __proto__.polluted true` が実行されると:
1. `key.split(".")` → `["__proto__", "polluted"]`
2. `structuredClone(config)["__proto__"]` → `Object.prototype`
3. `Object.prototype["polluted"] = true` → 以降のすべての `{}["polluted"]` が `true` になる

### 変更内容

**`FORBIDDEN_KEYS = new Set(["__proto__", "prototype", "constructor"])` を追加**

- `setConfigValue`: パスに禁止キーが含まれる場合は処理前に throw して汚染を防ぐ
- `getConfigValue`: パスに禁止キーが含まれる場合は `undefined` を返す (プロトタイプアクセスを避ける)

## テスト計画

- [x] `setConfigValue` で `__proto__`、`prototype`、`constructor` キーが throw すること
- [x] throw が発生しても `Object.prototype` が汚染されないこと
- [x] `getConfigValue` で禁止キーが `undefined` を返すこと
- [x] `bun run typecheck` / `bunx biome check` / `bun test` 全件 pass

Refs docs/security-audit-2026-05.md#High6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 設定読み書きでプロトタイプ汚染を防ぐ検証を導入しました。危険なキーを含むパスは読み取り時に未定義として扱われ、書き込み時は拒否されエラーになります。これによりグローバルなオブジェクト汚染を防止します。

* **テスト**
  * 上記の防御動作を検証するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/79)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->