### PR TITLE
fix(security): whoami --json から csrfToken を除外 (Medium #14)

### DIFF
--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -3,6 +3,8 @@
  *
  * 現在の認証ユーザー情報を取得して出力する。
  * alias: `cos me`
+ *
+ * セキュリティ: csrfToken は --json 出力から除外する。(issue #89)
  */
 
 import {
@@ -14,47 +16,64 @@ import {
 } from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
 import { loadSession } from "@/core/auth/session"
+import type { TokenStore } from "@/core/auth/store"
 import { createTokenStore } from "@/infra/keychain/index"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writePlainTable } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
-export const authWhoamiCommand = defineCommand({
-  meta: { name: "whoami", description: "現在の認証ユーザー情報を取得する" },
-  args: { ...commonArgs },
-  async run({ args }) {
-    const a = args as CommonArgs
-    checkSandbox("auth.whoami", a)
-    const logger = buildLogger(a)
-    const startTime = Date.now()
+/** AuthWhoamiCommandDeps は createAuthWhoamiCommand に注入できる依存。テスト専用。 */
+export interface AuthWhoamiCommandDeps {
+  /** createStore は TokenStore を生成する関数。未指定時は OS keychain を使用する。 */
+  createStore?: () => TokenStore
+}
 
-    const store = createTokenStore()
-    const sid = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
-    if (!sid) {
-      writeErrorJson(
-        "AUTH_REQUIRED",
-        "認証情報が見つかりません",
-        "`cos auth login` を実行してログインしてください",
+/** createAuthWhoamiCommand は依存を注入して whoami コマンドを生成する。 */
+export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
+  const { createStore = createTokenStore } = deps
+
+  return defineCommand({
+    meta: { name: "whoami", description: "現在の認証ユーザー情報を取得する" },
+    args: { ...commonArgs },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.whoami", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      const store = createStore()
+      const sid = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
+      if (!sid) {
+        writeErrorJson(
+          "AUTH_REQUIRED",
+          "認証情報が見つかりません",
+          "`cos auth login` を実行してログインしてください",
+        )
+        process.exit(2)
+      }
+
+      logger.info("ユーザー情報を取得中...")
+
+      const client = new CosenseRestClient({ sid })
+      const me = await client.getMe()
+
+      if (a.json || !a.plain) {
+        // csrfToken は機密情報のため出力から除外する
+        const { csrfToken: _csrfToken, ...safeMe } = me
+        writeJson(safeMe, { command: "auth.whoami", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      writePlainTable(
+        ["フィールド", "値"],
+        [
+          ["名前", me.name],
+          ["ID", me.id],
+        ],
       )
-      process.exit(2)
-    }
+    },
+  })
+}
 
-    logger.info("ユーザー情報を取得中...")
-
-    const client = new CosenseRestClient({ sid })
-    const me = await client.getMe()
-
-    if (a.json || !a.plain) {
-      writeJson(me, { command: "auth.whoami", startTime }, buildJsonOpts(a))
-      return
-    }
-
-    writePlainTable(
-      ["フィールド", "値"],
-      [
-        ["名前", me.name],
-        ["ID", me.id],
-      ],
-    )
-  },
-})
+/** authWhoamiCommand は OS keychain を使うデフォルト実装。 */
+export const authWhoamiCommand = createAuthWhoamiCommand()

--- a/tests/unit/commands/auth/whoami.test.ts
+++ b/tests/unit/commands/auth/whoami.test.ts
@@ -1,0 +1,124 @@
+/**
+ * whoami.test.ts — `cos auth whoami` コマンドのユニットテスト。
+ *
+ * --json 出力に csrfToken が含まれないこと、および id/name 等の通常フィールドが
+ * 正しく出力されることを検証する。(issue #89)
+ *
+ * keychain は InMemoryTokenStore で代替し、API は msw でモックする。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthWhoamiCommand } from "@/commands/auth/whoami"
+import { saveSession } from "@/core/auth/session"
+import { InMemoryTokenStore } from "@/core/auth/store"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+// ---------------------------------------------------------------------------
+// MSW サーバーセットアップ
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://scrapbox.io"
+const testSid = "s%3Atest-whoami-sid-abc123"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({
+      id: "yamada-taro-id",
+      name: "yamada-taro",
+      displayName: "山田太郎",
+      email: "yamada@example.co.jp",
+      csrfToken: "秘密のCSRFトークン",
+      isPasswordUser: true,
+    })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+/** コマンドを実行するヘルパー。InMemoryTokenStore にセッションを事前セットアップする。 */
+async function runWhoami(args: Record<string, unknown>) {
+  const store = new InMemoryTokenStore()
+  await saveSession(store, { profile: "default", sid: testSid })
+  const command = createAuthWhoamiCommand({ createStore: () => store })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** stdout への書き込みをキャプチャして JSON として返すヘルパー。 */
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => {
+    const raw = chunks.join("")
+    return JSON.parse(raw)
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock.mockRestore()
+  server.resetHandlers()
+})
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authWhoamiCommand — --json 出力のセキュリティ検証", () => {
+  it("--json 出力に csrfToken が含まれないこと (issue #89)", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoami({
+      json: true,
+      plain: false,
+      quiet: false,
+      verbose: false,
+      profile: "default",
+    })
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).not.toHaveProperty("csrfToken")
+  })
+
+  it("--json 出力に id・name・displayName が含まれること", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoami({
+      json: true,
+      plain: false,
+      quiet: false,
+      verbose: false,
+      profile: "default",
+    })
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).toHaveProperty("id", "yamada-taro-id")
+    expect(output.data).toHaveProperty("name", "yamada-taro")
+    expect(output.data).toHaveProperty("displayName", "山田太郎")
+  })
+})

