### PR TITLE
chore: @types/bun を latest から ^1.3.13 にピン留め (Low #19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.13",
     "@types/json5": "^2.2.0",
     "msw": "^2.7.5",
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary

- `package.json` の `@types/bun` を `"latest"` から `"^1.3.13"` に変更
- `bun.lock` で解決済みのバージョン 1.3.13 を基準に semver 範囲を固定
- フローティングタグによる意図しないバージョン更新を防止

## Test plan

- [x] `bun install --frozen-lockfile` が成功することを確認
- [x] Lint (`bunx biome check src tests`) — エラーなし
- [x] 型チェック (`bun run typecheck`) — エラーなし
- [x] テスト (`bun test`) — 977 pass / 0 fail

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)