### PR TITLE
fix(security): --host 非ループバック時に --token 未指定の場合は起動を拒否する (Medium #10)

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -142,11 +142,17 @@ export function makeServeCommand(deps: ServeDeps = {}) {
       // 5. 認証
       const sid = await getSidFn(a.profile)
 
-      // 6. --host 外部公開警告
-      if (a.host !== DEFAULT_HOST) {
-        logger.warn(
-          `--host=${a.host} が指定されています。外部ネットワークからアクセス可能になる場合があります。`,
+      // 6. --host 非ループバック時の --token 必須チェック
+      const LOOPBACK_HOSTS = ["127.0.0.1", "::1", "localhost"]
+      const isLoopback = LOOPBACK_HOSTS.includes(a.host ?? DEFAULT_HOST)
+      if (!isLoopback && !a.token) {
+        writeErrorJson(
+          "TOKEN_REQUIRED",
+          "--host に非ループバックアドレスを指定する場合は --token が必須です",
+          "--token <値> を追加して再実行してください",
         )
+        process.exit(1)
+        return
       }
 
       // 7. sandbox ポリシー生成（ハンドラ内の二段ガード用）

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -144,14 +144,15 @@ export function makeServeCommand(deps: ServeDeps = {}) {
 
       // 6. --host 非ループバック時の --token 必須チェック
       const LOOPBACK_HOSTS = ["127.0.0.1", "::1", "localhost"]
-      const isLoopback = LOOPBACK_HOSTS.includes(a.host ?? DEFAULT_HOST)
+      const hostLower = (a.host ?? DEFAULT_HOST).toLowerCase()
+      const isLoopback = LOOPBACK_HOSTS.includes(hostLower)
       if (!isLoopback && !a.token) {
         writeErrorJson(
           "TOKEN_REQUIRED",
           "--host に非ループバックアドレスを指定する場合は --token が必須です",
           "--token <値> を追加して再実行してください",
         )
-        process.exit(1)
+        process.exit(5)
         return
       }
 

--- a/tests/unit/commands/serve.test.ts
+++ b/tests/unit/commands/serve.test.ts
@@ -91,6 +91,106 @@ const mockCreateWriter: ServeDeps["createWriter"] = async () => stubWriter
 
 describe("makeServeCommand", () => {
   describe("バリデーション", () => {
+    it("--host 0.0.0.0 かつ --token 未指定の場合は exit 1 で起動を拒否する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, host: "0.0.0.0", token: undefined },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(1)
+    })
+
+    it("--host 192.168.1.1 かつ --token 未指定の場合は exit 1 で起動を拒否する", async () => {
+      try {
+        await runServe(
+          { ...defaultArgs, host: "192.168.1.1", token: undefined },
+          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(1)
+    })
+
+    it("--host 0.0.0.0 かつ --token 指定の場合は起動する", async () => {
+      let called = false
+      try {
+        await runServe(
+          { ...defaultArgs, host: "0.0.0.0", token: "ひみつトークン" },
+          {
+            getSid: mockGetSid,
+            createWriter: mockCreateWriter,
+            startServer: async () => {
+              called = true
+            },
+          },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(called).toBe(true)
+    })
+
+    it("--host 127.0.0.1 (デフォルト) は --token なしでも起動できる", async () => {
+      let called = false
+      try {
+        await runServe(
+          { ...defaultArgs, host: "127.0.0.1", token: undefined },
+          {
+            getSid: mockGetSid,
+            createWriter: mockCreateWriter,
+            startServer: async () => {
+              called = true
+            },
+          },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(called).toBe(true)
+    })
+
+    it("--host ::1 は --token なしでも起動できる", async () => {
+      let called = false
+      try {
+        await runServe(
+          { ...defaultArgs, host: "::1", token: undefined },
+          {
+            getSid: mockGetSid,
+            createWriter: mockCreateWriter,
+            startServer: async () => {
+              called = true
+            },
+          },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(called).toBe(true)
+    })
+
+    it("--host localhost は --token なしでも起動できる", async () => {
+      let called = false
+      try {
+        await runServe(
+          { ...defaultArgs, host: "localhost", token: undefined },
+          {
+            getSid: mockGetSid,
+            createWriter: mockCreateWriter,
+            startServer: async () => {
+              called = true
+            },
+          },
+        )
+      } catch {
+        // 想定内
+      }
+      expect(called).toBe(true)
+    })
+
     it("--rest 未指定の場合は exit 5 で終了する", async () => {
       try {
         await runServe(

--- a/tests/unit/commands/serve.test.ts
+++ b/tests/unit/commands/serve.test.ts
@@ -91,104 +91,71 @@ const mockCreateWriter: ServeDeps["createWriter"] = async () => stubWriter
 
 describe("makeServeCommand", () => {
   describe("バリデーション", () => {
-    it("--host 0.0.0.0 かつ --token 未指定の場合は exit 1 で起動を拒否する", async () => {
-      try {
-        await runServe(
-          { ...defaultArgs, host: "0.0.0.0", token: undefined },
-          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(1)
-    })
-
-    it("--host 192.168.1.1 かつ --token 未指定の場合は exit 1 で起動を拒否する", async () => {
-      try {
-        await runServe(
-          { ...defaultArgs, host: "192.168.1.1", token: undefined },
-          { getSid: mockGetSid, createWriter: mockCreateWriter, startServer: immediateStartServer },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(1)
-    })
-
-    it("--host 0.0.0.0 かつ --token 指定の場合は起動する", async () => {
-      let called = false
-      try {
-        await runServe(
-          { ...defaultArgs, host: "0.0.0.0", token: "ひみつトークン" },
-          {
-            getSid: mockGetSid,
-            createWriter: mockCreateWriter,
-            startServer: async () => {
-              called = true
+    describe("--host 非ループバック時の --token 必須チェック", () => {
+      // 非ループバックアドレスかつ --token 未指定の場合は exit 5 で起動を拒否する
+      it.each([
+        { host: "0.0.0.0", label: "全インターフェース" },
+        { host: "192.168.1.1", label: "プライベートIP" },
+      ])("$label ($host) かつ --token 未指定の場合は exit 5 で起動を拒否する", async ({ host }) => {
+        try {
+          await runServe(
+            { ...defaultArgs, host, token: undefined },
+            {
+              getSid: mockGetSid,
+              createWriter: mockCreateWriter,
+              startServer: immediateStartServer,
             },
-          },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(called).toBe(true)
-    })
+          )
+        } catch {
+          // 想定内
+        }
+        expect(exitMock).toHaveBeenCalledWith(5)
+      })
 
-    it("--host 127.0.0.1 (デフォルト) は --token なしでも起動できる", async () => {
-      let called = false
-      try {
-        await runServe(
-          { ...defaultArgs, host: "127.0.0.1", token: undefined },
-          {
-            getSid: mockGetSid,
-            createWriter: mockCreateWriter,
-            startServer: async () => {
-              called = true
+      // 非ループバックアドレスでも --token 指定があれば起動できる
+      it("--host 0.0.0.0 かつ --token 指定の場合は起動する", async () => {
+        let called = false
+        try {
+          await runServe(
+            { ...defaultArgs, host: "0.0.0.0", token: "ひみつトークン" },
+            {
+              getSid: mockGetSid,
+              createWriter: mockCreateWriter,
+              startServer: async () => {
+                called = true
+              },
             },
-          },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(called).toBe(true)
-    })
+          )
+        } catch {
+          // 想定内
+        }
+        expect(called).toBe(true)
+      })
 
-    it("--host ::1 は --token なしでも起動できる", async () => {
-      let called = false
-      try {
-        await runServe(
-          { ...defaultArgs, host: "::1", token: undefined },
-          {
-            getSid: mockGetSid,
-            createWriter: mockCreateWriter,
-            startServer: async () => {
-              called = true
+      // ループバックアドレスは --token なしでも起動できる
+      it.each([
+        { host: "127.0.0.1", label: "IPv4 ループバック (デフォルト)" },
+        { host: "::1", label: "IPv6 ループバック" },
+        { host: "localhost", label: "localhost" },
+        { host: "LOCALHOST", label: "大文字 LOCALHOST" },
+      ])("$label ($host) は --token なしでも起動できる", async ({ host }) => {
+        let called = false
+        try {
+          await runServe(
+            { ...defaultArgs, host, token: undefined },
+            {
+              getSid: mockGetSid,
+              createWriter: mockCreateWriter,
+              startServer: async () => {
+                called = true
+              },
             },
-          },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(called).toBe(true)
-    })
-
-    it("--host localhost は --token なしでも起動できる", async () => {
-      let called = false
-      try {
-        await runServe(
-          { ...defaultArgs, host: "localhost", token: undefined },
-          {
-            getSid: mockGetSid,
-            createWriter: mockCreateWriter,
-            startServer: async () => {
-              called = true
-            },
-          },
-        )
-      } catch {
-        // 想定内
-      }
-      expect(called).toBe(true)
+          )
+        } catch {
+          // 想定内
+        }
+        expect(called).toBe(true)
+      })
     })
 
     it("--rest 未指定の場合は exit 5 で終了する", async () => {


### PR DESCRIPTION
## Summary

- `src/commands/serve.ts` の `--host` 非ループバック時に警告のみだった処理を、`--token` 未指定の場合は `exit(5)` で起動拒否するよう変更
- ループバックアドレス (`127.0.0.1` / `::1` / `localhost`) は `--token` なしでも起動可能
- ホスト名比較を `toLowerCase()` で正規化し、`LOCALHOST` などの大文字表記にも対応
- バリデーションエラーとして他のバリデーション (`--rest` 未指定、`--port` 不正) と `exit(5)` を統一

## Test plan

- [ ] `bun test` 全件パス (921 pass, 0 fail)
- [ ] `bun run typecheck` エラーなし
- [ ] `bunx biome check src tests` 警告ゼロ
- [ ] `--host 0.0.0.0` + `--token` なし → exit 5 で拒否
- [ ] `--host 0.0.0.0` + `--token ひみつトークン` → 起動成功
- [ ] `--host 127.0.0.1` + `--token` なし → 起動成功
- [ ] `--host ::1` + `--token` なし → 起動成功
- [ ] `--host localhost` / `LOCALHOST` + `--token` なし → 起動成功

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `serve` コマンドで非ローカルホストを使用する際、`--token` の指定が必須になりました。トークンが指定されていない場合、コマンドはエラーで停止します。

* **テスト**
  * ホストとトークンの検証に関するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/99)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->