--- a/tests/unit/commands/auth/whoami.test.ts
+++ b/tests/unit/commands/auth/whoami.test.ts
@@ -94,28 +94,24 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("authWhoamiCommand — --json 出力のセキュリティ検証", () => {
+  const defaultWhoamiArgs = {
+    json: true,
+    plain: false,
+    quiet: false,
+    verbose: false,
+    profile: "default",
+  }
+
   it("--json 出力に csrfToken が含まれないこと (issue #89)", async () => {
     const getJson = captureJsonOutput()
-    await runWhoami({
-      json: true,
-      plain: false,
-      quiet: false,
-      verbose: false,
-      profile: "default",
-    })
+    await runWhoami(defaultWhoamiArgs)
     const output = getJson() as { data?: Record<string, unknown> }
     expect(output.data).not.toHaveProperty("csrfToken")
   })
 
   it("--json 出力に id・name・displayName が含まれること", async () => {
     const getJson = captureJsonOutput()
-    await runWhoami({
-      json: true,
-      plain: false,
-      quiet: false,
-      verbose: false,
-      profile: "default",
-    })
+    await runWhoami(defaultWhoamiArgs)
     const output = getJson() as { data?: Record<string, unknown> }
     expect(output.data).toHaveProperty("id", "yamada-taro-id")
     expect(output.data).toHaveProperty("name", "yamada-taro")


### PR DESCRIPTION
## Summary

- `cos auth whoami --json` の出力から `csrfToken` を除外する (issue #89 / Medium #14)
- `createAuthWhoamiCommand(deps)` パターンに変更し、`TokenStore` を注入可能にする
- `whoami.test.ts` を新規作成し、csrfToken 非出力と通常フィールド出力を検証する

## 変更ファイル

- `src/commands/auth/whoami.ts` — `createAuthWhoamiCommand(deps)` パターンへ変更、`csrfToken` をデストラクチャリングで除外
- `tests/unit/commands/auth/whoami.test.ts` — 新規テスト（MSW + InMemoryTokenStore）

## Test plan

- [x] `bun test tests/unit/commands/auth/whoami.test.ts` — 2 pass
- [x] `bun test` 全件 — 952 pass / 0 fail
- [x] `bun run typecheck` — エラーなし
- [x] `bunx biome check src tests` — エラーなし

Closes #89