### PR TITLE
fix(security): sync push --all に safeFsName 二重防御を追加 (Medium #16)

### DIFF
--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -17,7 +17,7 @@ import {
   requireProject,
 } from "@/commands/_shared"
 import { syncPush } from "@/core/sync/engine"
-import { FilenameInvalidError } from "@/core/sync/fsname"
+import { FilenameInvalidError, safeFsName } from "@/core/sync/fsname"
 import { loadConfig } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -176,6 +176,13 @@ export const syncPushCommand = defineCommand({
 
       for (const metaFile of metaFiles) {
         const title = metaFile.replace(/\.json$/, "")
+        // 二重防御: engine 側の検証に加え、不正ファイル名を push 前にスキップする
+        try {
+          safeFsName(title)
+        } catch {
+          logger.warn(`不正なファイル名をスキップ: ${metaFile}`)
+          continue
+        }
         try {
           const result = await syncPush(client, writer, syncDir, project, title, {
             dryRun,

--- a/tests/unit/commands/sync/push.test.ts
+++ b/tests/unit/commands/sync/push.test.ts
@@ -1,12 +1,46 @@
 /**
- * sync/push.test.ts — `cos sync push [<title>]` コマンドの入力バリデーションテスト。
+ * sync/push.test.ts — `cos sync push [<title>]` コマンドのテスト。
+ *
+ * - 入力バリデーション・sandbox・exit コードのテスト
+ * - --all モードでの不正ファイル名スキップ動作のテスト (issue #91)
  */
 
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import { syncPushCommand } from "@/commands/sync/push"
+
+/** syncPush に渡された title をキャプチャする */
+const capturedPushTitles: string[] = []
+
+// Bun は mock.module をファイル先頭にホイストするため import より前に評価される
+// node:fs をモックして readdirSync / existsSync を差し替える。
+// realFs を spread して readFileSync 等の他メソッドは実装をそのまま使う。
+mock.module("node:fs", () => {
+  // biome-ignore lint/style/useNodejsImportProtocol: モックバイパスに "node:" なしが必要
+  const realFs = require("fs") as typeof import("node:fs")
+  return {
+    ...realFs,
+    // .coscli 配下のパスは同期メタディレクトリとして存在するものとみなす
+    existsSync: (p: unknown) => {
+      if (typeof p === "string" && p.includes(".coscli")) return true
+      return realFs.existsSync(p as Parameters<typeof realFs.existsSync>[0])
+    },
+    readdirSync: (_dir: unknown) => ["CON.json", "正常なページ.json"],
+  }
+})
+
+// syncPush をモックして実際の API コールを回避し、呼び出し引数をキャプチャする
+mock.module("@/core/sync/engine", () => ({
+  syncPush: mock(
+    async (_client: unknown, _writer: unknown, _dir: string, _project: string, title: string) => {
+      capturedPushTitles.push(title)
+      return { committed: true, status: "pushed", newCommitId: "テストコミットID" }
+    },
+  ),
+}))
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
 
 async function runPush(args: Record<string, unknown>) {
   await (
@@ -47,17 +81,24 @@ function defaultArgs(overrides: Record<string, unknown> = {}): Record<string, un
 beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // requireSid のキーチェーン呼び出しをスキップするためダミー SID を設定する
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  // 各テスト前にキャプチャを初期化する
+  capturedPushTitles.length = 0
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
 })
 
-describe("syncPushCommand", () => {
+describe("syncPushCommand バリデーション", () => {
   it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
     try {
       await runPush(defaultArgs({ project: undefined }))
@@ -98,5 +139,34 @@ describe("syncPushCommand", () => {
       // process.exit モック後の継続による throw は想定内
     }
     expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})
+
+describe("syncPushCommand --all モード 不正ファイル名スキップ (issue #91)", () => {
+  it("Windows 予約名 (CON) のメタファイルはスキップされ、正常なファイルだけ push される", async () => {
+    // Given: readdirSync が ["CON.json", "正常なページ.json"] を返す (mock.module で設定済み)
+    // When: --all で push する
+    await runPush(
+      defaultArgs({
+        all: true,
+        dir: "/tmp/cos-test-sync",
+      }),
+    )
+
+    // Then: syncPush は "正常なページ" に対してのみ呼ばれること
+    expect(capturedPushTitles).toEqual(["正常なページ"])
+  })
+
+  it("Windows 予約名スキップ時に警告メッセージが stderr に出力される", async () => {
+    await runPush(
+      defaultArgs({
+        all: true,
+        dir: "/tmp/cos-test-sync",
+      }),
+    )
+
+    // 警告メッセージに不正ファイル名 CON.json が含まれること
+    const stderrOutput = stderrMock.mock.calls.map((call: unknown[]) => call[0] as string).join("")
+    expect(stderrOutput).toContain("CON.json")
   })
 })


### PR DESCRIPTION
## 概要

`docs/security-audit-2026-05.md` Medium #16 対応。

`src/commands/sync/push.ts` の `--all` モードで `readdirSync` から取得したメタファイル名を `syncPush` に渡す前に `safeFsName` でバリデートし、不正なファイル名（Windows 予約名・末尾スペース・末尾ピリオド等）をスキップするよう修正した。

### 変更内容

- `src/commands/sync/push.ts:178` — `safeFsName(title)` 呼び出しを追加。`FilenameInvalidError` を catch した場合は警告ログを出力して `continue`
- `tests/unit/commands/sync/push.test.ts` — `--all` モードでの不正ファイル名スキップ動作テストを追加（`CON.json` がスキップされ `正常なページ.json` だけが push されること、警告メッセージが stderr に出力されること）

## テスト計画

- [x] `bun test tests/unit/commands/sync/push.test.ts` — 6 件全件パス
- [x] `bun test` — 973 件全件パス
- [x] `bun run typecheck` — エラーなし
- [x] `bunx biome check src tests` — エラーなし

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)