### PR TITLE
fix(security): setConfigValue の中間オブジェクトを Object.create(null) 化し prototype 汚染の深層防御を追加 (High #6 補強)

### DIFF
--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -116,7 +116,7 @@ export function setConfigValue(config: CoscliConfig, key: string, value: unknown
   let current = updated
   for (const part of parts.slice(0, -1)) {
     if (typeof current[part] !== "object" || current[part] === null) {
-      current[part] = {}
+      current[part] = Object.create(null) as Record<string, unknown>
     }
     current = current[part] as Record<string, unknown>
   }

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -200,4 +200,20 @@ describe("prototype 汚染への防御", () => {
     const config = {}
     expect(getConfigValue(config, "constructor")).toBeUndefined()
   })
+
+  it("setConfigValue の内部で生成するネストオブジェクトのプロトタイプが null になる", () => {
+    // setConfigValue は CoscliConfigSchema.parse() で変換するため戻り値からは確認できない。
+    // 同等の内部構築ロジックを用いて Object.create(null) が使われることを確認する。
+    const updated: Record<string, unknown> = {}
+    const parts = ["output", "color"]
+    let current = updated
+    for (const part of parts.slice(0, -1)) {
+      if (typeof current[part] !== "object" || current[part] === null) {
+        // src/infra/config.ts の setConfigValue と同一ロジック
+        current[part] = Object.create(null) as Record<string, unknown>
+      }
+      current = current[part] as Record<string, unknown>
+    }
+    expect(Object.getPrototypeOf(updated["output"] as object)).toBeNull()
+  })
 })

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -200,20 +200,4 @@ describe("prototype 汚染への防御", () => {
     const config = {}
     expect(getConfigValue(config, "constructor")).toBeUndefined()
   })
-
-  it("setConfigValue の内部で生成するネストオブジェクトのプロトタイプが null になる", () => {
-    // setConfigValue は CoscliConfigSchema.parse() で変換するため戻り値からは確認できない。
-    // 同等の内部構築ロジックを用いて Object.create(null) が使われることを確認する。
-    const updated: Record<string, unknown> = {}
-    const parts = ["output", "color"]
-    let current = updated
-    for (const part of parts.slice(0, -1)) {
-      if (typeof current[part] !== "object" || current[part] === null) {
-        // src/infra/config.ts の setConfigValue と同一ロジック
-        current[part] = Object.create(null) as Record<string, unknown>
-      }
-      current = current[part] as Record<string, unknown>
-    }
-    expect(Object.getPrototypeOf(updated["output"] as object)).toBeNull()
-  })
 })


### PR DESCRIPTION
## Summary

- `src/infra/config.ts:119` の中間オブジェクト生成を `{}` から `Object.create(null)` に変更
- FORBIDDEN_KEYS による入口 reject (PR #79) に加え、`setConfigValue` 内部で新規作成するネストオブジェクトのプロトタイプチェーンを切断することで深層防御を強化
- FORBIDDEN_KEYS チェックが何らかの理由で機能しない場合でも `Object.prototype` が汚染されにくくなる

## Test plan

- [x] 既存の prototype 汚染テスト群（`__proto__`, `prototype`, `constructor` への throw、Object.prototype 汚染なし）が全件パス
- [x] `bun test` 全 929 件パス
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ

## 技術的背景

`setConfigValue` は最終的に `CoscliConfigSchema.parse()` (zod) でオブジェクトを変換するため、
戻り値から中間オブジェクトのプロトタイプを直接テストすることは困難。
本変更は `zod.parse` 前の内部処理段階での防御強化であり、コードレビューで確認する実装詳細として扱う。

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

この変更には、エンドユーザーが認識できる新機能や改善は含まれていません。内部的な実装の改善のみが行われました。

* **チア（内部改善）**
  * 設定値処理の内部実装を最適化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/97)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->