### PR TITLE
fix(security): COS_SID / --sid のフォーマット検証を追加 (High #7)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -202,12 +202,47 @@ export function getRawFlagValue(argv: string[], flagName: string): string | unde
   return result
 }
 
+const SID_MAX_LENGTH = 4096
+// RFC 6265 cookie-octet 相当: 制御文字・スペース・ダブルクォートを除く印字可能 ASCII
+const SID_PATTERN = /^[\x21\x23-\x7E]+$/
+
+/** SidValidationError は SID フォーマット違反を表すエラー。 */
+export class SidValidationError extends Error {
+  constructor() {
+    super("SID のフォーマットが不正です。改行・制御文字・空白は使用できません")
+    this.name = "SidValidationError"
+  }
+}
+
+/**
+ * assertValidSid は SID 文字列のフォーマットを検証する。
+ * 長さ 1〜4096、印字可能 ASCII (制御文字・スペース・ダブルクォートを除く) のみ許可。
+ * 違反時は SidValidationError をスローする。
+ */
+export function assertValidSid(sid: string): void {
+  if (sid.length === 0 || sid.length > SID_MAX_LENGTH || !SID_PATTERN.test(sid)) {
+    throw new SidValidationError()
+  }
+}
+
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
 export async function requireSid(profile?: string): Promise<string> {
   // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)
   if (!profile) {
     const envSid = process.env["COS_SID"]
-    if (envSid) return envSid
+    if (envSid) {
+      try {
+        assertValidSid(envSid)
+      } catch {
+        writeErrorJson(
+          "INVALID_SID",
+          "COS_SID のフォーマットが不正です",
+          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
+        )
+        exitWithError(5, "INVALID_SID")
+      }
+      return envSid
+    }
   }
   const store = createTokenStore()
   const sessionOpts = profile !== undefined ? { profile } : {}
@@ -219,6 +254,16 @@ export async function requireSid(profile?: string): Promise<string> {
       "`cos auth login` を実行してログインしてください",
     )
     exitWithError(2, "AUTH_REQUIRED")
+  }
+  try {
+    assertValidSid(sid)
+  } catch {
+    writeErrorJson(
+      "INVALID_SID",
+      "キーチェーンに保存された SID のフォーマットが不正です",
+      "`cos auth logout` 後に再ログインしてください",
+    )
+    exitWithError(5, "INVALID_SID")
   }
   return sid
 }

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -203,8 +203,8 @@ export function getRawFlagValue(argv: string[], flagName: string): string | unde
 }
 
 const SID_MAX_LENGTH = 4096
-// RFC 6265 cookie-octet 相当: 制御文字・スペース・ダブルクォートを除く印字可能 ASCII
-const SID_PATTERN = /^[\x21\x23-\x7E]+$/
+// RFC 6265 cookie-octet: DQUOTE(0x22), comma(0x2C), semicolon(0x3B), backslash(0x5C), CTL, SP を除外
+const SID_PATTERN = /^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/
 
 /** SidValidationError は SID フォーマット違反を表すエラー。 */
 export class SidValidationError extends Error {
@@ -214,11 +214,7 @@ export class SidValidationError extends Error {
   }
 }
 
-/**
- * assertValidSid は SID 文字列のフォーマットを検証する。
- * 長さ 1〜4096、印字可能 ASCII (制御文字・スペース・ダブルクォートを除く) のみ許可。
- * 違反時は SidValidationError をスローする。
- */
+/** assertValidSid は SID 文字列のフォーマットを検証し、違反時は SidValidationError をスローする。 */
 export function assertValidSid(sid: string): void {
   if (sid.length === 0 || sid.length > SID_MAX_LENGTH || !SID_PATTERN.test(sid)) {
     throw new SidValidationError()
@@ -230,7 +226,7 @@ export async function requireSid(profile?: string): Promise<string> {
   // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)
   if (!profile) {
     const envSid = process.env["COS_SID"]
-    if (envSid) {
+    if (envSid !== undefined) {
       try {
         assertValidSid(envSid)
       } catch {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -23,6 +23,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   type CommonArgs,
+  SidValidationError,
+  assertValidSid,
   buildJsonOpts,
   buildLogger,
   checkSandbox,
@@ -238,6 +240,18 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
           process.exit(0)
         }
         sid = input as string
+      }
+
+      // sid フォーマット検証 (制御文字・改行混入によるヘッダインジェクション防止)
+      try {
+        assertValidSid(sid)
+      } catch (err) {
+        if (err instanceof SidValidationError) {
+          writeErrorJson("INVALID_SID", err.message, "有効な connect.sid を指定してください")
+          process.exit(5)
+          return
+        }
+        throw err
       }
 
       logger.info("認証情報を確認中...")

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -8,6 +8,8 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test"
 import {
   type CommonArgs,
+  SidValidationError,
+  assertValidSid,
   buildJsonOpts,
   buildLogger,
   commonArgs,
@@ -151,6 +153,59 @@ describe("buildJsonOpts - 環境変数伝播 (COS_RESULTS_ONLY / COS_SELECT)", (
     // 環境変数もフラグも指定されていない場合は既定値を維持する
     const opts = buildJsonOpts(makeArgs())
     expect(opts.resultsOnly).toBe(false)
+  })
+})
+
+describe("assertValidSid / SidValidationError", () => {
+  it("正常な SID は検証を通過する", () => {
+    expect(() => assertValidSid("s%3Atest-session-id.xyz")).not.toThrow()
+  })
+
+  it("英数字と記号のみの SID は検証を通過する", () => {
+    expect(() => assertValidSid("abc123XYZ!#$%&'*+-.^_`|~")).not.toThrow()
+  })
+
+  it("1 文字の SID は検証を通過する", () => {
+    expect(() => assertValidSid("a")).not.toThrow()
+  })
+
+  it("4096 文字ちょうどの SID は検証を通過する", () => {
+    expect(() => assertValidSid("a".repeat(4096))).not.toThrow()
+  })
+
+  it("空文字列は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("")).toThrow(SidValidationError)
+  })
+
+  it("4097 文字の SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("a".repeat(4097))).toThrow(SidValidationError)
+  })
+
+  it("CR (\\r) を含む SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("valid-sid\r\n")).toThrow(SidValidationError)
+  })
+
+  it("LF (\\n) のみを含む SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("valid-sid\n")).toThrow(SidValidationError)
+  })
+
+  it("NUL バイト (\\x00) を含む SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("valid\x00sid")).toThrow(SidValidationError)
+  })
+
+  it("スペースを含む SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid("valid sid")).toThrow(SidValidationError)
+  })
+
+  it("ダブルクォートを含む SID は SidValidationError をスローする", () => {
+    expect(() => assertValidSid('valid"sid')).toThrow(SidValidationError)
+  })
+
+  it("SidValidationError は Error を継承し SID に関するメッセージを持つ", () => {
+    const err = new SidValidationError()
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe("SidValidationError")
+    expect(err.message).toContain("SID")
   })
 })
 

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -201,6 +201,21 @@ describe("assertValidSid / SidValidationError", () => {
     expect(() => assertValidSid('valid"sid')).toThrow(SidValidationError)
   })
 
