### PR TITLE
fix(page/rename): リネーム元が persistent:false/404 の場合に NOT_FOUND (exit 4) で終了する

### DIFF
--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -63,14 +63,15 @@ export const pageRenameCommand = defineCommand({
       const client = await buildRestClient(a)
 
       // リネーム元の存在 + persistent チェック (issue #112)
-      // persistent:false はプレースホルダーページであり実体がないため、rename すると空ページが新規作成される。
+      // persistent:true 以外 (false / undefined) のページは実体がなく rename すると空ページが新規作成される。
+      // persistent が undefined のケースも安全側に倒して NOT_FOUND (exit 4) で終了する。
       // 404 (NotFoundError) も同様にリネーム不可として NOT_FOUND (exit 4) で終了する。
       try {
         const srcPage = await client.getPage(project, a.title)
-        if (srcPage.persistent === false) {
+        if (srcPage.persistent !== true) {
           writeErrorJson(
             "NOT_FOUND",
-            `"${a.title}" は実体のないプレースホルダーページです`,
+            `"${a.title}" は実体のないページのため rename できません`,
             "cos page get で persistent の値を確認してください",
           )
           process.exit(EXIT_NOT_FOUND)

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -4,8 +4,11 @@
  * ページタイトルを変更する。WebSocket commit で lines[0] を書き換えることで
  * @cosense/std が TitleChange を自動 emit する。
  *
- * --force-fallback なし時は変更前に新タイトルの重複チェックを行い、
- * 重複する場合は DUPLICATE_TITLE エラー (exit 5) で終了する。
+ * --dry-run 以外時は変更前に以下のチェックを行う:
+ * 1. リネーム元が persistent:false (プレースホルダー) または存在しない場合は
+ *    NOT_FOUND エラー (exit 4) で終了する。(issue #112)
+ * 2. --force-fallback なし時、リネーム先に実体ページが存在する場合は
+ *    DUPLICATE_TITLE エラー (exit 5) で終了する。(issue #57)
  */
 
 import {
@@ -19,6 +22,7 @@ import {
   dryRunArg,
   requireProject,
 } from "@/commands/_shared"
+import { EXIT_NOT_FOUND } from "@/core/exit-codes"
 import { renamePage } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -55,28 +59,57 @@ export const pageRenameCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // dry-run 以外かつ同名でない場合は重複チェックを行う (同名は no-op なのでスキップ)
-    if (!a["dry-run"] && !a["force-fallback"] && a["new-title"] !== a.title) {
+    if (!a["dry-run"]) {
       const client = await buildRestClient(a)
+
+      // リネーム元の存在 + persistent チェック (issue #112)
+      // persistent:false はプレースホルダーページであり実体がないため、rename すると空ページが新規作成される。
+      // 404 (NotFoundError) も同様にリネーム不可として NOT_FOUND (exit 4) で終了する。
       try {
-        const page = await client.getPage(project, a["new-title"])
-        // persistent !== false の場合のみ実体ページが存在するとみなす。
-        // Cosense REST API は存在しないページに persistent:false のスタブとして 200 を返すため、
-        // getPage の成功だけでは重複の証明にならない。(issue #57)
-        // persistent が undefined の場合も安全側に倒して実体ページ扱いにする。
-        if (page.persistent !== false) {
+        const srcPage = await client.getPage(project, a.title)
+        if (srcPage.persistent === false) {
           writeErrorJson(
-            "DUPLICATE_TITLE",
-            `"${a["new-title"]}" は既に存在します`,
-            "別のタイトルを指定するか、--force-fallback を使用してください",
+            "NOT_FOUND",
+            `"${a.title}" は実体のないプレースホルダーページです`,
+            "cos page get で persistent の値を確認してください",
           )
-          process.exit(5)
+          process.exit(EXIT_NOT_FOUND)
           return
         }
       } catch (err) {
-        // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー
         const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
-        if (!isNotFound) throw err
+        if (isNotFound) {
+          writeErrorJson(
+            "NOT_FOUND",
+            `ページ "${a.title}" が見つかりません`,
+            "ページタイトルを確認してください",
+          )
+          process.exit(EXIT_NOT_FOUND)
+          return
+        }
+        throw err
+      }
+
+      // リネーム先の重複チェック (--force-fallback なし時、同名は no-op なのでスキップ)
+      // Cosense REST API は存在しないページに persistent:false のスタブとして 200 を返すため、
+      // getPage の成功だけでは重複の証明にならない。persistent !== false の場合のみ実体ページ扱い。(issue #57)
+      if (!a["force-fallback"] && a["new-title"] !== a.title) {
+        try {
+          const page = await client.getPage(project, a["new-title"])
+          if (page.persistent !== false) {
+            writeErrorJson(
+              "DUPLICATE_TITLE",
+              `"${a["new-title"]}" は既に存在します`,
+              "別のタイトルを指定するか、--force-fallback を使用してください",
+            )
+            process.exit(5)
+            return
+          }
+        } catch (err) {
+          // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー
+          const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
+          if (!isNotFound) throw err
+        }
       }
     }
 

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -77,7 +77,7 @@ export const pageRenameCommand = defineCommand({
           return
         }
       } catch (err) {
-        const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
+        const isNotFound = err instanceof Error && err.name === "NotFoundError"
         if (isNotFound) {
           writeErrorJson(
             "NOT_FOUND",
@@ -107,7 +107,7 @@ export const pageRenameCommand = defineCommand({
           }
         } catch (err) {
           // 404 (NotFoundError) は正常: 重複なし。その他のエラーは再スロー
-          const isNotFound = err instanceof Error && err.constructor.name === "NotFoundError"
+          const isNotFound = err instanceof Error && err.name === "NotFoundError"
           if (!isNotFound) throw err
         }
       }

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -503,4 +503,59 @@ describe("pageRenameCommand", () => {
     // renamePage が呼ばれる (dry-run はスキップではなくプレビュー実行)
     expect(renamePageSpy).toHaveBeenCalledTimes(1)
   })
+
+  it("リネーム元が persistent フィールド欠落のページを返す場合、安全側に倒して exit 4 NOT_FOUND で終了し renamePage は呼ばれない (issue #112)", async () => {
+    // 前提: リネーム元タイトルが persistent フィールドを持たない (undefined) レスポンスを返す。
+    // 期待: persistent:true 以外は実体不明として NOT_FOUND エラー (exit 4) で終了し、
+    //       WebSocket commit (renamePage) は呼ばれない。
+    // 注記: persistent === undefined のケースは safe-side に倒して rename を禁止する。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const project = decodeURIComponent(params["project"] as string)
+        const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "persistentなしソースページ") {
+          // persistent フィールドを含まないレスポンス (undefined 扱い)
+          return HttpResponse.json({
+            id: "ambiguous-source-page-id",
+            title: "persistentなしソースページ",
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "persistentなしソースページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "persistentなしソースページ",
+        "new-title": "新しいタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // persistent が undefined でも安全側に倒して NOT_FOUND エラー (exit 4) で終了することを確認する
+    expect(exitMock).toHaveBeenCalledWith(4)
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).toContain("NOT_FOUND")
+    // persistent が不明なページへの rename は実行されない
+    expect(renamePageSpy).not.toHaveBeenCalled()
+  })
 })

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -1,8 +1,9 @@
 /**
  * page/rename.test.ts — `cos page rename <title> <new-title>` コマンドのテスト。
  *
- * 重複チェックにおける persistent フラグの判定ロジックを検証する。
+ * 重複チェックおよびリネーム元 persistent チェックのロジックを検証する。
  * issue #57: persistent:false のスタブページを重複と誤判定しないよう修正。
+ * issue #112: リネーム元が persistent:false/404 の場合に NOT_FOUND (exit 4) で終了する。
  *
  * - REST getPage は msw でモックする。
  * - WebSocket 書き込み (renamePage) は spyOn でモックして WS 接続を回避する。
@@ -112,6 +113,25 @@ describe("pageRenameCommand", () => {
       http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
         const project = decodeURIComponent(params["project"] as string)
         const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "既存ページ") {
+          // リネーム元は実体のある persistent:true のページ
+          return HttpResponse.json({
+            id: "source-page-id",
+            title: "既存ページ",
+            persistent: true,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "既存ページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
         if (project === TEST_PROJECT && title === "存在しない新タイトル") {
           // persistent:false のスタブページを返す (200 だが実体なし)
           return HttpResponse.json({
@@ -166,18 +186,21 @@ describe("pageRenameCommand", () => {
       http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
         const project = decodeURIComponent(params["project"] as string)
         const title = decodeURIComponent(params["title"] as string)
-        if (project === TEST_PROJECT && title === "既存ページタイトル") {
-          // persistent:true の実体ページを返す
+        if (
+          project === TEST_PROJECT &&
+          (title === "変更元ページ" || title === "既存ページタイトル")
+        ) {
+          // リネーム元・リネーム先ともに実体のある persistent:true のページ
           return HttpResponse.json({
-            id: "existing-page-id",
-            title: "既存ページタイトル",
+            id: `${title}-id`,
+            title,
             persistent: true,
             created: 1700000000,
             updated: 1700000000,
             lines: [
               {
                 id: "line-1",
-                text: "既存ページタイトル",
+                text: title,
                 userId: "user-1",
                 created: 1700000000,
                 updated: 1700000000,
@@ -214,10 +237,31 @@ describe("pageRenameCommand", () => {
   })
 
   it("新タイトルが 404 NotFoundError を返す場合、重複なしとして rename が継続する", async () => {
-    // 前提: Cosense REST API が 404 を返す (真のページなし)。
+    // 前提: Cosense REST API がリネーム先に対して 404 を返す (真のページなし)。
     // 期待: NotFoundError は重複なしを意味するため、rename が継続する。
     server.use(
-      http.get(`${BASE_URL}/api/pages/:project/:title`, () => {
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const title = decodeURIComponent(params["title"] as string)
+        if (title === "既存ページ") {
+          // リネーム元は実体のある persistent:true のページ
+          return HttpResponse.json({
+            id: "source-page-id",
+            title: "既存ページ",
+            persistent: true,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "既存ページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        // リネーム先 "存在しないタイトル" は 404 → 重複なし
         return HttpResponse.json({ message: "Not found" }, { status: 404 })
       }),
     )
@@ -253,6 +297,25 @@ describe("pageRenameCommand", () => {
       http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
         const project = decodeURIComponent(params["project"] as string)
         const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "変更元ページ") {
+          // リネーム元は実体のある persistent:true のページ
+          return HttpResponse.json({
+            id: "source-page-id",
+            title: "変更元ページ",
+            persistent: true,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "変更元ページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
         if (project === TEST_PROJECT && title === "persistentなしページ") {
           // persistent フィールドを含まないレスポンス
           return HttpResponse.json({
@@ -297,5 +360,147 @@ describe("pageRenameCommand", () => {
     expect(stdoutOutput).toContain("DUPLICATE_TITLE")
     // 重複扱いなので rename は呼ばれない
     expect(renamePageSpy).not.toHaveBeenCalled()
+  })
+
+  it("リネーム元が persistent:false のプレースホルダーの場合、exit 4 NOT_FOUND で終了し renamePage は呼ばれない (issue #112)", async () => {
+    // 前提: リネーム元タイトルが persistent:false のプレースホルダーページを返す。
+    // 期待: 実体のないページはリネーム不可として NOT_FOUND エラー (exit 4) で終了し、
+    //       WebSocket commit (renamePage) は呼ばれない。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const project = decodeURIComponent(params["project"] as string)
+        const title = decodeURIComponent(params["title"] as string)
+        if (project === TEST_PROJECT && title === "プレースホルダーページ") {
+          // persistent:false のプレースホルダーページ (本文なし)
+          return HttpResponse.json({
+            id: "placeholder-page-id",
+            title: "プレースホルダーページ",
+            persistent: false,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "プレースホルダーページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "プレースホルダーページ",
+        "new-title": "新しいタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // NOT_FOUND エラー (exit 4) で終了することを確認する
+    expect(exitMock).toHaveBeenCalledWith(4)
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).toContain("NOT_FOUND")
+    // プレースホルダーへの rename は実行されない
+    expect(renamePageSpy).not.toHaveBeenCalled()
+  })
+
+  it("リネーム元が 404 (NotFoundError) を返す場合、exit 4 NOT_FOUND で終了し renamePage は呼ばれない (issue #112)", async () => {
+    // 前提: リネーム元タイトルが 404 を返す (ページが存在しない)。
+    // 期待: 存在しないページはリネーム不可として NOT_FOUND エラー (exit 4) で終了し、
+    //       WebSocket commit (renamePage) は呼ばれない。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, () => {
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "存在しないソースページ",
+        "new-title": "新しいタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // NOT_FOUND エラー (exit 4) で終了することを確認する
+    expect(exitMock).toHaveBeenCalledWith(4)
+    const stdoutOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(stdoutOutput).toContain("NOT_FOUND")
+    // 存在しないページへの rename は実行されない
+    expect(renamePageSpy).not.toHaveBeenCalled()
+  })
+
+  it("--dry-run 時はリネーム元 persistent チェックをスキップし renamePage が呼ばれる", async () => {
+    // 前提: --dry-run フラグが指定されており、リネーム元は persistent:false のプレースホルダー。
+    // 期待: dry-run は副作用なしのプレビューのため REST チェックをスキップし、
+    //       renamePage が呼ばれる (dry-run なので実際の変更はない)。
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const title = decodeURIComponent(params["title"] as string)
+        if (title === "プレースホルダーページ") {
+          // dry-run 時はこのハンドラが呼ばれないことを期待するが、
+          // 万一呼ばれた場合に備えて persistent:false を返す
+          return HttpResponse.json({
+            id: "placeholder-page-id",
+            title: "プレースホルダーページ",
+            persistent: false,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              {
+                id: "line-1",
+                text: "プレースホルダーページ",
+                userId: "user-1",
+                created: 1700000000,
+                updated: 1700000000,
+              },
+            ],
+          })
+        }
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+
+    try {
+      await runRename({
+        title: "プレースホルダーページ",
+        "new-title": "新しいタイトル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": true,
+        quiet: false,
+        "force-fallback": false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+
+    // dry-run なので NOT_FOUND エラーにならない
+    expect(exitMock).not.toHaveBeenCalledWith(4)
+    // renamePage が呼ばれる (dry-run はスキップではなくプレビュー実行)
+    expect(renamePageSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

- `cos page rename` でリネーム元が `persistent: false` (Cosense のプレースホルダー) の場合、`renamePage` の WebSocket patch がタイトル行のみの空ページを新規作成するバグを修正する
- リネーム元ページの REST API チェック (`getPage`) を追加し、`persistent === false` または 404 (存在しない) の場合は `NOT_FOUND` エラー (exit 4) で停止し WebSocket commit を実行しない
- `--dry-run` 時はチェックをスキップする (副作用なしのプレビューのため)
- `--force-fallback` はリネーム先の重複処理専用フラグのため、リネーム元チェックには影響しない

## Test plan

- [x] `bun test tests/unit/commands/page/rename.test.ts` — 8 件全パス (新規 3 件 + 既存 5 件)
- [x] `bunx biome check src tests` — エラー 0
- [x] `bun run typecheck` — エラー 0
- [x] `bun test` — 983 pass, 0 fail
- [x] CodeRabbit — 指摘 1 件 (`err.constructor.name` → `err.name`) 対応済み

## 変更ファイル

- `src/commands/page/rename.ts` — リネーム元 persistent/404 チェック追加、`err.name` 修正
- `tests/unit/commands/page/rename.test.ts` — 新規テスト 3 件追加、既存テスト 4 件をソースページのモックで更新

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * `cos page rename` コマンドでリネーム対象ページの存在確認を強化し、ページが見つからない場合は終了コード 4（EXIT_NOT_FOUND）で統一
  * ページ重複検出ロジックを改善し、より正確に重複タイトルを判定
  * `--dry-run` オプション使用時の動作を最適化

* **テスト**
  * ページ存在確認とエラーコードの動作検証を拡充

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->