### PR TITLE
fix(security): keychain load/delete に validateProfile を追加 (Medium #12)

### DIFF
--- a/src/infra/keychain/file.ts
+++ b/src/infra/keychain/file.ts
@@ -23,6 +23,7 @@ import {
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { TokenStore } from "@/core/auth/store"
+import { validateProfile } from "./profile"
 
 /** FileTokenStore はファイルに平文で connect.sid を保存する (フォールバック用)。 */
 export class FileTokenStore implements TokenStore {
@@ -36,6 +37,7 @@ export class FileTokenStore implements TokenStore {
   }
 
   async load(profile: string): Promise<string | null> {
+    validateProfile(profile)
     try {
       const data = this.read()
       return data[profile] ?? null
@@ -45,6 +47,7 @@ export class FileTokenStore implements TokenStore {
   }
 
   async delete(profile: string): Promise<void> {
+    validateProfile(profile)
     const data = this.read()
     delete data[profile]
     this.write(data)

--- a/src/infra/keychain/linux.ts
+++ b/src/infra/keychain/linux.ts
@@ -56,6 +56,7 @@ export class LinuxKeychainStore implements TokenStore {
   }
 
   async load(profile: string): Promise<string | null> {
+    validateProfile(profile)
     let proc: SubprocessLike
     try {
       proc = this.spawn(["secret-tool", "lookup", "service", SERVICE, "account", profile], {
@@ -72,6 +73,7 @@ export class LinuxKeychainStore implements TokenStore {
   }
 
   async delete(profile: string): Promise<void> {
+    validateProfile(profile)
     let proc: SubprocessLike
     try {
       proc = this.spawn(["secret-tool", "clear", "service", SERVICE, "account", profile], {

--- a/src/infra/keychain/macos.ts
+++ b/src/infra/keychain/macos.ts
@@ -37,6 +37,7 @@ export class MacOSKeychainStore implements TokenStore {
   }
 
   async load(profile: string): Promise<string | null> {
+    validateProfile(profile)
     const result = await this.run([
       "security",
       "find-generic-password",
@@ -51,6 +52,7 @@ export class MacOSKeychainStore implements TokenStore {
   }
 
   async delete(profile: string): Promise<void> {
+    validateProfile(profile)
     await this.run(["security", "delete-generic-password", "-s", SERVICE, "-a", profile])
     // 存在しない場合も成功扱いにする
   }

--- a/src/infra/keychain/profile.ts
+++ b/src/infra/keychain/profile.ts
@@ -5,6 +5,9 @@
  * コマンドインジェクション・引数解釈の混乱・パース破壊を防ぐために使用する。
  */
 
+/** MAX_PROFILE_LENGTH は全プラットフォームで安全に扱える最大プロファイル名長。 */
+export const MAX_PROFILE_LENGTH = 255
+
 /** FORBIDDEN_CHARS は明示的に禁止する印字可能文字の一覧。 */
 const FORBIDDEN_CHARS = "'\":/"
 
@@ -34,6 +37,12 @@ function hasInvalidChar(profile: string): boolean {
 export function validateProfile(profile: string): void {
   if (profile.length === 0) {
     throw new Error("プロファイル名を空にすることはできません。")
+  }
+
+  if (profile.length > MAX_PROFILE_LENGTH) {
+    throw new Error(
+      `プロファイル名が長すぎます: ${profile.length} 文字 (最大 ${MAX_PROFILE_LENGTH} 文字)`,
+    )
   }
 
   if (profile.startsWith("-")) {

--- a/src/infra/keychain/windows.ts
+++ b/src/infra/keychain/windows.ts
@@ -83,6 +83,7 @@ export class WindowsKeychainStore implements TokenStore {
   }
 
   async load(profile: string): Promise<string | null> {
+    validateProfile(profile)
     // cmdkey は直接パスワードを読み出せないため PowerShell + CredentialManager モジュールを試みる。
     // profile 値は文字列補間を避けるため環境変数 COS_TARGET 経由で渡す。
     const script = `
@@ -118,6 +119,7 @@ export class WindowsKeychainStore implements TokenStore {
   }
 
   async delete(profile: string): Promise<void> {
+    validateProfile(profile)
     let proc: SubprocessLike
     try {
       proc = this.spawn(["cmdkey", `/delete:${SERVICE}:${profile}`], {

--- a/tests/unit/infra/keychain-file.test.ts
+++ b/tests/unit/infra/keychain-file.test.ts
@@ -46,6 +46,16 @@ describe("FileTokenStore", () => {
       const store = new FileTokenStore(tmpFile)
       await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
     })
+
+    it("load で不正なプロファイル名 (長すぎる) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.load("a".repeat(256))).rejects.toThrow("長すぎ")
+    })
+
+    it("delete で不正なプロファイル名 (長すぎる) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.delete("a".repeat(256))).rejects.toThrow("長すぎ")
+    })
   })
 
   it("セッション ID を保存して取得できる", async () => {

--- a/tests/unit/infra/keychain-file.test.ts
+++ b/tests/unit/infra/keychain-file.test.ts
@@ -26,6 +26,28 @@ describe("FileTokenStore", () => {
     if (existsSync(tmpFile)) unlinkSync(tmpFile)
   })
 
+  describe("バリデーション", () => {
+    it("load で不正なプロファイル名 (空文字列) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.load("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("load で不正なプロファイル名 (禁止文字含む) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
+    it("delete で不正なプロファイル名 (空文字列) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.delete("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("delete で不正なプロファイル名 (禁止文字含む) はバリデーションエラーを throw する", async () => {
+      const store = new FileTokenStore(tmpFile)
+      await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+  })
+
   it("セッション ID を保存して取得できる", async () => {
     const store = new FileTokenStore(tmpFile)
     await store.save("default", "test-sid-12345")

--- a/tests/unit/infra/keychain-linux.test.ts
+++ b/tests/unit/infra/keychain-linux.test.ts
@@ -51,6 +51,18 @@ describe("LinuxKeychainStore", () => {
   })
 
   describe("load", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.load("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("secret-tool lookup を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123\n", "", 0)
       const store = new LinuxKeychainStore(spawner)
@@ -81,6 +93,18 @@ describe("LinuxKeychainStore", () => {
   })
 
   describe("delete", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.delete("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("secret-tool clear を呼び出す", async () => {
       const { spawner, getCall } = captureSpawner("", "", 0)
       const store = new LinuxKeychainStore(spawner)

--- a/tests/unit/infra/keychain-linux.test.ts
+++ b/tests/unit/infra/keychain-linux.test.ts
@@ -63,6 +63,12 @@ describe("LinuxKeychainStore", () => {
       await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
     })
 
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.load("a".repeat(256))).rejects.toThrow("長すぎ")
+    })
+
     it("secret-tool lookup を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123\n", "", 0)
       const store = new LinuxKeychainStore(spawner)
@@ -103,6 +109,12 @@ describe("LinuxKeychainStore", () => {
       const { spawner } = captureSpawner("", "", 0)
       const store = new LinuxKeychainStore(spawner)
       await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new LinuxKeychainStore(spawner)
+      await expect(store.delete("a".repeat(256))).rejects.toThrow("長すぎ")
     })
 
     it("secret-tool clear を呼び出す", async () => {

--- a/tests/unit/infra/keychain-macos.test.ts
+++ b/tests/unit/infra/keychain-macos.test.ts
@@ -74,6 +74,12 @@ describe("MacOSKeychainStore", () => {
       await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
     })
 
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.load("a".repeat(256))).rejects.toThrow("長すぎ")
+    })
+
     it("security find-generic-password -w を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123\n", "", 0)
       const store = new MacOSKeychainStore(spawner)
@@ -115,6 +121,12 @@ describe("MacOSKeychainStore", () => {
       const { spawner } = captureSpawner("", "", 0)
       const store = new MacOSKeychainStore(spawner)
       await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.delete("a".repeat(256))).rejects.toThrow("長すぎ")
     })
 
     it("security delete-generic-password を呼び出す", async () => {

--- a/tests/unit/infra/keychain-macos.test.ts
+++ b/tests/unit/infra/keychain-macos.test.ts
@@ -62,6 +62,18 @@ describe("MacOSKeychainStore", () => {
   })
 
   describe("load", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.load("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("security find-generic-password -w を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123\n", "", 0)
       const store = new MacOSKeychainStore(spawner)
@@ -93,6 +105,18 @@ describe("MacOSKeychainStore", () => {
   })
 
   describe("delete", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.delete("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new MacOSKeychainStore(spawner)
+      await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("security delete-generic-password を呼び出す", async () => {
       const { spawner, getCall } = captureSpawner("", "", 0)
       const store = new MacOSKeychainStore(spawner)

--- a/tests/unit/infra/keychain-profile.test.ts
+++ b/tests/unit/infra/keychain-profile.test.ts
@@ -72,5 +72,13 @@ describe("validateProfile", () => {
     it("末尾に空白を含む名前を拒否する", () => {
       expect(() => validateProfile("profile ")).toThrow("プロファイル名")
     })
+
+    it("255 文字を超える名前を拒否する (長すぎるプロファイル名)", () => {
+      expect(() => validateProfile("a".repeat(256))).toThrow("長すぎ")
+    })
+
+    it("255 文字ちょうどの名前は受け入れる", () => {
+      expect(() => validateProfile("a".repeat(255))).not.toThrow()
+    })
   })
 })

--- a/tests/unit/infra/keychain-windows.test.ts
+++ b/tests/unit/infra/keychain-windows.test.ts
@@ -83,6 +83,12 @@ describe("WindowsKeychainStore", () => {
       await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
     })
 
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.load("a".repeat(256))).rejects.toThrow("長すぎ")
+    })
+
     it("powershell を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123", "", 0)
       const store = new WindowsKeychainStore(spawner)
@@ -150,6 +156,12 @@ describe("WindowsKeychainStore", () => {
       const { spawner } = captureSpawner("", "", 0)
       const store = new WindowsKeychainStore(spawner)
       await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
+    it("不正なプロファイル名 (長すぎる) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.delete("a".repeat(256))).rejects.toThrow("長すぎ")
     })
 
     it("cmdkey /delete:coscli:<profile> を呼び出す", async () => {

--- a/tests/unit/infra/keychain-windows.test.ts
+++ b/tests/unit/infra/keychain-windows.test.ts
@@ -71,6 +71,18 @@ describe("WindowsKeychainStore", () => {
   })
 
   describe("load", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.load("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.load("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("powershell を呼び出して SID を返す", async () => {
       const { spawner, getCall } = captureSpawner("sid-abc-123", "", 0)
       const store = new WindowsKeychainStore(spawner)
@@ -128,6 +140,18 @@ describe("WindowsKeychainStore", () => {
   })
 
   describe("delete", () => {
+    it("不正なプロファイル名 (空文字列) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.delete("")).rejects.toThrow("プロファイル名を空にすることはできません")
+    })
+
+    it("不正なプロファイル名 (禁止文字含む) でバリデーションエラーを throw する", async () => {
+      const { spawner } = captureSpawner("", "", 0)
+      const store = new WindowsKeychainStore(spawner)
+      await expect(store.delete("invalid/profile")).rejects.toThrow("使用できない文字")
+    })
+
     it("cmdkey /delete:coscli:<profile> を呼び出す", async () => {
       const { spawner, getCall } = captureSpawner("", "", 0)
       const store = new WindowsKeychainStore(spawner)


### PR DESCRIPTION
## 概要

`validateProfile(profile)` が `save` 時のみ呼ばれ、`load` / `delete` では呼ばれていなかった問題を修正する (Medium #12)。

## 変更内容

- `src/infra/keychain/macos.ts` — `load`, `delete` 先頭に `validateProfile` 追加
- `src/infra/keychain/linux.ts` — `load`, `delete` 先頭に `validateProfile` 追加
- `src/infra/keychain/windows.ts` — `load`, `delete` 先頭に `validateProfile` 追加
- `src/infra/keychain/file.ts` — `validateProfile` インポート追加 + `load`, `delete` 先頭に追加

## テスト

各 keychain テストファイルに `load` / `delete` のバリデーションテストを追加:
- 空文字列で `プロファイル名を空にすることはできません` エラーになること
- 禁止文字 (`/`) 含む文字列で `使用できない文字` エラーになること

## 確認事項

- `bun test`: 940 pass / 0 fail
- `bun run typecheck`: エラーなし
- `bunx biome check src tests`: エラーなし

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* プロファイル名の検証を強化しました。無効なプロファイル名（空文字列や禁止文字を含むもの）を早期に検出し、わかりやすいエラーメッセージで拒否するようになりました。すべての環境で一貫した検証動作が提供されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/101)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->