+  it("セミコロン (;) を含む SID は SidValidationError をスローする (RFC 6265 cookie-octet 違反)", () => {
+    // connect.sid=value;Path=/ のようなヘッダー区切り文字はSIDとして無効
+    expect(() => assertValidSid("valid;sid")).toThrow(SidValidationError)
+  })
+
+  it("カンマ (,) を含む SID は SidValidationError をスローする (RFC 6265 cookie-octet 違反)", () => {
+    // カンマはCookieヘッダーの区切り文字として使われるためSIDとして無効
+    expect(() => assertValidSid("valid,sid")).toThrow(SidValidationError)
+  })
+
+  it("バックスラッシュ (\\\\) を含む SID は SidValidationError をスローする (RFC 6265 cookie-octet 違反)", () => {
+    // バックスラッシュはCookieヘッダーの値として無効
+    expect(() => assertValidSid("valid\\sid")).toThrow(SidValidationError)
+  })
+
   it("SidValidationError は Error を継承し SID に関するメッセージを持つ", () => {
     const err = new SidValidationError()
     expect(err).toBeInstanceOf(Error)

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
   // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
-  process.env["COS_SID"] = "ダミーセッションID-テスト用"
+  process.env["COS_SID"] = "dummy-session-id-for-test"
 })
 
 afterEach(() => {


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **High #7 — COS_SID / --sid のフォーマット検証なし** に対応。

- `assertValidSid` / `SidValidationError` を `src/commands/_shared.ts` に追加
- 長さ 1〜4096 / RFC 6265 cookie-octet 相当の文字セット (制御文字・スペース・ダブルクォート除く) を検証
- `requireSid()` で COS_SID 環境変数とキーチェーン取得値の両方を検証 → 違反時は exit 5 / `INVALID_SID`
- `auth login` コマンドで sid 確定直後に `assertValidSid` を呼び出し、Header Injection を防止
- テスト用 COS_SID ダミー値 (`ダミーセッションID-テスト用`) を有効 ASCII 文字列に統一

## 攻撃シナリオ

プロンプトインジェクション等で `COS_SID=$'bad\r\nX-Inject: evil'` が設定された場合、
HTTP リクエストの Cookie ヘッダが改行で分割され任意ヘッダを挿入できる（CRLF injection）。
本 PR で `\r` / `\n` を含む SID を exit 5 で早期拒否する。

## テスト

```bash
bun test tests/unit/commands/_shared.test.ts
```

新規テスト (11 件):
- 正常値通過 / 空文字 / 4096 文字上限 / 4097 文字超過
- CR, LF, NUL バイト, スペース, ダブルクォートで拒否
- `SidValidationError` の継承と message 検証

## 動作確認

```bash
# 不正 SID で exit 5 / INVALID_SID が返ること
COS_SID=$'bad\r\nvalue' bun src/cli.ts auth whoami 2>&1 | head -5
```

Closes #High7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * セッションID（SID）検証が強化され、環境変数や保存済みセッションから読み込んだ無効なSIDは明確なエラーとともに拒否されるようになりました。ログイン処理でも無効なSIDはエラー扱いになります。

* **テスト**
  * SID検証に関する網羅的な単体テストを追加・拡充しました（有効／無効ケース多数）。
  * テスト用のSID初期値をより明確な値に更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/80)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->