### PR TITLE
fix(security): fsname に Windows 予約名・末尾スペース/ピリオド検査を追加 (Medium #15)

### DIFF
--- a/src/core/sync/fsname.ts
+++ b/src/core/sync/fsname.ts
@@ -12,6 +12,9 @@ const FORBIDDEN_PATTERN = /[/\\:*?"<>|]/
 /** 予約名: . と .. はディレクトリトラバーサルの危険がある */
 const RESERVED_NAMES = new Set([".", ".."])
 
+/** Windows 予約デバイス名: 拡張子付きも含む (例: CON.txt) */
+const WINDOWS_RESERVED = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i
+
 /** FilenameInvalidError はファイル名として使用できないタイトルのエラー。 */
 export class FilenameInvalidError extends Error {
   constructor(
@@ -46,6 +49,12 @@ export function safeFsName(title: string): string {
       const display = `U+${code.toString(16).padStart(4, "0").toUpperCase()}`
       throw new FilenameInvalidError(title, `禁則文字 ${display} が含まれています`)
     }
+  }
+  if (WINDOWS_RESERVED.test(title)) {
+    throw new FilenameInvalidError(title, `"${title}" は Windows 予約デバイス名です`)
+  }
+  if (/[ .]$/.test(title)) {
+    throw new FilenameInvalidError(title, "末尾にスペースまたはピリオドを使用できません")
   }
   return title
 }

--- a/tests/unit/core/sync/fsname.test.ts
+++ b/tests/unit/core/sync/fsname.test.ts
@@ -65,6 +65,86 @@ describe("safeFsName", () => {
     expect(() => safeFsName("newline\nchar")).toThrow(FilenameInvalidError)
   })
 
+  describe("Windows 予約デバイス名", () => {
+    test("CON は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("CON")).toThrow(FilenameInvalidError)
+    })
+
+    test("PRN は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("PRN")).toThrow(FilenameInvalidError)
+    })
+
+    test("AUX は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("AUX")).toThrow(FilenameInvalidError)
+    })
+
+    test("NUL は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("NUL")).toThrow(FilenameInvalidError)
+    })
+
+    test("COM1 は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("COM1")).toThrow(FilenameInvalidError)
+    })
+
+    test("COM9 は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("COM9")).toThrow(FilenameInvalidError)
+    })
+
+    test("LPT1 は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("LPT1")).toThrow(FilenameInvalidError)
+    })
+
+    test("LPT9 は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("LPT9")).toThrow(FilenameInvalidError)
+    })
+
+    test("拡張子付き予約名 COM1.txt は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("COM1.txt")).toThrow(FilenameInvalidError)
+    })
+
+    test("拡張子付き予約名 NUL.log は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("NUL.log")).toThrow(FilenameInvalidError)
+    })
+
+    test("小文字の予約名 con は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("con")).toThrow(FilenameInvalidError)
+    })
+
+    test("混在大小文字の予約名 CoM1 は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("CoM1")).toThrow(FilenameInvalidError)
+    })
+
+    test("予約名を含む通常名 CONSOLE は通過する", () => {
+      expect(safeFsName("CONSOLE")).toBe("CONSOLE")
+    })
+
+    test("予約名を含む通常名 NULLポインタ は通過する", () => {
+      expect(safeFsName("NULLポインタ")).toBe("NULLポインタ")
+    })
+  })
+
+  describe("末尾スペース・末尾ピリオド", () => {
+    test("末尾スペースのファイル名は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("ファイル名 ")).toThrow(FilenameInvalidError)
+    })
+
+    test("末尾ピリオドのファイル名は FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("ファイル名.")).toThrow(FilenameInvalidError)
+    })
+
+    test("複数の末尾スペースは FilenameInvalidError を throw する", () => {
+      expect(() => safeFsName("ファイル名   ")).toThrow(FilenameInvalidError)
+    })
+
+    test("中間のスペースは通過する", () => {
+      expect(safeFsName("ファイル 名")).toBe("ファイル 名")
+    })
+
+    test("中間のピリオドは通過する", () => {
+      expect(safeFsName("ファイル.名")).toBe("ファイル.名")
+    })
+  })
+
   test("FilenameInvalidError は title と reason を持つ", () => {
     let caughtErr: unknown
     try {


### PR DESCRIPTION
## 概要

`src/core/sync/fsname.ts` の `safeFsName` に以下の検査を追加しました。

- **Windows 予約デバイス名** (`CON`, `PRN`, `AUX`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`) および拡張子付き (`CON.txt` 等) を `FilenameInvalidError` で拒否
- **末尾スペース・末尾ピリオド** を `FilenameInvalidError` で拒否 (Windows でファイル作成に失敗するため)

## 変更ファイル

- `src/core/sync/fsname.ts:15-16,53-58` — `WINDOWS_RESERVED` 正規表現定数と 2 チェックを追加
- `tests/unit/core/sync/fsname.test.ts` — 15 件のテストケースを追加 (TDD: RED→GREEN)

## テスト計画

- [x] `bun test` 全 33 件パス
- [x] `bunx biome check` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ファイル名のバリデーションを強化しました。Windows予約デバイス名（CON、PRN、AUXなど）の使用を拒否し、末尾のスペースとドットも許可しません。

* **テスト**
  * 強化されたファイル名検証ルールをカバーする包括的なテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->