### PR TITLE
fix(security): NotFoundError メッセージから URL クエリ文字列を除外 (Medium #11)

### DIFF
--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -260,6 +260,9 @@ export class CosenseRestClient {
     if (response.status === 403) throw new ForbiddenError()
     if (response.status === 404) throw new NotFoundError(new URL(url).pathname)
     if (response.status === 429) throw new RateLimitError()
-    throw new CosenseApiError(response.status, `API エラー: ${response.status} ${url}`)
+    throw new CosenseApiError(
+      response.status,
+      `API エラー: ${response.status} ${new URL(url).pathname}`,
+    )
   }
 }

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -258,7 +258,7 @@ export class CosenseRestClient {
   private async handleError(response: Response, url: string): Promise<never> {
     if (response.status === 401) throw new AuthError()
     if (response.status === 403) throw new ForbiddenError()
-    if (response.status === 404) throw new NotFoundError(url)
+    if (response.status === 404) throw new NotFoundError(new URL(url).pathname)
     if (response.status === 429) throw new RateLimitError()
     throw new CosenseApiError(response.status, `API エラー: ${response.status} ${url}`)
   }

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
-import { CosenseRestClient } from "@/core/api/rest"
+import { CosenseRestClient, NotFoundError } from "@/core/api/rest"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
@@ -220,6 +220,19 @@ describe("CosenseRestClient", () => {
       await expect(client.getSmartContext(TEST_PROJECT, "存在しないページ", 1)).rejects.toThrow()
     })
 
+    it("NotFoundError のメッセージにクエリ文字列 (?title=...) が含まれない", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      // 存在しないページを指定して 404 を発生させる
+      const error = await client
+        .getSmartContext(TEST_PROJECT, "存在しないページ", 1)
+        .catch((e) => e)
+      expect(error).toBeInstanceOf(NotFoundError)
+      // pathname は含まれること
+      expect(error.message).toContain("/api/smart-context/")
+      // クエリ文字列は含まれないこと
+      expect(error.message).not.toContain("?")
+    })
+
     it("未認証の場合は AuthError をスローする", async () => {
       const client = new CosenseRestClient({ sid: "" })
       await expect(client.getSmartContext(TEST_PROJECT, "テストページ", 1)).rejects.toThrow()
@@ -227,6 +240,19 @@ describe("CosenseRestClient", () => {
   })
 
   describe("searchPages", () => {
+    it("存在しないプロジェクトの NotFoundError メッセージにクエリ文字列 (?q=...) が含まれない", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      // 存在しないプロジェクトを指定して 404 を発生させる
+      const error = await client
+        .searchPages("存在しないプロジェクト", "検索キーワード")
+        .catch((e) => e)
+      expect(error).toBeInstanceOf(NotFoundError)
+      // pathname は含まれること
+      expect(error.message).toContain("/api/pages/")
+      // クエリ文字列は含まれないこと
+      expect(error.message).not.toContain("?")
+    })
+
     it("クエリにマッチするページを返す", async () => {
       const client = new CosenseRestClient({ sid: TEST_SID })
       const result = await client.searchPages(TEST_PROJECT, "Hello")

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -240,19 +240,6 @@ describe("CosenseRestClient", () => {
   })
 
   describe("searchPages", () => {
-    it("存在しないプロジェクトの NotFoundError メッセージにクエリ文字列 (?q=...) が含まれない", async () => {
-      const client = new CosenseRestClient({ sid: TEST_SID })
-      // 存在しないプロジェクトを指定して 404 を発生させる
-      const error = await client
-        .searchPages("存在しないプロジェクト", "検索キーワード")
-        .catch((e) => e)
-      expect(error).toBeInstanceOf(NotFoundError)
-      // pathname は含まれること
-      expect(error.message).toContain("/api/pages/")
-      // クエリ文字列は含まれないこと
-      expect(error.message).not.toContain("?")
-    })
-
     it("クエリにマッチするページを返す", async () => {
       const client = new CosenseRestClient({ sid: TEST_SID })
       const result = await client.searchPages(TEST_PROJECT, "Hello")
@@ -264,6 +251,19 @@ describe("CosenseRestClient", () => {
       const client = new CosenseRestClient({ sid: TEST_SID })
       const result = await client.searchPages(TEST_PROJECT, "存在しないキーワード")
       expect(result.pages).toHaveLength(0)
+    })
+
+    it("存在しないプロジェクトの NotFoundError メッセージにクエリ文字列 (?q=...) が含まれない", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      // 存在しないプロジェクトを指定して 404 を発生させる
+      const error = await client
+        .searchPages("存在しないプロジェクト", "検索キーワード")
+        .catch((e) => e)
+      expect(error).toBeInstanceOf(NotFoundError)
+      // pathname は含まれること
+      expect(error.message).toContain("/api/pages/")
+      // クエリ文字列は含まれないこと
+      expect(error.message).not.toContain("?")
     })
   })
 

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
-import { CosenseRestClient, NotFoundError } from "@/core/api/rest"
+import { CosenseApiError, CosenseRestClient, NotFoundError } from "@/core/api/rest"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
@@ -260,6 +260,23 @@ describe("CosenseRestClient", () => {
         .searchPages("存在しないプロジェクト", "検索キーワード")
         .catch((e) => e)
       expect(error).toBeInstanceOf(NotFoundError)
+      // pathname は含まれること
+      expect(error.message).toContain("/api/pages/")
+      // クエリ文字列は含まれないこと
+      expect(error.message).not.toContain("?")
+    })
+
+    it("5xx エラーの CosenseApiError メッセージにクエリ文字列 (?q=...) が含まれない", async () => {
+      // 500 を返すハンドラーで一時上書き (afterEach で自動リセットされる)
+      server.use(
+        http.get(`${BASE_URL}/api/pages/:project/search/query`, () => {
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      // クエリパラメータ (?q=...) を含む URL で 500 を発生させる
+      const error = await client.searchPages(TEST_PROJECT, "検索キーワード").catch((e) => e)
+      expect(error).toBeInstanceOf(CosenseApiError)
       // pathname は含まれること
       expect(error.message).toContain("/api/pages/")
       // クエリ文字列は含まれないこと


### PR DESCRIPTION
## Summary

- `src/core/api/rest.ts` の `handleError` メソッドで 404 発生時に完全 URL を `NotFoundError` に渡していたため、`?q=` や `?title=` 等のクエリパラメータがエラーメッセージ・ログに漏洩していた
- `new URL(url).pathname` を使い pathname のみをメッセージに含めるよう修正
- `getSmartContext` (`?title=`) と `searchPages` (`?q=`) の両 API で漏洩が防止されることをテストで検証

## Test plan

- [x] `getSmartContext` 404 時のエラーメッセージに `?title=` が含まれないこと
- [x] `getSmartContext` 404 時のエラーメッセージに pathname (`/api/smart-context/`) が含まれること
- [x] `searchPages` 404 時のエラーメッセージに `?q=` が含まれないこと
- [x] `searchPages` 404 時のエラーメッセージに pathname (`/api/pages/`) が含まれること
- [x] `bun test` 全件パス (923 pass / 0 fail)
- [x] `bunx biome check` エラーなし
- [x] `bun run typecheck` エラーなし
- [x] `bun run build` 正常完了

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 404時のエラーメッセージを改善し、表示されるURLからクエリ文字列を除いた簡潔なパス表記に変更しました。汎用APIエラーのメッセージも同様にパス表記を使用します。
* **テスト**
  * 「見つからない」ケースや5xx応答に対するテストを強化し、エラーメッセージの内容を検証するようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/100)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->