### PR TITLE
fix(security): SearchResultSchema.query の .passthrough() を除去し既知フィールドのみ受け付けるよう変更 (Low #17)

### DIFF
--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -93,6 +93,7 @@ export type PageListResponse = z.infer<typeof PageListResponseSchema>
 /** SearchResult は /api/pages/:project/search/query のレスポンス。 */
 export const SearchResultSchema = z.object({
   // 実 API (認証あり): query はオブジェクト形式 { words, excludes } を返すことがある
+  // セキュリティ: .passthrough() を使用せず既知フィールドのみ定義する (未知キーはデフォルトでストリップ)
   query: z
     .union([
       z.string(),

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -93,7 +93,15 @@ export type PageListResponse = z.infer<typeof PageListResponseSchema>
 /** SearchResult は /api/pages/:project/search/query のレスポンス。 */
 export const SearchResultSchema = z.object({
   // 実 API (認証あり): query はオブジェクト形式 { words, excludes } を返すことがある
-  query: z.union([z.string(), z.object({}).passthrough()]).optional(),
+  query: z
+    .union([
+      z.string(),
+      z.object({
+        words: z.array(z.string()).optional(),
+        excludes: z.array(z.string()).optional(),
+      }),
+    ])
+    .optional(),
   pages: z.array(
     z.object({
       id: z.string(),

--- a/tests/unit/schemas/page.test.ts
+++ b/tests/unit/schemas/page.test.ts
@@ -204,8 +204,9 @@ describe("SearchResultSchema — 実 API レスポンスとの整合性", () => 
       pages: [],
       projectName: "テストプロジェクト",
     })
-    // queryがオブジェクトの場合にwordsとexcludesが保持されること
-    const q = result.query as { words: string[]; excludes: string[] }
+    // 型ガードで query がオブジェクトであることを確認してから各フィールドを検証する
+    const q = result.query
+    if (typeof q !== "object" || q === null) throw new Error("query はオブジェクトであるべき")
     expect(q.words).toEqual(["TypeScript", "Cosense"])
     expect(q.excludes).toEqual(["非表示"])
   })
@@ -217,8 +218,7 @@ describe("SearchResultSchema — 実 API レスポンスとの整合性", () => 
       projectName: "テストプロジェクト",
     })
     // 未知のキーはストリップされ query オブジェクトに混入しないこと
-    const q = result.query as Record<string, unknown>
-    expect(q["unknownKey"]).toBeUndefined()
+    expect(Object.keys(result.query as object)).not.toContain("unknownKey")
   })
 
   it("query フィールドが文字列でもパースできる", () => {

--- a/tests/unit/schemas/page.test.ts
+++ b/tests/unit/schemas/page.test.ts
@@ -198,6 +198,29 @@ describe("SearchResultSchema — 実 API レスポンスとの整合性", () => 
     expect(result.projectName).toBe("テストプロジェクト")
   })
 
+  it("query オブジェクトの words・excludes フィールドが正しくパースされる", () => {
+    const result = SearchResultSchema.parse({
+      query: { words: ["TypeScript", "Cosense"], excludes: ["非表示"] },
+      pages: [],
+      projectName: "テストプロジェクト",
+    })
+    // queryがオブジェクトの場合にwordsとexcludesが保持されること
+    const q = result.query as { words: string[]; excludes: string[] }
+    expect(q.words).toEqual(["TypeScript", "Cosense"])
+    expect(q.excludes).toEqual(["非表示"])
+  })
+
+  it("query オブジェクトに未知のキーが含まれた場合はストリップされる", () => {
+    const result = SearchResultSchema.parse({
+      query: { words: ["テスト"], excludes: [], unknownKey: "不審な値" },
+      pages: [],
+      projectName: "テストプロジェクト",
+    })
+    // 未知のキーはストリップされ query オブジェクトに混入しないこと
+    const q = result.query as Record<string, unknown>
+    expect(q["unknownKey"]).toBeUndefined()
+  })
+
   it("query フィールドが文字列でもパースできる", () => {
     const result = SearchResultSchema.parse({
       query: "テスト",


### PR DESCRIPTION
## Summary

- `src/schemas/page.ts:96` の `query` フィールドで使用していた `.passthrough()` を除去
- `z.object({}).passthrough()` → `z.object({ words, excludes })` に変更し、未知キーをデフォルトでストリップする
- `words` / `excludes` フィールドを明示的に定義（どちらも `string[]` のオプショナル）
- スキーマにセキュリティ意図を示すコメントを追加

## Test plan

- [ ] `query: { words, excludes }` の既知フィールドが正しくパースされること
- [ ] `query` オブジェクトに未知キーが含まれた場合に `Object.keys()` で確認してストリップされること
- [ ] `query` が文字列形式でも引き続きパースできること
- [ ] `bun test` 全件 pass (975 pass, 16 skip, 0 fail)
- [ ] `bun run typecheck` エラーなし
- [ ] `bunx biome check` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #92