### PR TITLE
feat(notation): Cosense 記法ガイドと lint による書き込み時警告を追加

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import { serveCommand } from "@/commands/serve"
 
 // エージェント向け補助コマンド
 import { exitCodesCommand } from "@/commands/exit-codes"
+import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
 /** page サブコマンドグループ */
@@ -232,6 +233,7 @@ const main = defineCommand({
     serve: serveCommand,
     "exit-codes": exitCodesCommand,
     schema: schemaCommand,
+    notation: notationGuideCommand,
   },
 })
 

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -92,6 +92,20 @@ export const dryRunArg = {
 } as const
 
 /**
+ * strictNotationArg は書き込み系コマンドが追加スプレッドする --strict-notation フラグ定義。
+ *
+ * Cosense 記法の lint 警告が検出された場合に書き込みを中止して exit 5 を返す。
+ * 省略時は警告のみ meta.warnings に追加し書き込みは続行する。
+ */
+export const strictNotationArg = {
+  "strict-notation": {
+    type: "boolean" as const,
+    description: "Cosense 記法の lint 警告を検出したら書き込みを中止する",
+    default: false,
+  },
+} as const
+
+/**
  * unsafeReadArg は --from-file を持つコマンドが追加スプレッドする安全読み込みバイパスフラグ定義。
  *
  * 通常はセキュリティ上の理由で禁止されているパス (.env, ~/.ssh, /etc 等) も読み込みたい
@@ -121,6 +135,9 @@ export type CommonArgs = {
 
 /** DryRunArg は書き込み系コマンドが追加で受け取る --dry-run フラグの型。 */
 export type DryRunArg = { "dry-run": boolean }
+
+/** StrictNotationArg は書き込み系コマンドが追加で受け取る --strict-notation フラグの型。 */
+export type StrictNotationArg = { "strict-notation": boolean }
 
 /** WriteCommonArgs は書き込み系コマンドが受け取る共通フラグの型。 */
 export type WriteCommonArgs = CommonArgs & DryRunArg
@@ -302,4 +319,18 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
 export async function buildWriter(args: WriteCommonArgs) {
   const sid = await requireSid(args.profile)
   return createScrapboxWriter({ sid, dryRun: args["dry-run"] })
+}
+
+/**
+ * notationFindingToWarning は NotationFinding を JSON envelope の warnings 文字列に変換する。
+ *
+ * 書式: "[行 N] rule: message (hint: ...)"
+ */
+export function notationFindingToWarning(
+  finding: import("@/core/notation/lint").NotationFinding,
+): string {
+  const loc =
+    finding.column !== undefined ? `行 ${finding.line} 列 ${finding.column}` : `行 ${finding.line}`
+  const hint = finding.hint ? ` (修正案: ${finding.hint})` : ""
+  return `[${loc}] ${finding.rule}: ${finding.message}${hint}`
 }

--- a/src/commands/notation/guide.ts
+++ b/src/commands/notation/guide.ts
@@ -1,0 +1,63 @@
+/**
+ * notation/guide.ts — `cos notation` コマンド定義。
+ *
+ * Cosense 記法のリファレンスガイドを出力する。
+ * エージェントが書き込み前に正しい記法を参照するための補助コマンド。
+ *
+ * 出力形式:
+ *   デフォルト  — ヒューマンリーダブルなテーブル
+ *   --json      — 構造化 JSON envelope
+ *   --plain     — TSV (syntax\tdescription)
+ */
+
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
+import { NOTATION_GUIDE } from "@/core/notation/guide"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable, writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+/** notationGuideCommand は Cosense 記法ガイドを出力するコマンド定義を返す。 */
+export const notationGuideCommand = defineCommand({
+  meta: { name: "notation", description: "Cosense 記法ガイドを出力する" },
+  args: { ...commonArgs },
+  async run({ args }) {
+    const a = args as CommonArgs
+    checkSandbox("notation", a)
+
+    if (a.json) {
+      const startTime = Date.now()
+      writeJson(NOTATION_GUIDE, { command: "notation", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    // テーブル / TSV 出力: 全セクションのアイテムをフラット化して表示する
+    const headers = ["syntax", "description", "note"]
+    const rows: string[][] = []
+
+    for (const section of NOTATION_GUIDE.sections) {
+      // セクションヘッダ行 (空行で区切る)
+      if (rows.length > 0) {
+        rows.push(["", "", ""])
+      }
+      rows.push([`=== ${section.title} ===`, section.description ?? "", ""])
+      for (const item of section.items) {
+        rows.push([item.syntax, item.description, item.note ?? ""])
+      }
+    }
+
+    // tips セクション
+    if (NOTATION_GUIDE.tips.length > 0) {
+      rows.push(["", "", ""])
+      rows.push(["=== 注意事項 ===", "", ""])
+      for (const tip of NOTATION_GUIDE.tips) {
+        rows.push(["", tip, ""])
+      }
+    }
+
+    if (a.plain) {
+      writeTsv(headers, rows)
+    } else {
+      writePlainTable(headers, rows)
+    }
+  },
+})

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  type StrictNotationArg,
   type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
@@ -14,9 +15,12 @@ import {
   commonArgs,
   dryRunArg,
   isStdinPath,
+  notationFindingToWarning,
   requireProject,
+  strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { lintNotation } from "@/core/notation/lint"
 import { appendToPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -27,6 +31,7 @@ export const pageAppendCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...strictNotationArg,
     ...unsafeReadArg,
     title: {
       type: "positional",
@@ -43,7 +48,7 @@ export const pageAppendCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & {
+    const a = args as WriteCommonArgs & StrictNotationArg & {
       title: string
       line?: string
       "from-file"?: string
@@ -90,13 +95,28 @@ export const pageAppendCommand = defineCommand({
       process.exit(5)
     }
 
+    // Cosense 記法の lint 検査
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
     logger.info(`"${a.title}" に行を追加中...`)
 
     const writer = await buildWriter(a)
     const result = await appendToPage(writer, { project, title: a.title, lines })
 
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.append", startTime }, buildJsonOpts(a))
+      writeJson(result, { command: "page.append", startTime, warnings }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -48,12 +48,13 @@ export const pageAppendCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & StrictNotationArg & {
-      title: string
-      line?: string
-      "from-file"?: string
-      "allow-unsafe-read": boolean
-    }
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        line?: string
+        "from-file"?: string
+        "allow-unsafe-read": boolean
+      }
     checkSandbox("page.append", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  type StrictNotationArg,
   type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
@@ -16,10 +17,13 @@ import {
   commonArgs,
   dryRunArg,
   isStdinPath,
+  notationFindingToWarning,
   requireProject,
+  strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
 import { convert } from "@/core/format/index"
+import { lintNotation } from "@/core/notation/lint"
 import { editPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -32,6 +36,7 @@ export const pageEditCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...strictNotationArg,
     ...unsafeReadArg,
     title: {
       type: "positional",
@@ -50,7 +55,7 @@ export const pageEditCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & {
+    const a = args as WriteCommonArgs & StrictNotationArg & {
       title: string
       "from-file": string
       "input-format": string
@@ -113,13 +118,28 @@ export const pageEditCommand = defineCommand({
       return
     }
 
+    // Cosense 記法の lint 検査: findings を warnings に変換する
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
     logger.info(`"${a.title}" を編集中...`)
 
     const writer = await buildWriter(a)
     const result = await editPage(writer, { project, title: a.title, lines })
 
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.edit", startTime }, buildJsonOpts(a))
+      writeJson(result, { command: "page.edit", startTime, warnings }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -55,12 +55,13 @@ export const pageEditCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & StrictNotationArg & {
-      title: string
-      "from-file": string
-      "input-format": string
-      "allow-unsafe-read": boolean
-    }
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        "from-file": string
+        "input-format": string
+        "allow-unsafe-read": boolean
+      }
     checkSandbox("page.edit", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  type StrictNotationArg,
   type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
@@ -16,9 +17,12 @@ import {
   dryRunArg,
   getRawFlagValue,
   isStdinPath,
+  notationFindingToWarning,
   requireProject,
+  strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { lintNotation } from "@/core/notation/lint"
 import { insertIntoPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -29,6 +33,7 @@ export const pageInsertCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...strictNotationArg,
     ...unsafeReadArg,
     title: {
       type: "positional",
@@ -50,7 +55,7 @@ export const pageInsertCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & {
+    const a = args as WriteCommonArgs & StrictNotationArg & {
       title: string
       after: string
       line?: string
@@ -126,6 +131,21 @@ export const pageInsertCommand = defineCommand({
       return
     }
 
+    // Cosense 記法の lint 検査
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
     logger.info(`"${a.title}" の ${afterN} 行目の後ろに挿入中...`)
 
     const writer = await buildWriter(a)
@@ -143,7 +163,7 @@ export const pageInsertCommand = defineCommand({
     }
 
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.insert", startTime }, buildJsonOpts(a))
+      writeJson(result, { command: "page.insert", startTime, warnings }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -55,13 +55,14 @@ export const pageInsertCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & StrictNotationArg & {
-      title: string
-      after: string
-      line?: string
-      "from-file"?: string
-      "allow-unsafe-read": boolean
-    }
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        after: string
+        line?: string
+        "from-file"?: string
+        "allow-unsafe-read": boolean
+      }
     checkSandbox("page.insert", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -49,13 +49,14 @@ export const pageNewCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & StrictNotationArg & {
-      title: string
-      "from-file"?: string
-      "allow-unsafe-read": boolean
-      /** citty が --line を複数回受け取ると string[] になる */
-      line?: string | string[]
-    }
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        "from-file"?: string
+        "allow-unsafe-read": boolean
+        /** citty が --line を複数回受け取ると string[] になる */
+        line?: string | string[]
+      }
     checkSandbox("page.new", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  type StrictNotationArg,
   type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
@@ -14,9 +15,12 @@ import {
   commonArgs,
   dryRunArg,
   isStdinPath,
+  notationFindingToWarning,
   requireProject,
+  strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { lintNotation } from "@/core/notation/lint"
 import { createPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -27,6 +31,7 @@ export const pageNewCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...strictNotationArg,
     ...unsafeReadArg,
     title: {
       type: "positional",
@@ -44,7 +49,7 @@ export const pageNewCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & {
+    const a = args as WriteCommonArgs & StrictNotationArg & {
       title: string
       "from-file"?: string
       "allow-unsafe-read": boolean
@@ -96,13 +101,28 @@ export const pageNewCommand = defineCommand({
       process.exit(5)
     }
 
+    // Cosense 記法の lint 検査
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
     logger.info(`"${a.title}" を作成中...`)
 
     const writer = await buildWriter(a)
     const result = await createPage(writer, { project, title: a.title, lines })
 
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.new", startTime }, buildJsonOpts(a))
+      writeJson(result, { command: "page.new", startTime, warnings }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  type StrictNotationArg,
   type WriteCommonArgs,
   buildJsonOpts,
   buildLogger,
@@ -14,9 +15,12 @@ import {
   commonArgs,
   dryRunArg,
   isStdinPath,
+  notationFindingToWarning,
   requireProject,
+  strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { lintNotation } from "@/core/notation/lint"
 import { prependToPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -27,6 +31,7 @@ export const pagePrependCommand = defineCommand({
   args: {
     ...commonArgs,
     ...dryRunArg,
+    ...strictNotationArg,
     ...unsafeReadArg,
     title: {
       type: "positional",
@@ -43,7 +48,7 @@ export const pagePrependCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & {
+    const a = args as WriteCommonArgs & StrictNotationArg & {
       title: string
       line?: string
       "from-file"?: string
@@ -103,13 +108,28 @@ export const pagePrependCommand = defineCommand({
       return
     }
 
+    // Cosense 記法の lint 検査
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
     logger.info(`"${a.title}" の先頭に行を挿入中...`)
 
     const writer = await buildWriter(a)
     const result = await prependToPage(writer, { project, title: a.title, lines })
 
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.prepend", startTime }, buildJsonOpts(a))
+      writeJson(result, { command: "page.prepend", startTime, warnings }, buildJsonOpts(a))
       return
     }
 

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -48,12 +48,13 @@ export const pagePrependCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as WriteCommonArgs & StrictNotationArg & {
-      title: string
-      line?: string
-      "from-file"?: string
-      "allow-unsafe-read": boolean
-    }
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        line?: string
+        "from-file"?: string
+        "allow-unsafe-read": boolean
+      }
     checkSandbox("page.prepend", a)
     const logger = buildLogger(a)
     const project = requireProject(a)

--- a/src/core/notation/guide.ts
+++ b/src/core/notation/guide.ts
@@ -1,0 +1,197 @@
+/**
+ * guide.ts — Cosense 記法ガイドコンテンツ定義。
+ *
+ * NOTATION_GUIDE はエージェント向けの構造化された記法リファレンス。
+ * `cos notation` コマンドで JSON / テーブル / TSV 形式で出力できる。
+ *
+ * 参考: https://gist.github.com/taiseiue/493e17ed6d95a9fc5881d0701692e77e
+ * (ユーザー個別ポリシーは含まず coscli 仕様に最適化)
+ */
+
+/** NotationItem は1つの記法の説明。 */
+export interface NotationItem {
+  /** 記法の書き方例 */
+  syntax: string
+  /** 表示結果や用途 */
+  description: string
+  /** 注意事項や補足 (省略可) */
+  note?: string
+}
+
+/** NotationSection は記法カテゴリのグループ。 */
+export interface NotationSection {
+  /** カテゴリ名 */
+  title: string
+  /** カテゴリの説明 (省略可) */
+  description?: string
+  /** 記法一覧 */
+  items: NotationItem[]
+}
+
+/** NotationGuide はガイド全体の構造。 */
+export interface NotationGuide {
+  sections: NotationSection[]
+  /** エージェントが特に誤りやすいポイントの注意事項 */
+  tips: string[]
+}
+
+/** NOTATION_GUIDE は Cosense 記法のリファレンスデータ。 */
+export const NOTATION_GUIDE: NotationGuide = {
+  sections: [
+    {
+      title: "基本原則",
+      items: [
+        {
+          syntax: "[テキスト]",
+          description: "ブラケットで囲むとページリンクになる。これだけ覚えれば十分",
+        },
+        {
+          syntax: "1行目",
+          description: "ページの1行目がタイトルになる",
+        },
+        {
+          syntax: " (スペース/Tab)",
+          description: "行頭にスペースまたはTabで箇条書き（インデントで階層化）",
+        },
+      ],
+    },
+    {
+      title: "リンク",
+      items: [
+        {
+          syntax: "[ページタイトル]",
+          description: "同プロジェクト内のページへのリンク",
+        },
+        {
+          syntax: "https://example.com",
+          description: "URLをそのまま書くとリンクになる",
+        },
+        {
+          syntax: "[https://example.com タイトル]",
+          description: "URL + タイトルのリンク ([タイトル URL] の順でもOK)",
+        },
+        {
+          syntax: "[/プロジェクト名/ページ名]",
+          description: "別プロジェクトへのクロスプロジェクトリンク",
+        },
+        {
+          syntax: "#タグ名",
+          description: "[リンク] と機能的に同じ。ページのタグ付けに使う",
+          note: "日本語での多用は避ける（関連しすぎる問題）",
+        },
+      ],
+    },
+    {
+      title: "文字装飾",
+      description: "* の数が多いほど大きく表示される（Markdownとは逆）。スペースは必須",
+      items: [
+        {
+          syntax: "[* テキスト]",
+          description: "太字・最小サイズ（Markdownの**bold**に近い）",
+          note: "* の直後に半角スペースが必要。[*テキスト] はリンク記法になる",
+        },
+        {
+          syntax: "[** テキスト]",
+          description: "太字・中サイズ",
+          note: "* の直後に半角スペースが必要",
+        },
+        {
+          syntax: "[*** テキスト]",
+          description: "太字・大サイズ（見出しの代用に適する）",
+          note: "* の直後に半角スペースが必要",
+        },
+        {
+          syntax: "[**** テキスト]",
+          description: "太字・最大サイズ（トップレベル見出しに適する）",
+          note: "* の直後に半角スペースが必要",
+        },
+        {
+          syntax: "[[テキスト]]",
+          description: "太字（最小サイズ、[* テキスト] と同等）",
+        },
+        {
+          syntax: "[/ テキスト]",
+          description: "斜体（イタリック）",
+          note: "/ の直後に半角スペースが必要",
+        },
+        {
+          syntax: "[/* テキスト]",
+          description: "太字斜体",
+        },
+        {
+          syntax: "[- テキスト]",
+          description: "打ち消し線",
+          note: "- の直後に半角スペースが必要",
+        },
+      ],
+    },
+    {
+      title: "コードブロック",
+      items: [
+        {
+          syntax: "`コード`",
+          description: "インラインコード",
+        },
+        {
+          syntax: "code:ファイル名.js\n (インデント)コード本文",
+          description: "コードブロック。code: の後にファイル名（拡張子で言語ハイライト）",
+          note: "ブロック内はスペース/Tabでインデントする",
+        },
+      ],
+    },
+    {
+      title: "テーブル・引用",
+      items: [
+        {
+          syntax: "table:テーブル名\n (インデント)見出しA\t見出しB",
+          description: "テーブル。セルはTab区切り、ブロック内はインデント",
+        },
+        {
+          syntax: "> テキスト",
+          description: "引用",
+        },
+      ],
+    },
+    {
+      title: "画像・アイコン",
+      items: [
+        {
+          syntax: "[https://example.com/image.png]",
+          description: "画像の埋め込み（URLが画像の場合は自動的に表示）",
+        },
+        {
+          syntax: "[[https://example.com/image.png]]",
+          description: "横幅いっぱいの大きな画像",
+        },
+        {
+          syntax: "[ページ名.icon]",
+          description: "アイコン記法（ページのサムネイル画像を小さく表示）",
+        },
+        {
+          syntax: "[ユーザー名.icon*3]",
+          description: "アイコンを3個並べて表示",
+        },
+      ],
+    },
+    {
+      title: "数式・コマンドライン",
+      items: [
+        {
+          syntax: "[$ \\frac{a}{b}]",
+          description: "LaTeX 数式",
+        },
+        {
+          syntax: "$ git status",
+          description: "コマンドライン表示（行頭に $ または %）",
+        },
+      ],
+    },
+  ],
+  tips: [
+    "【重要】* の数が多いほど大きく表示されます（Markdownとは逆）。トップレベルの見出しには [*** テキスト] または [**** テキスト] を使ってください",
+    "【重要】[* テキスト] の * / / / - の直後には必ず半角スペースが必要です。スペースなしの [*テキスト] はページリンク記法として解釈されます",
+    "Cosenseに独立した「見出し記法」はありません。[*** テキスト] のような太字サイズで見出しを表現します",
+    "1行目がページタイトルになります。タイトルのみの行は通常最初の1行だけにしてください",
+    "長いページを作らないのがCosenseのベストプラクティスです。独立した内容は別ページに切り出してリンクでつなぎましょう",
+  ],
+}

--- a/src/core/notation/index.ts
+++ b/src/core/notation/index.ts
@@ -1,0 +1,8 @@
+/**
+ * notation/index.ts — Cosense 記法ヘルパーのエントリポイント。
+ */
+
+export { NOTATION_GUIDE } from "./guide"
+export type { NotationGuide, NotationItem, NotationSection } from "./guide"
+export { lintNotation } from "./lint"
+export type { NotationFinding } from "./lint"

--- a/src/core/notation/lint.ts
+++ b/src/core/notation/lint.ts
@@ -1,0 +1,275 @@
+/**
+ * lint.ts — Cosense 記法の静的検査 (lintNotation)。
+ *
+ * エージェントが書き込み前・書き込み時に記法の誤用を検出するための
+ * 軽量なルールエンジン。4ルールを実装する:
+ *
+ * 1. no-space-in-emphasis       — [*xxx] 等のスペース欠落
+ * 2. reversed-heading-hierarchy — [* x] → [** y] の Markdown 的な逆転
+ * 3. markdown-bold-residue      — **bold** / __bold__ の残留
+ * 4. markdown-italic-residue    — *italic* / _italic_ の残留
+ *
+ * code:/table: ブロックとインラインコードは全ルールの対象外。
+ */
+
+/** NotationFinding は lint ルールの検出結果を表す。 */
+export interface NotationFinding {
+  /** 1-indexed 行番号 */
+  line: number
+  /** 1-indexed 列番号 (省略可) */
+  column?: number
+  /** ルール識別子 */
+  rule: string
+  /** 重大度 (初期版は warning のみ) */
+  severity: "warning"
+  /** 日本語の説明 */
+  message: string
+  /** 修正案 (省略可) */
+  hint?: string
+}
+
+/**
+ * lintNotation は Cosense ページのテキスト行を検査し、記法の誤用を返す。
+ *
+ * @param lines ページ本文を行分割した配列 (1行目がタイトルになる場合も含む)
+ */
+export function lintNotation(lines: string[]): NotationFinding[] {
+  const findings: NotationFinding[] = []
+
+  // code:/table: ブロックに属するかを追跡する
+  let inBlock = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1
+    const raw = lines[i] ?? ""
+
+    // code: / table: ブロックの開始/終了を判定する
+    // ブロック先頭行は "code:xxx" / "table:xxx" (インデントなし)、
+    // 継続行はスペース or タブで始まる行
+    if (!inBlock) {
+      if (/^(?:code|table):/.test(raw)) {
+        inBlock = true
+        continue
+      }
+    } else {
+      // 空行またはインデントのない行でブロック終了
+      if (raw === "" || !/^[ \t]/.test(raw)) {
+        inBlock = false
+        // ブロック外に戻ったので今行を通常行として処理する
+      } else {
+        continue
+      }
+    }
+
+    // インラインコード区間をマスクした検査用文字列を生成する
+    // バッククォートで囲まれた範囲を空白に置換することで誤検出を防ぐ
+    const masked = maskInlineCode(raw)
+
+    // ルール 1: no-space-in-emphasis
+    checkNoSpaceInEmphasis(masked, lineNo, findings)
+
+    // ルール 3: markdown-bold-residue
+    checkMarkdownBoldResidue(masked, lineNo, findings)
+
+    // ルール 4: markdown-italic-residue
+    checkMarkdownItalicResidue(masked, lineNo, findings)
+  }
+
+  // ルール 2: reversed-heading-hierarchy はドキュメント全体を走査する
+  checkReversedHeadingHierarchy(lines, findings)
+
+  return findings
+}
+
+// ──────────────────────────────────────────
+// 内部ヘルパー
+// ──────────────────────────────────────────
+
+/**
+ * maskInlineCode はインラインコード (バッククォート囲み) 内のテキストを
+ * 空白文字列に置換した文字列を返す。
+ *
+ * 列番号が必要な場合は元の文字列を使用し、検出判定のみ masked を使う。
+ */
+function maskInlineCode(line: string): string {
+  // `...` を同じ長さのスペースに置換する
+  return line.replace(/`[^`]*`/g, (match) => " ".repeat(match.length))
+}
+
+/**
+ * checkNoSpaceInEmphasis はブラケット強調記法のスペース欠落を検出する。
+ *
+ * 検出対象:
+ *   [*xxx] [**xxx] [***xxx] [****xxx] — 太字スペース欠落
+ *   [-xxx]                            — 打ち消しスペース欠落
+ *   [/xxx] (クロスプロジェクトリンク [/proj/page] は除外)
+ */
+function checkNoSpaceInEmphasis(masked: string, lineNo: number, findings: NotationFinding[]): void {
+  // [*+非スペース文字] — 太字 (* の数は問わない)
+  for (const m of masked.matchAll(/\[(\*{1,4})([^\s\]$/*])/g)) {
+    const stars = m[1] ?? "*"
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "no-space-in-emphasis",
+      severity: "warning",
+      message: `[${stars}テキスト] の ${stars} 直後にスペースがありません。リンク記法として解釈されます`,
+      hint: `[${stars} テキスト] のように * の直後に半角スペースを入れてください`,
+    })
+  }
+
+  // [-非スペース文字] — 打ち消し
+  for (const m of masked.matchAll(/\[-([^\s\]])/g)) {
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "no-space-in-emphasis",
+      severity: "warning",
+      message: "[- テキスト] の - 直後にスペースがありません。リンク記法として解釈されます",
+      hint: "[- テキスト] のように - の直後に半角スペースを入れてください",
+    })
+  }
+
+  // [/非スペース文字] — 斜体 (クロスプロジェクトリンク [/proj/page] は除外)
+  // クロスプロジェクトリンクは内容に "/" が含まれる
+  for (const m of masked.matchAll(/\[\/([^\s/\]][^\]]*)\]/g)) {
+    const content = m[1] ?? ""
+    // "/" が含まれる場合はクロスプロジェクトリンクとみなして除外
+    if (content.includes("/")) continue
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "no-space-in-emphasis",
+      severity: "warning",
+      message: "[/ テキスト] の / 直後にスペースがありません。リンク記法として解釈されます",
+      hint: "[/ テキスト] のように / の直後に半角スペースを入れてください",
+    })
+  }
+}
+
+/**
+ * checkReversedHeadingHierarchy はドキュメント全体を走査し、
+ * [* x] (最小サイズ) が [** y] 以上のサイズより先に出現する
+ * Markdown 的な逆転を検出する。
+ *
+ * 「行全体が [*+ text] のみ」の行をヘッダ行として扱う。
+ */
+function checkReversedHeadingHierarchy(lines: string[], findings: NotationFinding[]): void {
+  // ヘッダ行の * の数と行番号を収集する
+  const headings: Array<{ starCount: number; lineNo: number }> = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]?.trim() ?? ""
+    // code: / table: ブロック内は除外
+    if (/^(?:code|table):/.test(raw)) {
+      // ブロック終わりまでスキップ (ここでは簡易的に次のインデントなし行まで)
+      while (i + 1 < lines.length && /^[ \t]/.test(lines[i + 1] ?? "")) {
+        i++
+      }
+      continue
+    }
+    // 行全体が [*+ text] の場合のみヘッダ行と判定する
+    const m = raw.match(/^\[(\*{1,4})\s+[^\]]+\]$/)
+    if (m) {
+      headings.push({ starCount: (m[1] ?? "").length, lineNo: i + 1 })
+    }
+  }
+
+  if (headings.length < 2) return
+
+  // 最小 * 数の初回出現位置を把握する
+  const minStars = Math.min(...headings.map((h) => h.starCount))
+  const maxStars = Math.max(...headings.map((h) => h.starCount))
+
+  // minStars === maxStars の場合はすべて同じサイズなので逆転なし
+  if (minStars === maxStars) return
+
+  // minStars の最初の出現より後に maxStars の出現があれば Markdown 的な逆転
+  const firstMin = headings.find((h) => h.starCount === minStars)
+  const firstMax = headings.find((h) => h.starCount === maxStars)
+
+  if (firstMin && firstMax && firstMin.lineNo < firstMax.lineNo) {
+    findings.push({
+      line: firstMin.lineNo,
+      rule: "reversed-heading-hierarchy",
+      severity: "warning",
+      message: `[${"*".repeat(minStars)} テキスト] (最小サイズ) が [${"*".repeat(maxStars)} テキスト] (より大きいサイズ) より前に出現しています。Markdown の見出しレベルと逆転しています`,
+      hint: "Cosense では * の数が多いほど大きく表示されます。トップレベルの見出しには [*** テキスト] または [**** テキスト] を使ってください",
+    })
+  }
+}
+
+/**
+ * checkMarkdownBoldResidue は Markdown の太字記法 (**bold** / __bold__) の残留を検出する。
+ */
+function checkMarkdownBoldResidue(
+  masked: string,
+  lineNo: number,
+  findings: NotationFinding[],
+): void {
+  // **text** (*** はリスト前の空行等の誤検知を防ぐため最低1文字以上の非アスタリスク)
+  for (const m of masked.matchAll(/\*\*([^*\s][^*]*[^*\s]|\S)\*\*/g)) {
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "markdown-bold-residue",
+      severity: "warning",
+      message: "Markdown の太字記法 **テキスト** が残っています",
+      hint: "Cosense の太字記法 [* テキスト] に置き換えてください",
+    })
+  }
+
+  // __text__
+  for (const m of masked.matchAll(/__([^_\s][^_]*[^_\s]|\S)__/g)) {
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "markdown-bold-residue",
+      severity: "warning",
+      message: "Markdown の太字記法 __テキスト__ が残っています",
+      hint: "Cosense の太字記法 [* テキスト] に置き換えてください",
+    })
+  }
+}
+
+/**
+ * checkMarkdownItalicResidue は Markdown の斜体記法 (*italic* / _italic_) の残留を検出する。
+ *
+ * [* text] 内の * を誤検知しないよう、[ の直後の * は除外する。
+ * **bold** の * も除外する (3文字以上連続する * は対象外)。
+ * URL 内の _ は除外する。
+ */
+function checkMarkdownItalicResidue(
+  masked: string,
+  lineNo: number,
+  findings: NotationFinding[],
+): void {
+  // *text* — ただし:
+  //   ** は除外 (bold-residue 側で検出)
+  //   [* のパターンは除外 (Cosense 太字記法)
+  //   先頭の * が [ に続く場合は除外
+  for (const m of masked.matchAll(/(?<!\[)(?<!\*)\*(?!\*)([^*\s][^*]*[^*\s]|\S)\*(?!\*)/g)) {
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "markdown-italic-residue",
+      severity: "warning",
+      message: "Markdown の斜体記法 *テキスト* が残っています",
+      hint: "Cosense の斜体記法 [/ テキスト] に置き換えてください",
+    })
+  }
+
+  // _text_ — URL 内の _ を除外するため、前後にスペースまたは行端が来る場合のみ検出
+  // ただし完全な URL パターン (https?:// や word/word 等) は除外が難しいため
+  // 単語の境界 (\b) を利用する
+  for (const m of masked.matchAll(/(?<![/\w])_([^_\s][^_]*[^_\s]|\S)_(?![/\w])/g)) {
+    findings.push({
+      line: lineNo,
+      column: m.index + 1,
+      rule: "markdown-italic-residue",
+      severity: "warning",
+      message: "Markdown の斜体記法 _テキスト_ が残っています",
+      hint: "Cosense の斜体記法 [/ テキスト] に置き換えてください",
+    })
+  }
+}

--- a/tests/unit/commands/notation/guide.test.ts
+++ b/tests/unit/commands/notation/guide.test.ts
@@ -1,0 +1,115 @@
+/**
+ * notation/guide.test.ts — `cos notation` コマンドのテスト。
+ *
+ * JSON / plain / テーブル形式の出力と正常終了を検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { notationGuideCommand } from "@/commands/notation/guide"
+import { NOTATION_GUIDE } from "@/core/notation/guide"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+function makeArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    select: undefined,
+    "enable-commands": undefined,
+    "disable-commands": undefined,
+    verbose: undefined,
+    quiet: false,
+    profile: undefined,
+    project: undefined,
+    ...overrides,
+  }
+}
+
+async function runNotation(args: Record<string, unknown>): Promise<void> {
+  await (
+    notationGuideCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+function captureStdout(): string {
+  return (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+describe("notationGuideCommand", () => {
+  describe("--json オプション", () => {
+    it("envelope 形式でガイドデータを出力する", async () => {
+      await runNotation(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed).toHaveProperty("data")
+      expect(parsed.data).toHaveProperty("sections")
+      expect(parsed.data).toHaveProperty("tips")
+    })
+
+    it("meta フィールドに command: 'notation' が含まれる", async () => {
+      await runNotation(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.meta?.command).toBe("notation")
+    })
+
+    it("sections の長さが NOTATION_GUIDE.sections.length と一致する", async () => {
+      await runNotation(makeArgs({ json: true }))
+      const out = captureStdout()
+      const parsed = JSON.parse(out)
+      expect(parsed.data.sections).toHaveLength(NOTATION_GUIDE.sections.length)
+    })
+  })
+
+  describe("デフォルト出力（テーブル形式）", () => {
+    it("syntax / description のヘッダを含む", async () => {
+      await runNotation(makeArgs())
+      const out = captureStdout()
+      expect(out).toContain("syntax")
+      expect(out).toContain("description")
+    })
+
+    it("Cosense の記法例 ([* 強調] 等) が出力に含まれる", async () => {
+      await runNotation(makeArgs())
+      const out = captureStdout()
+      expect(out).toContain("[*")
+    })
+  })
+
+  describe("--plain オプション", () => {
+    it("TSV 形式で出力する", async () => {
+      await runNotation(makeArgs({ plain: true }))
+      const out = captureStdout()
+      expect(out).toContain("\t")
+    })
+  })
+
+  describe("正常終了", () => {
+    it("process.exit を呼ばず正常終了する", async () => {
+      await runNotation(makeArgs({ json: true }))
+      expect(exitMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -1,7 +1,8 @@
 /**
  * page/edit.test.ts — `cos page edit <title>` コマンドのテスト。
  *
- * バリデーション (--input-format の無効値、空コンテンツ) を検証する。
+ * バリデーション (--input-format の無効値、空コンテンツ) と
+ * Cosense 記法 lint 統合 (warnings / --strict-notation) を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -54,6 +55,7 @@ describe("pageEditCommand", () => {
         plain: false,
         "results-only": false,
         "dry-run": false,
+        "strict-notation": false,
         quiet: false,
       })
     } catch {
@@ -75,6 +77,7 @@ describe("pageEditCommand", () => {
         plain: false,
         "results-only": false,
         "dry-run": false,
+        "strict-notation": false,
         quiet: false,
       })
     } catch {
@@ -99,6 +102,7 @@ describe("pageEditCommand", () => {
       plain: false,
       "results-only": false,
       "dry-run": true,
+      "strict-notation": false,
       quiet: false,
     })
     // VALIDATION_ERROR が出ていないこと (MD フォーマットは有効)
@@ -106,5 +110,76 @@ describe("pageEditCommand", () => {
     expect(calls).not.toContain("VALIDATION_ERROR")
     // exit 5 が呼ばれていないこと (MD フォーマットはバリデーションを通過する)
     expect(exitMock).not.toHaveBeenCalledWith(5)
+  })
+
+  describe("Cosense 記法 lint 統合", () => {
+    it("誤用記法があると --json 出力の meta.warnings に含まれる", async () => {
+      // [*テスト] はスペースなし → no-space-in-emphasis が検出される
+      const tmpFile = join(tmpdir(), `cos-test-edit-lint-${Date.now()}.txt`)
+      writeFileSync(tmpFile, "[*テスト]\n正常な行\n")
+      await runEdit({
+        title: "記法テストページ",
+        "from-file": tmpFile,
+        "input-format": "txt",
+        project: "テストプロジェクト",
+        json: true,
+        plain: false,
+        "results-only": false,
+        "dry-run": true,
+        "strict-notation": false,
+        quiet: false,
+      })
+      const out = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      const parsed = JSON.parse(out)
+      // meta.warnings に lint 結果が含まれること
+      expect(Array.isArray(parsed.meta?.warnings)).toBe(true)
+      expect(parsed.meta.warnings.length).toBeGreaterThan(0)
+      expect(parsed.meta.warnings[0]).toContain("no-space-in-emphasis")
+    })
+
+    it("正常な記法のファイルは meta.warnings が空配列", async () => {
+      // 正しいCosense記法: 大きいサイズが先に来る (*** → ** の順)
+      const tmpFile = join(tmpdir(), `cos-test-edit-lint-ok-${Date.now()}.txt`)
+      writeFileSync(tmpFile, "[*** 大見出し]\n[** 中見出し]\n通常テキスト\n")
+      await runEdit({
+        title: "記法正常テストページ",
+        "from-file": tmpFile,
+        "input-format": "txt",
+        project: "テストプロジェクト",
+        json: true,
+        plain: false,
+        "results-only": false,
+        "dry-run": true,
+        "strict-notation": false,
+        quiet: false,
+      })
+      const out = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      const parsed = JSON.parse(out)
+      expect(parsed.meta?.warnings).toEqual([])
+    })
+
+    it("--strict-notation が有効なら lint 警告があると exit 5 で中止する", async () => {
+      const tmpFile = join(tmpdir(), `cos-test-edit-strict-${Date.now()}.txt`)
+      writeFileSync(tmpFile, "[*NG記法]\n")
+      try {
+        await runEdit({
+          title: "厳格テストページ",
+          "from-file": tmpFile,
+          "input-format": "txt",
+          project: "テストプロジェクト",
+          json: true,
+          plain: false,
+          "results-only": false,
+          "dry-run": true,
+          "strict-notation": true,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const out = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(out).toContain("NOTATION_LINT")
+    })
   })
 })

--- a/tests/unit/core/notation/guide.test.ts
+++ b/tests/unit/core/notation/guide.test.ts
@@ -1,0 +1,52 @@
+/**
+ * guide.test.ts — NOTATION_GUIDE 定数の構造テスト。
+ *
+ * セクション・アイテム・tips の形式要件を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { NOTATION_GUIDE } from "@/core/notation/guide"
+
+describe("NOTATION_GUIDE", () => {
+  it("sections 配列を持つ", () => {
+    expect(Array.isArray(NOTATION_GUIDE.sections)).toBe(true)
+    expect(NOTATION_GUIDE.sections.length).toBeGreaterThan(0)
+  })
+
+  it("tips 配列を持つ", () => {
+    expect(Array.isArray(NOTATION_GUIDE.tips)).toBe(true)
+    expect(NOTATION_GUIDE.tips.length).toBeGreaterThan(0)
+  })
+
+  it("各 section は title と items を持つ", () => {
+    for (const section of NOTATION_GUIDE.sections) {
+      expect(typeof section.title).toBe("string")
+      expect(section.title.length).toBeGreaterThan(0)
+      expect(Array.isArray(section.items)).toBe(true)
+    }
+  })
+
+  it("各 item は syntax と description を持つ", () => {
+    for (const section of NOTATION_GUIDE.sections) {
+      for (const item of section.items) {
+        expect(typeof item.syntax).toBe("string")
+        expect(typeof item.description).toBe("string")
+      }
+    }
+  })
+
+  it("tips に * の数と強調サイズの注意事項が含まれる", () => {
+    const allTips = NOTATION_GUIDE.tips.join(" ")
+    // issue #82 の主要ミスに関する注意が tips に含まれること
+    expect(allTips).toMatch(/\*/)
+  })
+
+  it("文字装飾セクションが含まれる", () => {
+    const titles = NOTATION_GUIDE.sections.map((s) => s.title)
+    // 文字装飾に関するセクションが存在すること
+    const hasBoldSection = titles.some(
+      (t) => t.includes("装飾") || t.includes("強調") || t.includes("文字"),
+    )
+    expect(hasBoldSection).toBe(true)
+  })
+})

--- a/tests/unit/core/notation/lint.test.ts
+++ b/tests/unit/core/notation/lint.test.ts
@@ -1,0 +1,249 @@
+/**
+ * lint.test.ts — lintNotation() の単体テスト。
+ *
+ * 4ルール (no-space-in-emphasis / reversed-heading-hierarchy /
+ * markdown-bold-residue / markdown-italic-residue) の検出・非検出を網羅する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { lintNotation } from "@/core/notation/lint"
+
+// ------
+// ヘルパー: 指定 rule の finding だけを返す
+// ------
+function findingsFor(lines: string[], rule: string) {
+  return lintNotation(lines).filter((f) => f.rule === rule)
+}
+
+// ==============================
+// ルール 1: no-space-in-emphasis
+// ==============================
+describe("no-space-in-emphasis", () => {
+  it("[*テキスト] — * 直後にスペースなし → 検出", () => {
+    const findings = findingsFor(["[*テキスト]"], "no-space-in-emphasis")
+    expect(findings.length).toBe(1)
+    expect(findings[0]?.line).toBe(1)
+  })
+
+  it("[**テキスト] — ** 直後にスペースなし → 検出", () => {
+    const findings = findingsFor(["[**テキスト]"], "no-space-in-emphasis")
+    expect(findings.length).toBe(1)
+  })
+
+  it("[***テキスト] — *** 直後にスペースなし → 検出", () => {
+    expect(findingsFor(["[***テキスト]"], "no-space-in-emphasis").length).toBe(1)
+  })
+
+  it("[****テキスト] — **** 直後にスペースなし → 検出", () => {
+    expect(findingsFor(["[****テキスト]"], "no-space-in-emphasis").length).toBe(1)
+  })
+
+  it("[-テキスト] — - 直後にスペースなし → 検出", () => {
+    expect(findingsFor(["[-テキスト]"], "no-space-in-emphasis").length).toBe(1)
+  })
+
+  it("[/テキスト] — / 直後にスペースなし → 検出 (クロスプロジェクトリンク除外)", () => {
+    // [/word] はリンクではなく斜体記法のスペース欠落として検出
+    expect(findingsFor(["[/テキスト]"], "no-space-in-emphasis").length).toBe(1)
+  })
+
+  it("[/project/page] — クロスプロジェクトリンク → 検出しない", () => {
+    // スラッシュが2個含まれる場合はクロスプロジェクトリンク
+    expect(findingsFor(["[/mtane0412/ページ名]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("[* テキスト] — スペースあり → 検出しない", () => {
+    expect(findingsFor(["[* テキスト]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("[** テキスト] — スペースあり → 検出しない", () => {
+    expect(findingsFor(["[** テキスト]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("[- テキスト] — スペースあり → 検出しない", () => {
+    expect(findingsFor(["[- テキスト]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("[/ テキスト] — スペースあり → 検出しない", () => {
+    expect(findingsFor(["[/ テキスト]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("通常のページリンク [ページ名] → 検出しない", () => {
+    expect(findingsFor(["[ページ名]"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("code: ブロック内の [*foo] → 検出しない", () => {
+    const lines = ["code:sample.js", " [*foo]", " const x = 1"]
+    expect(findingsFor(lines, "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("インラインコード内の [*foo] → 検出しない", () => {
+    // バッククォートで囲まれた範囲内は対象外
+    expect(findingsFor(["`[*foo]`"], "no-space-in-emphasis").length).toBe(0)
+  })
+
+  it("issue #82 の実例: [*ルール＋幾何] → 検出", () => {
+    expect(findingsFor(["[*ルール＋幾何]"], "no-space-in-emphasis").length).toBe(1)
+  })
+
+  it("複数行に誤用がある場合、各行の finding を返す", () => {
+    const lines = ["[*強調1]", "正常な行", "[**強調2]"]
+    const findings = findingsFor(lines, "no-space-in-emphasis")
+    expect(findings.length).toBe(2)
+    expect(findings[0]?.line).toBe(1)
+    expect(findings[1]?.line).toBe(3)
+  })
+})
+
+// ==============================
+// ルール 2: reversed-heading-hierarchy
+// ==============================
+describe("reversed-heading-hierarchy", () => {
+  it("[* h1] → [** h2] の順序 → Markdown 的な逆転を検出", () => {
+    // Cosense では * が最小サイズなので逆転している
+    const lines = ["[* 章タイトル]", "本文", "[** 節タイトル]"]
+    const findings = findingsFor(lines, "reversed-heading-hierarchy")
+    expect(findings.length).toBeGreaterThan(0)
+  })
+
+  it("[* h1] → [*** h3] の順序 → 逆転を検出", () => {
+    const lines = ["[* 大見出し]", "[*** 小見出し]"]
+    expect(findingsFor(lines, "reversed-heading-hierarchy").length).toBeGreaterThan(0)
+  })
+
+  it("[*** 大見出し] → [* 小見出し] の順序 → 検出しない (正しい順序)", () => {
+    // 大きいサイズが先 → 正しい Cosense 的な使い方
+    const lines = ["[*** 大見出し]", "本文", "[* 注釈]"]
+    expect(findingsFor(lines, "reversed-heading-hierarchy").length).toBe(0)
+  })
+
+  it("[** 中見出し] → [* 小見出し] → 検出しない", () => {
+    const lines = ["[** 中見出し]", "[* 小見出し]"]
+    expect(findingsFor(lines, "reversed-heading-hierarchy").length).toBe(0)
+  })
+
+  it("[* ] のみのファイル → 検出しない (比較対象なし)", () => {
+    const lines = ["[* 章1]", "本文", "[* 章2]"]
+    expect(findingsFor(lines, "reversed-heading-hierarchy").length).toBe(0)
+  })
+
+  it("issue #82 の実例: * 見出し群 → ** 見出し群 → 検出", () => {
+    const lines = [
+      "[* 研究の4段階フェーズ]",
+      "本文",
+      "[* 手法の系譜]",
+      "[** ① ルールベース・幾何学的手法]",
+      "詳細",
+    ]
+    expect(findingsFor(lines, "reversed-heading-hierarchy").length).toBeGreaterThan(0)
+  })
+})
+
+// ==============================
+// ルール 3: markdown-bold-residue
+// ==============================
+describe("markdown-bold-residue", () => {
+  it("**bold** → 検出", () => {
+    expect(findingsFor(["**太字テキスト**"], "markdown-bold-residue").length).toBe(1)
+  })
+
+  it("__bold__ → 検出", () => {
+    expect(findingsFor(["__太字テキスト__"], "markdown-bold-residue").length).toBe(1)
+  })
+
+  it("[* bold] — Cosense 記法は検出しない", () => {
+    expect(findingsFor(["[* 太字テキスト]"], "markdown-bold-residue").length).toBe(0)
+  })
+
+  it("文中の **bold** → 検出", () => {
+    const findings = findingsFor(["これは**重要な**テキストです"], "markdown-bold-residue")
+    expect(findings.length).toBe(1)
+  })
+
+  it("code: ブロック内の **bold** → 検出しない", () => {
+    const lines = ["code:readme.md", " ## **重要**", " テキスト"]
+    expect(findingsFor(lines, "markdown-bold-residue").length).toBe(0)
+  })
+
+  it("インラインコード `**bold**` → 検出しない", () => {
+    expect(findingsFor(["`**太字**` はこう書きます"], "markdown-bold-residue").length).toBe(0)
+  })
+})
+
+// ==============================
+// ルール 4: markdown-italic-residue
+// ==============================
+describe("markdown-italic-residue", () => {
+  it("*italic* → 検出", () => {
+    expect(findingsFor(["*斜体テキスト*"], "markdown-italic-residue").length).toBe(1)
+  })
+
+  it("_italic_ → 検出", () => {
+    expect(findingsFor(["_斜体テキスト_"], "markdown-italic-residue").length).toBe(1)
+  })
+
+  it("[/ italic] — Cosense 記法は検出しない", () => {
+    expect(findingsFor(["[/ 斜体テキスト]"], "markdown-italic-residue").length).toBe(0)
+  })
+
+  it("[* 太字] の * を italic として誤検出しない", () => {
+    // [* テキスト] の * は Cosense の太字記法
+    expect(findingsFor(["[* テキスト]"], "markdown-italic-residue").length).toBe(0)
+  })
+
+  it("**bold** の内側の * を italic として誤検出しない", () => {
+    // **bold** は bold-residue ルールで検出すべきで、italic ルールは対象外
+    expect(findingsFor(["**太字**"], "markdown-italic-residue").length).toBe(0)
+  })
+
+  it("code: ブロック内の *italic* → 検出しない", () => {
+    const lines = ["code:example.md", " *斜体* はこう書く"]
+    expect(findingsFor(lines, "markdown-italic-residue").length).toBe(0)
+  })
+
+  it("インラインコード `*italic*` → 検出しない", () => {
+    expect(findingsFor(["`*italic*` はこう書きます"], "markdown-italic-residue").length).toBe(0)
+  })
+
+  it("URL 内の _ → 検出しない", () => {
+    // https://example.com/foo_bar_baz は italic ではない
+    expect(findingsFor(["https://example.com/foo_bar_baz"], "markdown-italic-residue").length).toBe(
+      0,
+    )
+  })
+})
+
+// ==============================
+// 複合テスト
+// ==============================
+describe("lintNotation 複合", () => {
+  it("正常なCosense記法のみのファイルは空配列を返す", () => {
+    const lines = [
+      "[*** 大見出し]",
+      "通常のテキスト",
+      "[** 中見出し]",
+      " 箇条書き",
+      "[* 強調]",
+      "[/ 斜体]",
+      "[- 打ち消し]",
+      "[ページリンク]",
+      "https://example.com",
+    ]
+    expect(lintNotation(lines)).toEqual([])
+  })
+
+  it("finding は line・rule・severity・message をすべて持つ", () => {
+    const findings = lintNotation(["[*テスト]"])
+    expect(findings.length).toBe(1)
+    const f = findings[0]
+    expect(typeof f?.line).toBe("number")
+    expect(typeof f?.rule).toBe("string")
+    expect(f?.severity).toBe("warning")
+    expect(typeof f?.message).toBe("string")
+  })
+
+  it("finding に hint が含まれる", () => {
+    const findings = lintNotation(["[*テスト]"])
+    expect(findings[0]?.hint).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- `cos notation` コマンドを新設。Cosense 記法ガイドを JSON / table / TSV 形式で出力し、エージェントが書き込み前に参照できる
- `src/core/notation/lint.ts` に `lintNotation()` を実装。4 ルール検査 (no-space-in-emphasis, reversed-heading-hierarchy, markdown-bold-residue, markdown-italic-residue) でエージェントの記法誤用を検出
- `page {new,edit,append,prepend,insert}` の書き込み時に自動で lint を実行し、検出結果を `meta.warnings` にフィードバック
- `--strict-notation` フラグを追加。lint 検出時に `NOTATION_LINT` エラーで exit 5 し書き込みを中止する

## 背景

エージェントが Cosense ページに書き込む際に記法を誤用するケースが報告されていた (#82)。
- `[* x]` を Markdown 感覚で h1 として使う (Cosense では `*` の数が多いほど大きく表示されるため逆転)
- `[*テキスト]` のように `*` 直後のスペースを省略するとリンク記法として解釈される

## Test plan

- [ ] `bun test tests/unit/core/notation` → 52 テスト pass を確認
- [ ] `bun test tests/unit/commands/notation` → コマンド出力テスト pass を確認
- [ ] `bun test tests/unit/commands/page/edit.test.ts` → lint 統合テスト (warnings / --strict-notation) pass を確認
- [ ] `bunx biome check src tests` → lint エラーゼロ確認
- [ ] `bun run typecheck` → 型エラーゼロ確認
- [ ] `bun test` → 全件 pass 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Cosense 記法ガイドを表示する notation コマンドを追加。出力は人間向け表、TSV、JSON に対応。
  * ページ操作コマンド（new/append/insert/prepend/edit等）に --strict-notation フラグを追加。問題があれば中断してエラーを返します。
  * ページ作成・編集・挿入等で記法の警告を JSON 出力の warnings に含めるようにした。

* **テスト**
  * 記法ガイドと記法リンターのユニットテストを追加・拡充。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/83)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->