### PR TITLE
feat(core): 行指定パーサと patch metadata 伝搬の基盤を追加

### DIFF
--- a/src/core/api/ws.ts
+++ b/src/core/api/ws.ts
@@ -10,12 +10,22 @@
 
 import type { Line } from "@/schemas/page"
 
+/**
+ * PatchMetadata は @cosense/std から update クロージャに渡されるページメタデータ。
+ *
+ * `commitId` は現在のページの最新コミット ID。`attempts` は retry 回数 (0 スタート)。
+ */
+export interface PatchMetadata {
+  commitId?: string
+  attempts: number
+}
+
 /** ScrapboxWriterStdClient は @cosense/std の API 関数群の interface。 */
 export interface ScrapboxWriterStdClient {
   patch(
     project: string,
     title: string,
-    update: (lines: Line[]) => Promise<string[]>,
+    update: (lines: Line[], metadata?: PatchMetadata) => Promise<string[]>,
     options?: { sid?: string; maxRetry?: number },
   ): Promise<{ commitId: string; pageId: string } | unknown>
 
@@ -40,7 +50,11 @@ export interface DryRunResult {
 export interface PatchOptions {
   project: string
   title: string
-  update: (lines: Line[]) => string[] | Promise<string[]>
+  /**
+   * update は現在の行と @cosense/std から渡されるメタデータを受け取り、
+   * 新しい行内容を返す。metadata.attempts > 0 は retry が発生したことを示す。
+   */
+  update: (lines: Line[], metadata?: PatchMetadata) => string[] | Promise<string[]>
   maxRetry?: number
   /** dry-run 時に出力するプレビュー行 (書き込み予定の内容)。 */
   previewLines?: string[]
@@ -125,8 +139,8 @@ export class CosenseWriter implements ScrapboxWriter {
     const result = await this.stdClient.patch(
       patchOpts.project,
       patchOpts.title,
-      async (lines: Line[]) => {
-        const updated = await patchOpts.update(lines)
+      async (lines: Line[], metadata?: PatchMetadata) => {
+        const updated = await patchOpts.update(lines, metadata)
         return updated
       },
       patchOptions,
@@ -244,7 +258,14 @@ export async function createScrapboxWriter(opts: {
       patch(
         project,
         title,
-        update as Parameters<typeof patch>[2],
+        // @cosense/std の MakePatchFn は (BaseLine[], PatchMetadata) を渡す。
+        // coscli 内部の update は (Line[], PatchMetadata?) を受け取るため、
+        // metadata から commitId と attempts のみ抽出して渡す。
+        (lines, metadata) =>
+          update(
+            lines as Line[],
+            metadata ? { commitId: metadata.commitId, attempts: metadata.attempts } : undefined,
+          ),
         {
           sid: options?.sid,
           retry: options?.maxRetry,

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * errors.ts — coscli 固有のエラークラス定義。
+ *
+ * CLI のエラーハンドラ (cli-error-handler.ts) が exit code / JSON code に変換する。
+ */
+
+/**
+ * CommitConflictError は楽観ロック競合を表すエラー。
+ *
+ * `page edit` 等で他者がページを更新したことを検知した場合に throw する。
+ * cli-error-handler が EXIT_CONFLICT (6) / "CONFLICT" にマップする。
+ */
+export class CommitConflictError extends Error {
+  /** 期待していた commitId (--expect-commit で指定した値等)。 */
+  readonly expectedCommitId: string | undefined
+  /** 実際の commitId (サーバーから取得した最新値)。 */
+  readonly actualCommitId: string | undefined
+
+  constructor(message: string, expectedCommitId?: string, actualCommitId?: string) {
+    super(message)
+    this.name = "CommitConflictError"
+    this.expectedCommitId = expectedCommitId
+    this.actualCommitId = actualCommitId
+  }
+}

--- a/src/core/range.ts
+++ b/src/core/range.ts
@@ -1,0 +1,87 @@
+/**
+ * range.ts — 行指定 (--line / --range) のパース。
+ *
+ * `--line <n>` または `--range a:b` を 1-indexed の {start, end} に変換する。
+ * 両端含む。タイトル行 (index=1) の保護は呼び出し側で行う。
+ */
+
+/** RangeSpecError は --line / --range の指定が不正な場合のエラー。 */
+export class RangeSpecError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "RangeSpecError"
+  }
+}
+
+/** 正の整数文字列にマッチする正規表現 (1-indexed 用)。 */
+const POSITIVE_INT_RE = /^[1-9]\d*$/
+
+/**
+ * parseLineSpec は --line / --range フラグを {start, end} に変換する。
+ *
+ * @param args.line - --line フラグの値 (文字列の正の整数)
+ * @param args.range - --range フラグの値 ("a:b" 形式)
+ * @returns 1-indexed の {start, end} (両端含む)
+ * @throws RangeSpecError フラグが不正または両方指定/未指定の場合
+ */
+export function parseLineSpec(args: {
+  line?: string
+  range?: string
+}): { start: number; end: number } {
+  const hasLine = args.line !== undefined && args.line !== ""
+  const hasRange = args.range !== undefined && args.range !== ""
+
+  // 両方同時指定は禁止
+  if (hasLine && hasRange) {
+    throw new RangeSpecError("--line と --range を同時に指定することはできません")
+  }
+
+  // 両方未指定も禁止
+  if (!hasLine && !hasRange) {
+    throw new RangeSpecError("--line または --range のいずれかを指定してください")
+  }
+
+  if (hasLine) {
+    return parseLine(args.line as string)
+  }
+
+  return parseRange(args.range as string)
+}
+
+/** parseLine は --line の値を {start, end} に変換する。 */
+function parseLine(value: string): { start: number; end: number } {
+  if (!POSITIVE_INT_RE.test(value)) {
+    throw new RangeSpecError(`--line の値が無効です: "${value}" (1 以上の整数を指定してください)`)
+  }
+  const n = Number.parseInt(value, 10)
+  return { start: n, end: n }
+}
+
+/** parseRange は --range の値を {start, end} に変換する。 */
+function parseRange(value: string): { start: number; end: number } {
+  // a:b 形式の検証
+  const parts = value.split(":")
+  if (parts.length !== 2) {
+    throw new RangeSpecError(
+      `--range の値が無効です: "${value}" (a:b 形式で正の整数を指定してください)`,
+    )
+  }
+
+  const aStr = parts[0] ?? ""
+  const bStr = parts[1] ?? ""
+
+  if (!POSITIVE_INT_RE.test(aStr) || !POSITIVE_INT_RE.test(bStr)) {
+    throw new RangeSpecError(
+      `--range の値が無効です: "${value}" (a:b 形式で 1 以上の整数を指定してください)`,
+    )
+  }
+
+  const a = Number.parseInt(aStr, 10)
+  const b = Number.parseInt(bStr, 10)
+
+  if (a > b) {
+    throw new RangeSpecError(`--range の値が無効です: "${value}" (a≤b となるよう指定してください)`)
+  }
+
+  return { start: a, end: b }
+}

--- a/src/infra/cli-error-handler.ts
+++ b/src/infra/cli-error-handler.ts
@@ -24,6 +24,7 @@ import { ZodError } from "zod"
  * resolveExitCode はエラーの種類に応じた終了コードを返す。
  *
  * - ZodError → 5 (バリデーションエラー)
+ * - CommitConflictError → 6 (楽観ロック競合)
  * - AuthError → 2 (認証エラー)
  * - ForbiddenError → 3 (権限エラー)
  * - NotFoundError → 4 (NotFound)

--- a/src/infra/cli-error-handler.ts
+++ b/src/infra/cli-error-handler.ts
@@ -9,7 +9,9 @@
  */
 
 import { AuthError, CosenseApiError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { CommitConflictError } from "@/core/errors"
 import {
+  EXIT_CONFLICT,
   EXIT_ERROR,
   EXIT_FORBIDDEN,
   EXIT_NOT_FOUND,
@@ -29,6 +31,7 @@ import { ZodError } from "zod"
  */
 export function resolveExitCode(err: unknown): number {
   if (err instanceof ZodError) return EXIT_VALIDATION_ERROR
+  if (err instanceof CommitConflictError) return EXIT_CONFLICT
   if (err instanceof AuthError) return EXIT_UNAUTHORIZED
   if (err instanceof ForbiddenError) return EXIT_FORBIDDEN
   if (err instanceof NotFoundError) return EXIT_NOT_FOUND
@@ -44,6 +47,7 @@ export function resolveExitCode(err: unknown): number {
  */
 export function resolveErrorCode(err: unknown): string {
   if (err instanceof ZodError) return "VALIDATION_ERROR"
+  if (err instanceof CommitConflictError) return "CONFLICT"
   if (err instanceof AuthError) return "AUTH_REQUIRED"
   if (err instanceof ForbiddenError) return "FORBIDDEN"
   if (err instanceof NotFoundError) return "NOT_FOUND"

--- a/tests/unit/core/api/ws.test.ts
+++ b/tests/unit/core/api/ws.test.ts
@@ -24,6 +24,11 @@ const mockStdClient = {
   unpin: mockUnpin,
 }
 
+/** テスト用のダミー行データ */
+const dummyLines: Line[] = [
+  { id: "line-1", text: "タイトル", userId: "user-1", created: 0, updated: 0 },
+]
+
 describe("CosenseWriter", () => {
   beforeEach(() => {
     mockPatch.mockClear()
@@ -41,6 +46,54 @@ describe("CosenseWriter", () => {
       update: async (_lines: Line[]) => ["行1", "行2"],
     })
     expect(mockPatch).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ commitId: "mock-commit-id" })
+  })
+
+  it("stdClient.patch から渡された metadata が update 関数の第2引数に伝搬される", async () => {
+    // stdClient が update(lines, metadata) で呼んだとき、
+    // patchOpts.update が metadata を受け取れることを検証する
+    let capturedMetadata: unknown
+
+    const mockPatchWithMetadata = mock(
+      async (
+        _project: string,
+        _title: string,
+        update: (lines: Line[], meta: { commitId?: string; attempts: number }) => Promise<string[]>,
+        _options?: unknown,
+      ) => {
+        // @cosense/std が metadata を渡すことをシミュレートする
+        const metadata = { commitId: "コミットabc", attempts: 0 }
+        await update(dummyLines, metadata)
+        return { commitId: "mock-commit-id", pageId: "mock-page-id" }
+      },
+    )
+
+    const stdClient = { ...mockStdClient, patch: mockPatchWithMetadata }
+    const writer = new CosenseWriter(stdClient as ConstructorParameters<typeof CosenseWriter>[0])
+
+    await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (_lines: Line[], metadata?: { commitId?: string; attempts: number }) => {
+        capturedMetadata = metadata
+        return ["行1"]
+      },
+    })
+
+    expect(capturedMetadata).toEqual({ commitId: "コミットabc", attempts: 0 })
+  })
+
+  it("metadata を受け取らない update 関数も引き続き動作する (後方互換)", async () => {
+    // 第2引数を省略した update 関数が壊れないことを確認する
+    const writer = new CosenseWriter(
+      mockStdClient as ConstructorParameters<typeof CosenseWriter>[0],
+    )
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      // metadata を受け取らない従来パターン
+      update: async (_lines: Line[]) => ["後方互換行"],
+    })
     expect(result).toMatchObject({ commitId: "mock-commit-id" })
   })
 

--- a/tests/unit/core/range.test.ts
+++ b/tests/unit/core/range.test.ts
@@ -1,0 +1,126 @@
+/**
+ * range.test.ts — 行指定パース (parseLineSpec) のテスト。
+ *
+ * --line と --range の引数を 1-indexed の {start, end} に変換する関数の検証。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { RangeSpecError, parseLineSpec } from "@/core/range"
+
+describe("parseLineSpec", () => {
+  describe("--line 単独指定", () => {
+    it("数値を start=end に変換する", () => {
+      // 5行目を指定した場合 → {start:5, end:5}
+      expect(parseLineSpec({ line: "5" })).toEqual({ start: 5, end: 5 })
+    })
+
+    it("1 を指定した場合 start=end=1 になる", () => {
+      // タイトル行番号 (1) を指定可能 (呼び出し側でタイトル保護を行う)
+      expect(parseLineSpec({ line: "1" })).toEqual({ start: 1, end: 1 })
+    })
+
+    it("大きな数値も正しく変換する", () => {
+      expect(parseLineSpec({ line: "999" })).toEqual({ start: 999, end: 999 })
+    })
+  })
+
+  describe("--range 単独指定", () => {
+    it("a:b 形式を {start:a, end:b} に変換する", () => {
+      // 3行目から7行目まで
+      expect(parseLineSpec({ range: "3:7" })).toEqual({ start: 3, end: 7 })
+    })
+
+    it("start = end の場合も正しく変換する", () => {
+      expect(parseLineSpec({ range: "5:5" })).toEqual({ start: 5, end: 5 })
+    })
+
+    it("1:2 も正しく変換する", () => {
+      expect(parseLineSpec({ range: "1:2" })).toEqual({ start: 1, end: 2 })
+    })
+  })
+
+  describe("エラー: 両方未指定", () => {
+    it("line も range も未指定なら RangeSpecError", () => {
+      expect(() => parseLineSpec({})).toThrow(RangeSpecError)
+    })
+
+    it("空文字でも RangeSpecError", () => {
+      // exactOptionalPropertyTypes により undefined は渡せないため空文字で代替テスト
+      expect(() => parseLineSpec({ line: "", range: "" })).toThrow(RangeSpecError)
+    })
+
+    it("エラーメッセージが日本語を含む", () => {
+      expect(() => parseLineSpec({})).toThrow(/--line/)
+    })
+  })
+
+  describe("エラー: 両方同時指定", () => {
+    it("line と range を同時指定すると RangeSpecError", () => {
+      expect(() => parseLineSpec({ line: "5", range: "3:7" })).toThrow(RangeSpecError)
+    })
+
+    it("エラーメッセージが日本語を含む", () => {
+      expect(() => parseLineSpec({ line: "5", range: "3:7" })).toThrow(/同時に/)
+    })
+  })
+
+  describe("エラー: 不正な --line 値", () => {
+    it("0 は不正 (1-indexed)", () => {
+      expect(() => parseLineSpec({ line: "0" })).toThrow(RangeSpecError)
+    })
+
+    it("負数は不正", () => {
+      expect(() => parseLineSpec({ line: "-1" })).toThrow(RangeSpecError)
+    })
+
+    it("アルファベットは不正", () => {
+      expect(() => parseLineSpec({ line: "abc" })).toThrow(RangeSpecError)
+    })
+
+    it("空文字は不正", () => {
+      expect(() => parseLineSpec({ line: "" })).toThrow(RangeSpecError)
+    })
+
+    it("小数は不正", () => {
+      expect(() => parseLineSpec({ line: "3.5" })).toThrow(RangeSpecError)
+    })
+  })
+
+  describe("エラー: 不正な --range 値", () => {
+    it("0:5 は不正 (a<1)", () => {
+      expect(() => parseLineSpec({ range: "0:5" })).toThrow(RangeSpecError)
+    })
+
+    it("7:3 は不正 (a>b)", () => {
+      expect(() => parseLineSpec({ range: "7:3" })).toThrow(RangeSpecError)
+    })
+
+    it("空文字は不正", () => {
+      expect(() => parseLineSpec({ range: "" })).toThrow(RangeSpecError)
+    })
+
+    it("コロンがない (abc) は不正", () => {
+      expect(() => parseLineSpec({ range: "abc" })).toThrow(RangeSpecError)
+    })
+
+    it("コロン後が空 (1:) は不正", () => {
+      expect(() => parseLineSpec({ range: "1:" })).toThrow(RangeSpecError)
+    })
+
+    it("コロン前が空 (:5) は不正", () => {
+      expect(() => parseLineSpec({ range: ":5" })).toThrow(RangeSpecError)
+    })
+
+    it("3 要素 (3:7:9) は不正", () => {
+      expect(() => parseLineSpec({ range: "3:7:9" })).toThrow(RangeSpecError)
+    })
+
+    it("アルファベット混入 (a:5) は不正", () => {
+      expect(() => parseLineSpec({ range: "a:5" })).toThrow(RangeSpecError)
+    })
+
+    it("エラーメッセージが日本語を含む", () => {
+      expect(() => parseLineSpec({ range: "7:3" })).toThrow(/a≤b/)
+    })
+  })
+})

--- a/tests/unit/infra/cli-error-handler.test.ts
+++ b/tests/unit/infra/cli-error-handler.test.ts
@@ -1,0 +1,39 @@
+/**
+ * cli-error-handler.test.ts — エラー種別と終了コードのマッピングテスト。
+ *
+ * resolveExitCode / resolveErrorCode が各エラー種別を正しい値に変換するか検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { CommitConflictError } from "@/core/errors"
+import { resolveErrorCode, resolveExitCode } from "@/infra/cli-error-handler"
+
+describe("resolveExitCode", () => {
+  it("CommitConflictError は EXIT_CONFLICT (6) を返す", () => {
+    const err = new CommitConflictError("楽観ロック競合が発生しました")
+    expect(resolveExitCode(err)).toBe(6)
+  })
+
+  it("CommitConflictError は expectedCommitId と actualCommitId を保持する", () => {
+    const err = new CommitConflictError("競合", "期待ID", "実際ID")
+    expect(err.expectedCommitId).toBe("期待ID")
+    expect(err.actualCommitId).toBe("実際ID")
+  })
+
+  it("未知のエラーは EXIT_ERROR (1) を返す", () => {
+    const err = new Error("一般エラー")
+    expect(resolveExitCode(err)).toBe(1)
+  })
+})
+
+describe("resolveErrorCode", () => {
+  it("CommitConflictError は CONFLICT を返す", () => {
+    const err = new CommitConflictError("競合発生")
+    expect(resolveErrorCode(err)).toBe("CONFLICT")
+  })
+
+  it("未知のエラーは ERROR を返す", () => {
+    const err = new Error("一般エラー")
+    expect(resolveErrorCode(err)).toBe("ERROR")
+  })
+})


### PR DESCRIPTION
## Summary

PR2 (page line コマンド群) と PR3 (page edit 楽観ロック安全化) の準備 PR。既存コマンドの挙動変化なし (後方互換)。

- **`src/core/range.ts` 新設**: `--line <n>` / `--range a:b` を 1-indexed `{start, end}` に変換する `parseLineSpec` と `RangeSpecError` を実装
- **`src/core/api/ws.ts` 拡張**: `PatchOptions.update` に `PatchMetadata` (commitId?, attempts) を追加。`CosenseWriter.patch` が `@cosense/std` から渡される metadata を呼び出し側に伝搬するよう修正
- **`src/core/errors.ts` 新設**: 楽観ロック競合時に throw する `CommitConflictError` を定義
- **`src/infra/cli-error-handler.ts` 更新**: `CommitConflictError` → `EXIT_CONFLICT (6)` / `"CONFLICT"` にマップ

## Test plan

- [x] `bun test` 全件 pass (1016 pass, 0 fail)
- [x] `bun run typecheck` 型エラーゼロ
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `tests/unit/core/range.test.ts` 25 件 (parseLineSpec の全ケース)
- [x] `tests/unit/core/api/ws.test.ts` に metadata 伝搬テストを追加 (後方互換も検証)
- [x] `tests/unit/infra/cli-error-handler.test.ts` 新設 (CommitConflictError → exit 6 マップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)