### PR TITLE
fix(security): Bearer トークン比較を timingSafeEqual で constant-time 化 (Medium #9)

### DIFF
--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -6,6 +6,7 @@
  * ハンドラは純粋関数として単体テスト可能。
  */
 
+import { timingSafeEqual } from "node:crypto"
 import { createPage, deletePage, editPage, getPage, getPageText, listPages } from "@/core/pages"
 import { PolicyError } from "@/core/sandbox"
 import { toHttpResponse } from "@/core/server/errors"
@@ -59,7 +60,11 @@ function buildRouteNotFoundResponse(method: string, pathname: string): Response 
 function checkToken(ctx: ServerContext, req: Request): Response | null {
   if (!ctx.token) return null
   const auth = req.headers.get("Authorization")
-  if (!auth || auth !== `Bearer ${ctx.token}`) {
+  const expected = Buffer.from(`Bearer ${ctx.token}`, "utf8")
+  const actual = Buffer.from(auth ?? "", "utf8")
+  // timingSafeEqual は長さ不一致で例外をスローするため、長さを先に比較する
+  const valid = expected.length === actual.length && timingSafeEqual(expected, actual)
+  if (!valid) {
     return new Response(
       JSON.stringify({
         ok: false,

--- a/tests/unit/core/server/rest.test.ts
+++ b/tests/unit/core/server/rest.test.ts
@@ -351,5 +351,21 @@ describe("createFetchHandler", () => {
       )
       expect(res.status).toBe(200)
     })
+
+    it("長さが異なる不正トークンは例外を投げず 401 PROXY_AUTH_REQUIRED を返す", async () => {
+      // timingSafeEqual は長さ不一致で例外をスローするため、長さチェックが必須。
+      // 現実的な攻撃では長さの異なるトークンが使われる可能性があるため、
+      // 例外が 500 に漏れ出ていないことを検証する。
+      const handler = createFetchHandler(tokenCtx)
+      const shortToken = "x"
+      const res = await handler(
+        new Request("http://localhost/api/pages", {
+          headers: { Authorization: `Bearer ${shortToken}` },
+        }),
+      )
+      expect(res.status).toBe(401)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe("PROXY_AUTH_REQUIRED")
+    })
   })
 })


### PR DESCRIPTION
## Summary

- `src/core/server/rest.ts` の `checkToken` 関数で `!==` による文字列比較をタイミング攻撃対策のため `node:crypto` の `timingSafeEqual` に置き換えた
- `timingSafeEqual` は長さ不一致で例外をスローするため、バイト長チェックを事前に実施する設計にした
- 長さが異なる不正トークンで例外が漏れ出ないことを検証するテストを追加した

## Test plan

- [x] `bun test tests/unit/core/server/rest.test.ts` — 25件全パス
- [x] `bunx biome check src tests` — 指摘なし
- [x] `bun run typecheck` — 型エラーなし
- [x] `bun test` (全体) — 914件パス
- [x] CodeRabbit — No findings

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロキシ認証トークン検証のセキュリティを強化しました。トークン比較時にタイミング攻撃への耐性を向上させるため、より安全な検証方式を導入しました。

* **テスト**
  * トークン長が異なる場合の認証処理に関するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->