### PR TITLE
fix(security): config.json5 / sync メタファイルに mode 0o600 を明示指定 (Low #18)

### DIFF
--- a/src/core/sync/meta.ts
+++ b/src/core/sync/meta.ts
@@ -36,7 +36,7 @@ export function writeMeta(syncDir: string, meta: SyncMeta): void {
   const filePath = metaFilePath(syncDir, meta.project, meta.title)
   const dir = join(syncDir, ".coscli", meta.project)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  writeFileSync(filePath, JSON.stringify(meta, null, 2))
+  writeFileSync(filePath, JSON.stringify(meta, null, 2), { mode: 0o600 })
 }
 
 /** readMeta はメタデータをファイルから読み込む。ファイルが存在しない場合は null を返す。破損時は Error を throw する。 */

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -74,7 +74,7 @@ export function saveConfig(config: CoscliConfig, filePath: string = defaultConfi
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   // JSON5 形式のヘッダコメントを付与
   const header = "// coscli 設定ファイル (JSON5形式 — コメント・末尾カンマ可)\n"
-  writeFileSync(filePath, header + JSON.stringify(config, null, 2))
+  writeFileSync(filePath, header + JSON.stringify(config, null, 2), { mode: 0o600 })
 }
 
 /** FORBIDDEN_KEYS は prototype 汚染を引き起こす危険なキー名の集合。 */

--- a/tests/unit/core/sync/meta.test.ts
+++ b/tests/unit/core/sync/meta.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { type SyncMeta, SyncMetaSchema, readMeta, writeMeta } from "@/core/sync/meta"
@@ -81,6 +81,17 @@ describe("writeMeta / readMeta", () => {
   test("readMeta はファイルが存在しない場合 null を返す", () => {
     const result = readMeta(TEST_DIR, "存在しないプロジェクト", "存在しないページ")
     expect(result).toBeNull()
+  })
+
+  test("writeMeta で書き込まれたファイルのパーミッションが 0o600 であること", () => {
+    const meta = makeValidMeta()
+    writeMeta(TEST_DIR, meta)
+
+    const metaPath = join(TEST_DIR, ".coscli", "テストプロジェクト", "テストページ.json")
+    const stat = statSync(metaPath)
+    // 下位 9 ビットでファイルパーミッションを確認する
+    const mode = stat.mode & 0o777
+    expect(mode).toBe(0o600)
   })
 
   test("metaPath はタイトルをファイル名に使う", () => {

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { existsSync, unlinkSync } from "node:fs"
+import { existsSync, statSync, unlinkSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -78,6 +78,14 @@ describe("saveConfig", () => {
     const loaded = loadConfig(nestedPath)
     expect(loaded.defaultProject).toBe("ネストテスト")
     unlinkSync(nestedPath)
+  })
+
+  it("保存されたファイルのパーミッションが 0o600 であること", () => {
+    saveConfig({ defaultProject: "パーミッションテスト" }, path)
+    const stat = statSync(path)
+    // 下位 9 ビットでファイルパーミッションを確認する
+    const mode = stat.mode & 0o777
+    expect(mode).toBe(0o600)
   })
 })
 


### PR DESCRIPTION
## Summary

- `src/infra/config.ts:77` の `writeFileSync` に `{ mode: 0o600 }` を追加
- `src/core/sync/meta.ts:39` の `writeFileSync` に `{ mode: 0o600 }` を追加
- 両ファイルにパーミッション `0o600` を検証するテストを追加

## 背景

`umask 022` 環境では mode 未指定の `writeFileSync` が `0o644` でファイルを作成するため、他ユーザーが config.json5 や sync メタファイルを読める状態になっていた。

## Test plan

- [x] `bun test` 全件パス (977 pass, 0 fail)
- [x] `bunx biome check src tests` エラーなし
- [x] `bun run typecheck` エラーなし
- [x] `saveConfig` のパーミッション検証テスト追加・パス確認
- [x] `writeMeta` のパーミッション検証テスト追加・パス確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * メタデータファイルと設定ファイルのアクセス権限をより安全な設定に変更し、セキュリティを強化しました。

* **テスト**
  * ファイル権限の設定が正しく適用されていることを確認するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->