### PR TITLE
fix(security): HTTP redirect 手動制御による Cookie 漏洩防止 (High #8)

### DIFF
--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -19,6 +19,8 @@ import { type Me, MeSchema } from "@/schemas/user"
 import { z } from "zod"
 
 const BASE_URL = "https://scrapbox.io"
+const ALLOWED_ORIGIN = new URL(BASE_URL).origin
+const MAX_REDIRECTS = 5
 
 /** CosenseApiError は API エラーの基底クラス。 */
 export class CosenseApiError extends Error {
@@ -210,21 +212,47 @@ export class CosenseRestClient {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), this.timeout)
 
-    let response: Response
     try {
-      response = await fetch(url, {
-        headers: this.buildHeaders(),
-        signal: controller.signal,
-      })
+      let currentUrl = url
+      for (let redirectCount = 0; ; redirectCount++) {
+        const response = await fetch(currentUrl, {
+          headers: this.buildHeaders(),
+          signal: controller.signal,
+          redirect: "manual",
+        })
+
+        // 3xx リダイレクト応答を手動処理 (Cookie の外部漏洩防止)
+        if (response.status >= 300 && response.status < 400) {
+          if (redirectCount >= MAX_REDIRECTS) {
+            throw new CosenseApiError(
+              0,
+              `リダイレクトの上限 (${MAX_REDIRECTS} 回) に達しました: ${url}`,
+            )
+          }
+          const location = response.headers.get("Location")
+          if (!location) {
+            throw new CosenseApiError(0, `Location ヘッダが見つかりません: ${currentUrl}`)
+          }
+          const redirectUrl = new URL(location, BASE_URL)
+          if (redirectUrl.origin !== ALLOWED_ORIGIN) {
+            throw new CosenseApiError(
+              0,
+              `外部ドメインへのリダイレクトを拒否しました: ${redirectUrl.origin}`,
+            )
+          }
+          currentUrl = redirectUrl.href
+          continue
+        }
+
+        if (!response.ok) {
+          await this.handleError(response, url)
+        }
+
+        return response
+      }
     } finally {
       clearTimeout(timer)
     }
-
-    if (!response.ok) {
-      await this.handleError(response, url)
-    }
-
-    return response
   }
 
   private async handleError(response: Response, url: string): Promise<never> {

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -233,7 +233,7 @@ export class CosenseRestClient {
           if (!location) {
             throw new CosenseApiError(0, `Location ヘッダが見つかりません: ${currentUrl}`)
           }
-          const redirectUrl = new URL(location, BASE_URL)
+          const redirectUrl = new URL(location, currentUrl)
           if (redirectUrl.origin !== ALLOWED_ORIGIN) {
             throw new CosenseApiError(
               0,

--- a/tests/unit/core/api/redirect.test.ts
+++ b/tests/unit/core/api/redirect.test.ts
@@ -1,0 +1,75 @@
+/**
+ * redirect.test.ts — HTTP リダイレクト制御のテスト。
+ *
+ * msw でリダイレクト応答をモックし、CosenseRestClient の
+ * 同一オリジン追従・外部オリジン拒否・上限回数超過を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { CosenseRestClient } from "@/core/api/rest"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import meFixture from "../../../fixtures/me.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_SID = "s%3Atest-connect-sid"
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("CosenseRestClient — リダイレクト制御", () => {
+  it("同一オリジンへの 302 リダイレクトを追従してレスポンスを返す", async () => {
+    // 1 回目の呼び出しで 302 → 同一オリジンの /api/users/me へリダイレクト
+    // 2 回目の呼び出しで正常なレスポンスを返す
+    let callCount = 0
+    server.use(
+      http.get(`${BASE_URL}/api/users/me`, () => {
+        callCount++
+        if (callCount === 1) {
+          return new HttpResponse(null, {
+            status: 302,
+            headers: { Location: `${BASE_URL}/api/users/me` },
+          })
+        }
+        return HttpResponse.json(meFixture)
+      }),
+    )
+    const client = new CosenseRestClient({ sid: TEST_SID })
+    const me = await client.getMe()
+    expect(me.name).toBe("テストユーザー")
+    expect(callCount).toBe(2)
+  })
+
+  it("外部オリジンへの 302 リダイレクトはエラーをスローする (Cookie 漏洩防止)", async () => {
+    // 攻撃者サーバーへのリダイレクト — connect.sid が流出しないよう拒否すること
+    server.use(
+      http.get(`${BASE_URL}/api/users/me`, () => {
+        return new HttpResponse(null, {
+          status: 302,
+          headers: { Location: "https://evil.example.com/steal-cookies" },
+        })
+      }),
+    )
+    const client = new CosenseRestClient({ sid: TEST_SID })
+    await expect(client.getMe()).rejects.toThrow("外部ドメイン")
+  })
+
+  it("5 回を超えるリダイレクトはエラーをスローする (ループ防止)", async () => {
+    // 同一 URL への永続リダイレクトでループを発生させる
+    server.use(
+      http.get(`${BASE_URL}/api/users/me`, () => {
+        return new HttpResponse(null, {
+          status: 302,
+          headers: { Location: `${BASE_URL}/api/users/me` },
+        })
+      }),
+    )
+    // タイムアウトを短く設定してループが早期終了することを確認する
+    const client = new CosenseRestClient({ sid: TEST_SID, timeout: 5000 })
+    await expect(client.getMe()).rejects.toThrow()
+  }, 10000)
+})

--- a/tests/unit/core/api/redirect.test.ts
+++ b/tests/unit/core/api/redirect.test.ts
@@ -60,16 +60,42 @@ describe("CosenseRestClient — リダイレクト制御", () => {
 
   it("5 回を超えるリダイレクトはエラーをスローする (ループ防止)", async () => {
     // 同一 URL への永続リダイレクトでループを発生させる
+    let callCount = 0
     server.use(
       http.get(`${BASE_URL}/api/users/me`, () => {
+        callCount++
         return new HttpResponse(null, {
           status: 302,
           headers: { Location: `${BASE_URL}/api/users/me` },
         })
       }),
     )
-    // タイムアウトを短く設定してループが早期終了することを確認する
-    const client = new CosenseRestClient({ sid: TEST_SID, timeout: 5000 })
-    await expect(client.getMe()).rejects.toThrow()
-  }, 10000)
+    const client = new CosenseRestClient({ sid: TEST_SID, timeout: 10000 })
+    await expect(client.getMe()).rejects.toThrow("リダイレクトの上限")
+    // MAX_REDIRECTS=5 なので 6 回目のリクエストでエラーになる
+    expect(callCount).toBe(6)
+  }, 15000)
+
+  it("相対 Location ヘッダ (クエリのみ) を currentUrl 基準に解決してリダイレクトを追従する", async () => {
+    // ?v=2 のような相対 URL を BASE_URL 基準で解決するとパスが消えてしまうため
+    // currentUrl を基準に解決することを確認する
+    let callCount = 0
+    server.use(
+      http.get(`${BASE_URL}/api/users/me`, () => {
+        callCount++
+        if (callCount === 1) {
+          // クエリのみの相対 URL: currentUrl 基準なら /api/users/me?v=2 になる
+          return new HttpResponse(null, {
+            status: 302,
+            headers: { Location: "?v=2" },
+          })
+        }
+        return HttpResponse.json(meFixture)
+      }),
+    )
+    const client = new CosenseRestClient({ sid: TEST_SID })
+    const me = await client.getMe()
+    expect(me.name).toBe("テストユーザー")
+    expect(callCount).toBe(2)
+  })
 })


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` の **High #8 — HTTP redirect で Cookie 漏洩の可能性** に対応。

- `doFetch` に `redirect: "manual"` を追加し、3xx 応答を手動処理するよう変更
- `Location` ヘッダの origin を検証し、`https://scrapbox.io` 以外のドメインへの追従を拒否
- リダイレクト上限 `MAX_REDIRECTS = 5` を超えた場合はエラーをスロー（ループ防止）
- 同一オリジンへのリダイレクトは最大 5 回まで安全に追従
- `tests/unit/core/api/redirect.test.ts` を新規追加

## 攻撃シナリオ

Cosense が悪意ある設定により `https://attacker.com/steal` へ 302 リダイレクトする場合、
デフォルトの `redirect: "follow"` では `Cookie: connect.sid=...` が攻撃者サーバーに送信される。
本 PR で外部オリジンへのリダイレクト追従を拒否する。

## テスト

```bash
bun test tests/unit/core/api/redirect.test.ts
```

新規テスト (3 件):
- 同一オリジン 302 リダイレクトを追従してレスポンスを返す
- 外部オリジン 302 リダイレクトはエラーをスローする (Cookie 漏洩防止)
- 5 回を超えるリダイレクトはエラーをスローする (ループ防止)

Closes #High8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * APIクライアントが3xxレスポンスを適切に追従して処理するようになりました
  * 外部オリジンへのリダイレクトが拒否されるようになりました
  * リダイレクト回数の上限によるループ防止が追加されました

* **テスト**
  * リダイレクト挙動（同一オリジン追従、外部拒否、ループ検知、相対Location解決）を検証する包括的なテストが追加されました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/81)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->