### PR TITLE
feat(page/line): replace / delete / get コマンドを追加する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,6 @@ import { exitCodesCommand } from "@/commands/exit-codes"
 import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
-/** page サブコマンドグループ */
 /** page line サブコマンドグループ */
 const pageLineCommand = defineCommand({
   meta: { name: "line", description: "行単位編集 (replace / delete / get)" },
@@ -92,6 +91,7 @@ const pageLineCommand = defineCommand({
   },
 })
 
+/** page サブコマンドグループ */
 const pageCommand = defineCommand({
   meta: { name: "page", description: "ページ操作コマンド" },
   subCommands: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,9 @@ import { pageEditCommand } from "@/commands/page/edit"
 import { pageGetCommand } from "@/commands/page/get"
 import { pageIconCommand } from "@/commands/page/icon"
 import { pageInsertCommand } from "@/commands/page/insert"
+import { pageLineDeleteCommand } from "@/commands/page/line/delete"
+import { pageLineGetCommand } from "@/commands/page/line/get"
+import { pageLineReplaceCommand } from "@/commands/page/line/replace"
 // ページコマンド
 import { pageListCommand } from "@/commands/page/list"
 import { pageNewCommand } from "@/commands/page/new"
@@ -78,6 +81,17 @@ import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
 /** page サブコマンドグループ */
+/** page line サブコマンドグループ */
+const pageLineCommand = defineCommand({
+  meta: { name: "line", description: "行単位編集 (replace / delete / get)" },
+  subCommands: {
+    replace: pageLineReplaceCommand,
+    delete: pageLineDeleteCommand,
+    rm: pageLineDeleteCommand,
+    get: pageLineGetCommand,
+  },
+})
+
 const pageCommand = defineCommand({
   meta: { name: "page", description: "ページ操作コマンド" },
   subCommands: {
@@ -103,6 +117,7 @@ const pageCommand = defineCommand({
     rm: pageDeleteCommand,
     watch: pageWatchCommand,
     context: pageContextCommand,
+    line: pageLineCommand,
   },
 })
 

--- a/src/commands/page/line/delete.ts
+++ b/src/commands/page/line/delete.ts
@@ -1,0 +1,114 @@
+/**
+ * page/line/delete.ts — `cos page line delete <title>` コマンド。
+ *
+ * 指定行 (--line n) または範囲 (--range a:b) を削除する。
+ * タイトル行 (1行目) は削除不可。範囲外は VALIDATION_ERROR (exit 5) で終了する。
+ */
+
+import {
+  type WriteCommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  dryRunArg,
+  requireProject,
+} from "@/commands/_shared"
+import { deleteLinesFromPage } from "@/core/pages"
+import { RangeSpecError, parseLineSpec } from "@/core/range"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageLineDeleteCommand = defineCommand({
+  meta: { name: "delete", description: "指定行または範囲を削除する" },
+  args: {
+    ...commonArgs,
+    ...dryRunArg,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "削除する行番号 (1-indexed、タイトル行=1)",
+    },
+    range: {
+      type: "string",
+      description: "削除する行範囲 (例: 3:7)",
+    },
+    "expect-commit": {
+      type: "string",
+      description: "期待する commitId (楽観ロック用)",
+    },
+    force: {
+      type: "boolean",
+      description: "楽観ロックを無効化して強制上書きする",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as WriteCommonArgs & {
+      title: string
+      line?: string
+      range?: string
+      "expect-commit"?: string
+      force: boolean
+    }
+    checkSandbox("page.line.delete", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --line / --range パース
+    let start: number
+    let end: number
+    try {
+      const spec = parseLineSpec({
+        ...(a.line !== undefined && { line: a.line }),
+        ...(a.range !== undefined && { range: a.range }),
+      })
+      start = spec.start
+      end = spec.end
+    } catch (err) {
+      if (err instanceof RangeSpecError) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
+    }
+
+    logger.info(`"${a.title}" の ${start}〜${end} 行目を削除中...`)
+
+    const writer = await buildWriter(a)
+    let result: Awaited<ReturnType<typeof deleteLinesFromPage>> | undefined
+    try {
+      result = await deleteLinesFromPage(writer, {
+        project,
+        title: a.title,
+        start,
+        end,
+      })
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        (err.message.startsWith("--range/--line の値が範囲外です") ||
+          err.message.startsWith("タイトル行は編集できません"))
+      ) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
+    }
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.line.delete", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" の ${start}〜${end} 行目を削除しました`)
+  },
+})

--- a/src/commands/page/line/delete.ts
+++ b/src/commands/page/line/delete.ts
@@ -15,6 +15,7 @@ import {
   dryRunArg,
   requireProject,
 } from "@/commands/_shared"
+import { PageLineError } from "@/core/errors"
 import { deleteLinesFromPage } from "@/core/pages"
 import { RangeSpecError, parseLineSpec } from "@/core/range"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -38,23 +39,12 @@ export const pageLineDeleteCommand = defineCommand({
       type: "string",
       description: "削除する行範囲 (例: 3:7)",
     },
-    "expect-commit": {
-      type: "string",
-      description: "期待する commitId (楽観ロック用)",
-    },
-    force: {
-      type: "boolean",
-      description: "楽観ロックを無効化して強制上書きする",
-      default: false,
-    },
   },
   async run({ args }) {
     const a = args as WriteCommonArgs & {
       title: string
       line?: string
       range?: string
-      "expect-commit"?: string
-      force: boolean
     }
     checkSandbox("page.line.delete", a)
     const logger = buildLogger(a)
@@ -92,11 +82,7 @@ export const pageLineDeleteCommand = defineCommand({
         end,
       })
     } catch (err) {
-      if (
-        err instanceof Error &&
-        (err.message.startsWith("--range/--line の値が範囲外です") ||
-          err.message.startsWith("タイトル行は編集できません"))
-      ) {
+      if (err instanceof PageLineError) {
         writeErrorJson("VALIDATION_ERROR", err.message)
         process.exit(5)
         return

--- a/src/commands/page/line/get.ts
+++ b/src/commands/page/line/get.ts
@@ -1,0 +1,89 @@
+/**
+ * page/line/get.ts — `cos page line get <title>` コマンド。
+ *
+ * 指定行 (--line n) または範囲 (--range a:b) の内容を取得して出力する。
+ * 書き込みは行わない読み取り専用コマンド。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { getLineRange } from "@/core/page-line"
+import { RangeSpecError, parseLineSpec } from "@/core/range"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageLineGetCommand = defineCommand({
+  meta: { name: "get", description: "指定行または範囲を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "取得する行番号 (1-indexed、タイトル行=1)",
+    },
+    range: {
+      type: "string",
+      description: "取得する行範囲 (例: 3:7)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & {
+      title: string
+      line?: string
+      range?: string
+    }
+    checkSandbox("page.line.get", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --line / --range パース
+    let start: number
+    let end: number
+    try {
+      const spec = parseLineSpec({
+        ...(a.line !== undefined && { line: a.line }),
+        ...(a.range !== undefined && { range: a.range }),
+      })
+      start = spec.start
+      end = spec.end
+    } catch (err) {
+      if (err instanceof RangeSpecError) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
+    }
+
+    logger.info(`"${a.title}" の ${start}〜${end} 行目を取得中...`)
+
+    const client = await buildRestClient(a)
+    const result = await getLineRange(client, {
+      project,
+      title: a.title,
+      start,
+      end,
+    })
+
+    if (a.json || !a.plain) {
+      writeJson(result, { command: "page.line.get", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    for (const line of result.lines) {
+      process.stdout.write(`${line.text}\n`)
+    }
+  },
+})

--- a/src/commands/page/line/replace.ts
+++ b/src/commands/page/line/replace.ts
@@ -21,6 +21,7 @@ import {
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { PageLineError } from "@/core/errors"
 import { lintNotation } from "@/core/notation/lint"
 import { replaceLinesInPage } from "@/core/pages"
 import { RangeSpecError, parseLineSpec } from "@/core/range"
@@ -56,15 +57,6 @@ export const pageLineReplaceCommand = defineCommand({
       type: "string",
       description: "置換内容のファイルパス (- で stdin)",
     },
-    "expect-commit": {
-      type: "string",
-      description: "期待する commitId (楽観ロック用)",
-    },
-    force: {
-      type: "boolean",
-      description: "楽観ロックを無効化して強制上書きする",
-      default: false,
-    },
   },
   async run({ args }) {
     const a = args as WriteCommonArgs &
@@ -75,8 +67,6 @@ export const pageLineReplaceCommand = defineCommand({
         text?: string
         "from-file"?: string
         "allow-unsafe-read": boolean
-        "expect-commit"?: string
-        force: boolean
       }
     checkSandbox("page.line.replace", a)
     const logger = buildLogger(a)
@@ -200,11 +190,7 @@ export const pageLineReplaceCommand = defineCommand({
         previewLines: lines,
       })
     } catch (err) {
-      if (
-        err instanceof Error &&
-        (err.message.startsWith("--range/--line の値が範囲外です") ||
-          err.message.startsWith("タイトル行は編集できません"))
-      ) {
+      if (err instanceof PageLineError) {
         writeErrorJson("VALIDATION_ERROR", err.message)
         process.exit(5)
         return

--- a/src/commands/page/line/replace.ts
+++ b/src/commands/page/line/replace.ts
@@ -1,0 +1,222 @@
+/**
+ * page/line/replace.ts — `cos page line replace <title>` コマンド。
+ *
+ * 指定行 (--line n) または範囲 (--range a:b) を新しい内容で置換する。
+ * --text で直接テキスト指定、--from-file または - で stdin から読み込む。
+ * タイトル行 (1行目) は置換不可。範囲外は VALIDATION_ERROR (exit 5) で終了する。
+ */
+
+import {
+  type StrictNotationArg,
+  type WriteCommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildWriter,
+  checkSandbox,
+  commonArgs,
+  dryRunArg,
+  isStdinPath,
+  notationFindingToWarning,
+  requireProject,
+  strictNotationArg,
+  unsafeReadArg,
+} from "@/commands/_shared"
+import { lintNotation } from "@/core/notation/lint"
+import { replaceLinesInPage } from "@/core/pages"
+import { RangeSpecError, parseLineSpec } from "@/core/range"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageLineReplaceCommand = defineCommand({
+  meta: { name: "replace", description: "指定行または範囲を置換する" },
+  args: {
+    ...commonArgs,
+    ...dryRunArg,
+    ...strictNotationArg,
+    ...unsafeReadArg,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    line: {
+      type: "string",
+      description: "置換する行番号 (1-indexed、タイトル行=1)",
+    },
+    range: {
+      type: "string",
+      description: "置換する行範囲 (例: 3:7)",
+    },
+    text: {
+      type: "string",
+      description: "置換内容 (複数行は \\n で区切る)",
+    },
+    "from-file": {
+      type: "string",
+      description: "置換内容のファイルパス (- で stdin)",
+    },
+    "expect-commit": {
+      type: "string",
+      description: "期待する commitId (楽観ロック用)",
+    },
+    force: {
+      type: "boolean",
+      description: "楽観ロックを無効化して強制上書きする",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as WriteCommonArgs &
+      StrictNotationArg & {
+        title: string
+        line?: string
+        range?: string
+        text?: string
+        "from-file"?: string
+        "allow-unsafe-read": boolean
+        "expect-commit"?: string
+        force: boolean
+      }
+    checkSandbox("page.line.replace", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // --line / --range パース
+    let start: number
+    let end: number
+    try {
+      const spec = parseLineSpec({
+        ...(a.line !== undefined && { line: a.line }),
+        ...(a.range !== undefined && { range: a.range }),
+      })
+      start = spec.start
+      end = spec.end
+    } catch (err) {
+      if (err instanceof RangeSpecError) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
+    }
+
+    // --text / --from-file 排他チェック
+    const hasText = a.text !== undefined
+    const hasFile = a["from-file"] !== undefined
+
+    if (hasText && hasFile) {
+      writeErrorJson("VALIDATION_ERROR", "--text と --from-file を同時に指定することはできません")
+      process.exit(5)
+      return
+    }
+
+    if (!hasText && !hasFile) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "置換内容が指定されていません",
+        "--text または --from-file でコンテンツを指定してください",
+      )
+      process.exit(5)
+      return
+    }
+
+    // 行内容の読み込み
+    let lines: string[] = []
+    if (hasText) {
+      lines = (a.text as string).split(/\r?\n|\\n/)
+    } else {
+      const filePath = a["from-file"] as string
+      if (isStdinPath(filePath)) {
+        try {
+          const content = readStdinBounded()
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            writeErrorJson("UNSAFE_PATH", err.message)
+            process.exit(5)
+            return
+          }
+          throw err
+        }
+      } else {
+        try {
+          const content = readFromFile(filePath, { allowUnsafe: a["allow-unsafe-read"] })
+          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+        } catch (err) {
+          if (err instanceof UnsafePathError) {
+            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+            process.exit(5)
+            return
+          }
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `ファイルの読み込みに失敗しました: "${filePath}"`,
+            "ファイルパスが正しいか確認してください",
+          )
+          process.exit(5)
+          return
+        }
+      }
+    }
+
+    if (lines.length === 0) {
+      writeErrorJson(
+        "CONTENT_REQUIRED",
+        "置換内容が空です",
+        "--text または --from-file でコンテンツを指定してください",
+      )
+      process.exit(5)
+      return
+    }
+
+    // Cosense 記法の lint 検査
+    const findings = lintNotation(lines)
+    const warnings = findings.map(notationFindingToWarning)
+
+    if (a["strict-notation"] && findings.length > 0) {
+      writeErrorJson(
+        "NOTATION_LINT",
+        `Cosense 記法の問題が ${findings.length} 件あります`,
+        "--strict-notation を外すと警告のみで実行できます",
+        { findings },
+      )
+      process.exit(5)
+      return
+    }
+
+    logger.info(`"${a.title}" の ${start}〜${end} 行目を置換中...`)
+
+    const writer = await buildWriter(a)
+    let result: Awaited<ReturnType<typeof replaceLinesInPage>> | undefined
+    try {
+      result = await replaceLinesInPage(writer, {
+        project,
+        title: a.title,
+        start,
+        end,
+        lines,
+        previewLines: lines,
+      })
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        (err.message.startsWith("--range/--line の値が範囲外です") ||
+          err.message.startsWith("タイトル行は編集できません"))
+      ) {
+        writeErrorJson("VALIDATION_ERROR", err.message)
+        process.exit(5)
+        return
+      }
+      throw err
+    }
+
+    if (a.json || a["dry-run"]) {
+      writeJson(result, { command: "page.line.replace", startTime, warnings }, buildJsonOpts(a))
+      return
+    }
+
+    logger.success(`ページ "${a.title}" の ${start}〜${end} 行目を置換しました`)
+  },
+})

--- a/src/commands/page/line/replace.ts
+++ b/src/commands/page/line/replace.ts
@@ -121,7 +121,7 @@ export const pageLineReplaceCommand = defineCommand({
       if (isStdinPath(filePath)) {
         try {
           const content = readStdinBounded()
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+          lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
         } catch (err) {
           if (err instanceof UnsafePathError) {
             writeErrorJson("UNSAFE_PATH", err.message)
@@ -133,7 +133,7 @@ export const pageLineReplaceCommand = defineCommand({
       } else {
         try {
           const content = readFromFile(filePath, { allowUnsafe: a["allow-unsafe-read"] })
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
+          lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
         } catch (err) {
           if (err instanceof UnsafePathError) {
             writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -5,6 +5,20 @@
  */
 
 /**
+ * PageLineError はページ行操作のバリデーションエラー。
+ *
+ * `replaceLinesInPage` / `deleteLinesFromPage` でタイトル行への操作や
+ * 範囲外アクセスが発生した場合に throw する。
+ * コマンド層が VALIDATION_ERROR (exit 5) にマップする。
+ */
+export class PageLineError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "PageLineError"
+  }
+}
+
+/**
  * CommitConflictError は楽観ロック競合を表すエラー。
  *
  * `page edit` 等で他者がページを更新したことを検知した場合に throw する。

--- a/src/core/page-line.ts
+++ b/src/core/page-line.ts
@@ -17,6 +17,8 @@ import type { Line } from "@/schemas/page"
  * @returns { start, end, lines } — 指定範囲の行データ
  * @throws Error end > ページ行数 の場合
  * @throws NotFoundError ページが存在しない場合
+ * @remarks start <= end は parseLineSpec により呼び出し側で保証される前提。
+ *   end チェックで start の範囲外も間接的にカバーされる。
  */
 export async function getLineRange(
   client: CosenseRestClient,

--- a/src/core/page-line.ts
+++ b/src/core/page-line.ts
@@ -1,0 +1,35 @@
+/**
+ * page-line.ts — ページの行取得 (読み取り専用)。
+ *
+ * `getLineRange` は REST 経由でページを取得し、指定行範囲 (1-indexed) の
+ * 行データのみを返す。書き込みは行わない。
+ */
+
+import type { CosenseRestClient } from "@/core/api/rest"
+import type { Line } from "@/schemas/page"
+
+/**
+ * getLineRange は REST 経由でページを取得し、指定行範囲の Line[] を返す。
+ *
+ * @param client - REST クライアント
+ * @param opts.start - 開始行 (1-indexed)
+ * @param opts.end - 終了行 (1-indexed, 両端含む)
+ * @returns { start, end, lines } — 指定範囲の行データ
+ * @throws Error end > ページ行数 の場合
+ * @throws NotFoundError ページが存在しない場合
+ */
+export async function getLineRange(
+  client: CosenseRestClient,
+  opts: { project: string; title: string; start: number; end: number },
+): Promise<{ start: number; end: number; lines: Line[] }> {
+  const page = await client.getPage(opts.project, opts.title)
+
+  if (opts.end > page.lines.length) {
+    throw new Error(`--range/--line の値が範囲外です (ページの行数は ${page.lines.length} です)`)
+  }
+
+  // slice は 0-indexed のため start-1 から end まで (end は exclusive)
+  const lines = page.lines.slice(opts.start - 1, opts.end)
+
+  return { start: opts.start, end: opts.end, lines }
+}

--- a/src/core/page-line.ts
+++ b/src/core/page-line.ts
@@ -26,6 +26,16 @@ export async function getLineRange(
 ): Promise<{ start: number; end: number; lines: Line[] }> {
   const page = await client.getPage(opts.project, opts.title)
 
+  if (
+    !Number.isInteger(opts.start) ||
+    !Number.isInteger(opts.end) ||
+    opts.start < 1 ||
+    opts.start > opts.end
+  ) {
+    throw new Error(
+      `--range/--line の値が不正です (1以上の整数で start <= end を満たしてください: start=${opts.start}, end=${opts.end})`,
+    )
+  }
   if (opts.end > page.lines.length) {
     throw new Error(`--range/--line の値が範囲外です (ページの行数は ${page.lines.length} です)`)
   }

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -141,6 +141,73 @@ export async function insertIntoPage(
   })
 }
 
+/**
+ * replaceLinesInPage は指定行範囲を新しい内容で置換する (WebSocket commit)。
+ *
+ * start / end は 1-indexed で両端含む。タイトル行 (start=1) は保護。
+ * end > existing.length の場合は update 関数内で Error を throw する。
+ */
+export async function replaceLinesInPage(
+  writer: ScrapboxWriter,
+  opts: {
+    project: string
+    title: string
+    start: number
+    end: number
+    lines: string[]
+    previewLines?: string[]
+  },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: (existing) => {
+      if (opts.start < 2) {
+        throw new Error("タイトル行は編集できません (start は 2 以上を指定してください)")
+      }
+      if (opts.end > existing.length) {
+        throw new Error(`--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`)
+      }
+      return [
+        existing[0]?.text ?? opts.title,
+        ...existing.slice(1, opts.start - 1).map((l) => l.text),
+        ...opts.lines,
+        ...existing.slice(opts.end).map((l) => l.text),
+      ]
+    },
+    ...(opts.previewLines !== undefined && { previewLines: opts.previewLines }),
+  })
+}
+
+/**
+ * deleteLinesFromPage は指定行範囲を削除する (WebSocket commit)。
+ *
+ * start / end は 1-indexed で両端含む。タイトル行 (start=1) は保護。
+ * end > existing.length の場合は update 関数内で Error を throw する。
+ */
+export async function deleteLinesFromPage(
+  writer: ScrapboxWriter,
+  opts: { project: string; title: string; start: number; end: number },
+) {
+  return writer.patch({
+    project: opts.project,
+    title: opts.title,
+    update: (existing) => {
+      if (opts.start < 2) {
+        throw new Error("タイトル行は編集できません (start は 2 以上を指定してください)")
+      }
+      if (opts.end > existing.length) {
+        throw new Error(`--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`)
+      }
+      return [
+        existing[0]?.text ?? opts.title,
+        ...existing.slice(1, opts.start - 1).map((l) => l.text),
+        ...existing.slice(opts.end).map((l) => l.text),
+      ]
+    },
+  })
+}
+
 /** pinPage はページをピン留めする (WebSocket commit)。 */
 export async function pinPage(
   writer: ScrapboxWriter,

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -7,6 +7,7 @@
 
 import type { CosenseRestClient } from "@/core/api/rest"
 import type { ScrapboxWriter } from "@/core/api/ws"
+import { PageLineError } from "@/core/errors"
 
 /** listPages はプロジェクトのページ一覧を取得する。 */
 export async function listPages(
@@ -163,10 +164,12 @@ export async function replaceLinesInPage(
     title: opts.title,
     update: (existing) => {
       if (opts.start < 2) {
-        throw new Error("タイトル行は編集できません (start は 2 以上を指定してください)")
+        throw new PageLineError("タイトル行は編集できません (start は 2 以上を指定してください)")
       }
       if (opts.end > existing.length) {
-        throw new Error(`--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`)
+        throw new PageLineError(
+          `--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`,
+        )
       }
       return [
         existing[0]?.text ?? opts.title,
@@ -194,10 +197,12 @@ export async function deleteLinesFromPage(
     title: opts.title,
     update: (existing) => {
       if (opts.start < 2) {
-        throw new Error("タイトル行は編集できません (start は 2 以上を指定してください)")
+        throw new PageLineError("タイトル行は編集できません (start は 2 以上を指定してください)")
       }
       if (opts.end > existing.length) {
-        throw new Error(`--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`)
+        throw new PageLineError(
+          `--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`,
+        )
       }
       return [
         existing[0]?.text ?? opts.title,

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -166,6 +166,11 @@ export async function replaceLinesInPage(
       if (opts.start < 2) {
         throw new PageLineError("タイトル行は編集できません (start は 2 以上を指定してください)")
       }
+      if (opts.start > opts.end) {
+        throw new PageLineError(
+          `--range/--line の値が不正です (start <= end を満たしてください: start=${opts.start}, end=${opts.end})`,
+        )
+      }
       if (opts.end > existing.length) {
         throw new PageLineError(
           `--range/--line の値が範囲外です (1〜${existing.length} の行が存在します)`,
@@ -198,6 +203,11 @@ export async function deleteLinesFromPage(
     update: (existing) => {
       if (opts.start < 2) {
         throw new PageLineError("タイトル行は編集できません (start は 2 以上を指定してください)")
+      }
+      if (opts.start > opts.end) {
+        throw new PageLineError(
+          `--range/--line の値が不正です (start <= end を満たしてください: start=${opts.start}, end=${opts.end})`,
+        )
       }
       if (opts.end > existing.length) {
         throw new PageLineError(

--- a/tests/unit/commands/page/line/delete.test.ts
+++ b/tests/unit/commands/page/line/delete.test.ts
@@ -1,0 +1,117 @@
+/**
+ * page/line/delete.test.ts — `cos page line delete <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageLineDeleteCommand } from "@/commands/page/line/delete"
+import * as pages from "@/core/pages"
+
+const capturedDeleteCalls: { start: number; end: number }[] = []
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let deletePageSpy: ReturnType<typeof spyOn>
+
+async function runDelete(args: Record<string, unknown>) {
+  await (
+    pageLineDeleteCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({ args, cmd: {} as never, rawArgs: [] })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  capturedDeleteCalls.splice(0)
+  deletePageSpy = spyOn(pages, "deleteLinesFromPage").mockImplementation(async (_writer, opts) => {
+    capturedDeleteCalls.push({ start: opts.start, end: opts.end })
+    return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
+  })
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  deletePageSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageLineDeleteCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDelete({ title: "テストページ", line: "5" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line と --range 両方未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDelete({ title: "テストページ", project: "プロジェクト" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line と --range 両方指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runDelete({
+        title: "テストページ",
+        line: "5",
+        range: "3:7",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("不正な --range (abc) の場合は exit 5 で終了する", async () => {
+    try {
+      await runDelete({
+        title: "テストページ",
+        range: "abc",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line 5 で deleteLinesFromPage を start=5,end=5 で呼ぶ", async () => {
+    await runDelete({
+      title: "テストページ",
+      line: "5",
+      project: "プロジェクト",
+      "dry-run": false,
+      json: false,
+    })
+    expect(deletePageSpy).toHaveBeenCalledTimes(1)
+    expect(capturedDeleteCalls[0]).toMatchObject({ start: 5, end: 5 })
+  })
+
+  it("--range 3:5 で deleteLinesFromPage を start=3,end=5 で呼ぶ", async () => {
+    await runDelete({
+      title: "テストページ",
+      range: "3:5",
+      project: "プロジェクト",
+      "dry-run": false,
+      json: false,
+    })
+    expect(capturedDeleteCalls[0]).toMatchObject({ start: 3, end: 5 })
+  })
+})

--- a/tests/unit/commands/page/line/get.test.ts
+++ b/tests/unit/commands/page/line/get.test.ts
@@ -48,8 +48,8 @@ beforeEach(() => {
   capturedGetCalls.splice(0)
   getLineRangeSpy = spyOn(pageLine, "getLineRange").mockImplementation(async (_client, opts) => {
     capturedGetCalls.push({ start: opts.start, end: opts.end })
-    const count = opts.end - opts.start + 1
-    return { start: opts.start, end: opts.end, lines: sampleLines.slice(0, count) }
+    // 1-indexed の start/end に対応した切り出し (実装と同じロジック)
+    return { start: opts.start, end: opts.end, lines: sampleLines.slice(opts.start - 1, opts.end) }
   })
 })
 
@@ -124,6 +124,7 @@ describe("pageLineGetCommand", () => {
       json: false,
       plain: true,
     })
-    expect(stdoutOutput).toContain("本文1行目")
+    // --line 2 は 2 行目 (本文2行目) のみを返す
+    expect(stdoutOutput).toBe("本文2行目\n")
   })
 })

--- a/tests/unit/commands/page/line/get.test.ts
+++ b/tests/unit/commands/page/line/get.test.ts
@@ -1,0 +1,129 @@
+/**
+ * page/line/get.test.ts — `cos page line get <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageLineGetCommand } from "@/commands/page/line/get"
+import * as pageLine from "@/core/page-line"
+
+const capturedGetCalls: { start: number; end: number }[] = []
+
+/** getLineRange が返すサンプル行データ */
+const sampleLines = [
+  { id: "l1", text: "本文1行目", userId: "u1", created: 0, updated: 0 },
+  { id: "l2", text: "本文2行目", userId: "u1", created: 0, updated: 0 },
+  { id: "l3", text: "本文3行目", userId: "u1", created: 0, updated: 0 },
+]
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let getLineRangeSpy: ReturnType<typeof spyOn>
+
+/** stdout への書き込み内容を蓄積する */
+let stdoutOutput: string
+
+async function runGet(args: Record<string, unknown>) {
+  await (
+    pageLineGetCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({ args, cmd: {} as never, rawArgs: [] })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutOutput = ""
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdoutOutput += typeof chunk === "string" ? chunk : chunk.toString()
+    return true
+  })
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  capturedGetCalls.splice(0)
+  getLineRangeSpy = spyOn(pageLine, "getLineRange").mockImplementation(async (_client, opts) => {
+    capturedGetCalls.push({ start: opts.start, end: opts.end })
+    const count = opts.end - opts.start + 1
+    return { start: opts.start, end: opts.end, lines: sampleLines.slice(0, count) }
+  })
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  getLineRangeSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageLineGetCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runGet({ title: "テストページ", line: "3" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line と --range 両方未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runGet({ title: "テストページ", project: "プロジェクト" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("不正な --range (abc) の場合は exit 5 で終了する", async () => {
+    try {
+      await runGet({
+        title: "テストページ",
+        range: "abc",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line 2 で getLineRange を start=2,end=2 で呼ぶ", async () => {
+    await runGet({
+      title: "テストページ",
+      line: "2",
+      project: "プロジェクト",
+      json: false,
+      plain: true,
+    })
+    expect(getLineRangeSpy).toHaveBeenCalledTimes(1)
+    expect(capturedGetCalls[0]).toMatchObject({ start: 2, end: 2 })
+  })
+
+  it("--range 2:3 で getLineRange を start=2,end=3 で呼ぶ", async () => {
+    await runGet({
+      title: "テストページ",
+      range: "2:3",
+      project: "プロジェクト",
+      json: false,
+      plain: true,
+    })
+    expect(capturedGetCalls[0]).toMatchObject({ start: 2, end: 3 })
+  })
+
+  it("plain モードで各行の text を改行区切りで出力する", async () => {
+    await runGet({
+      title: "テストページ",
+      line: "2",
+      project: "プロジェクト",
+      json: false,
+      plain: true,
+    })
+    expect(stdoutOutput).toContain("本文1行目")
+  })
+})

--- a/tests/unit/commands/page/line/replace.test.ts
+++ b/tests/unit/commands/page/line/replace.test.ts
@@ -1,0 +1,171 @@
+/**
+ * page/line/replace.test.ts — `cos page line replace <title>` コマンドのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import * as fs from "node:fs"
+import { pageLineReplaceCommand } from "@/commands/page/line/replace"
+import * as pages from "@/core/pages"
+
+const capturedReplaceCalls: { start: number; end: number; lines: string[] }[] = []
+const realReadFileSync = fs.readFileSync.bind(fs)
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let readFileSyncSpy: ReturnType<typeof spyOn>
+let replacePageSpy: ReturnType<typeof spyOn>
+
+async function runReplace(args: Record<string, unknown>) {
+  await (
+    pageLineReplaceCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({ args, cmd: {} as never, rawArgs: [] })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  capturedReplaceCalls.splice(0)
+  readFileSyncSpy = spyOn(fs, "readFileSync").mockImplementation(((
+    pathOrFd: number | string,
+    encoding: string,
+  ) => {
+    if (pathOrFd === 0) return "stdin行1\nstdin行2\n"
+    return realReadFileSync(
+      pathOrFd as Parameters<typeof fs.readFileSync>[0],
+      encoding as BufferEncoding,
+    )
+  }) as typeof fs.readFileSync)
+  replacePageSpy = spyOn(pages, "replaceLinesInPage").mockImplementation(async (_writer, opts) => {
+    capturedReplaceCalls.push({ start: opts.start, end: opts.end, lines: opts.lines })
+    return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
+  })
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  readFileSyncSpy.mockRestore()
+  replacePageSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageLineReplaceCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({ title: "テストページ", line: "5", text: "置換行" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line と --range 両方未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({ title: "テストページ", text: "置換行", project: "プロジェクト" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line と --range 両方指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({
+        title: "テストページ",
+        line: "5",
+        range: "3:7",
+        text: "置換行",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--text と --from-file 両方未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({ title: "テストページ", line: "5", project: "プロジェクト" })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--text と --from-file 両方指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({
+        title: "テストページ",
+        line: "5",
+        text: "置換行",
+        "from-file": "test.txt",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("不正な --range (abc) の場合は exit 5 で終了する", async () => {
+    try {
+      await runReplace({
+        title: "テストページ",
+        range: "abc",
+        text: "置換行",
+        project: "プロジェクト",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--line 5 --text '新しい行' で replaceLinesInPage を start=5,end=5 で呼ぶ", async () => {
+    await runReplace({
+      title: "テストページ",
+      line: "5",
+      text: "新しい行",
+      project: "プロジェクト",
+      "dry-run": false,
+      json: false,
+    })
+    expect(replacePageSpy).toHaveBeenCalledTimes(1)
+    expect(capturedReplaceCalls[0]).toMatchObject({ start: 5, end: 5, lines: ["新しい行"] })
+  })
+
+  it("--range 3:5 --text 'A\\nB' で replaceLinesInPage を start=3,end=5,lines=['A','B'] で呼ぶ", async () => {
+    await runReplace({
+      title: "テストページ",
+      range: "3:5",
+      text: "A\\nB",
+      project: "プロジェクト",
+      "dry-run": false,
+      json: false,
+    })
+    expect(capturedReplaceCalls[0]).toMatchObject({ start: 3, end: 5, lines: ["A", "B"] })
+  })
+
+  it("--from-file - で stdin から行を読み込む", async () => {
+    await runReplace({
+      title: "テストページ",
+      line: "3",
+      "from-file": "-",
+      project: "プロジェクト",
+      "dry-run": false,
+      json: false,
+    })
+    expect(capturedReplaceCalls[0]?.lines).toEqual(["stdin行1", "stdin行2"])
+  })
+})

--- a/tests/unit/core/page-line.test.ts
+++ b/tests/unit/core/page-line.test.ts
@@ -1,0 +1,115 @@
+/**
+ * page-line.test.ts — getLineRange の単体テスト。
+ *
+ * REST 経由で指定行範囲のみを取得する純粋読み取り関数の検証。
+ * 実際の HTTP 通信は行わない。
+ */
+
+import { describe, expect, it, mock } from "bun:test"
+import type { CosenseRestClient } from "@/core/api/rest"
+import { NotFoundError } from "@/core/api/rest"
+import { getLineRange } from "@/core/page-line"
+
+/** getPage モックが返す 5 行のサンプルページ */
+const samplePage = {
+  id: "page1",
+  title: "サンプルページ",
+  updated: 1700000000,
+  accessed: 1700000001,
+  views: 10,
+  linked: 2,
+  commitId: "abc",
+  snapshotCreated: null,
+  persistent: true,
+  image: null,
+  pin: 0,
+  pageRank: 0.1,
+  descriptions: [],
+  lines: [
+    { id: "l0", text: "サンプルページ", userId: "u1", created: 0, updated: 0 },
+    { id: "l1", text: "本文1行目", userId: "u1", created: 0, updated: 0 },
+    { id: "l2", text: "本文2行目", userId: "u1", created: 0, updated: 0 },
+    { id: "l3", text: "本文3行目", userId: "u1", created: 0, updated: 0 },
+    { id: "l4", text: "本文4行目", userId: "u1", created: 0, updated: 0 },
+  ],
+  relatedPages: { links1hop: [], links2hop: [], hasBackLinksOrIcons: false },
+  collaborators: [],
+}
+
+function createMockClient(overrides: Partial<CosenseRestClient> = {}): CosenseRestClient {
+  return {
+    getPage: mock(async () => samplePage),
+    ...overrides,
+  } as unknown as CosenseRestClient
+}
+
+describe("getLineRange", () => {
+  it("--line 2 で 2 行目のみを返す", async () => {
+    const client = createMockClient()
+    const result = await getLineRange(client, {
+      project: "テストプロジェクト",
+      title: "サンプルページ",
+      start: 2,
+      end: 2,
+    })
+    // 1-indexed の 2 行目 = lines[1]
+    expect(result.start).toBe(2)
+    expect(result.end).toBe(2)
+    expect(result.lines).toHaveLength(1)
+    expect(result.lines[0]?.text).toBe("本文1行目")
+  })
+
+  it("--range 2:4 で 2-4 行目を返す", async () => {
+    const client = createMockClient()
+    const result = await getLineRange(client, {
+      project: "テストプロジェクト",
+      title: "サンプルページ",
+      start: 2,
+      end: 4,
+    })
+    expect(result.start).toBe(2)
+    expect(result.end).toBe(4)
+    expect(result.lines).toHaveLength(3)
+    expect(result.lines.map((l) => l.text)).toEqual(["本文1行目", "本文2行目", "本文3行目"])
+  })
+
+  it("タイトル行 (start=1) を含む範囲も取得できる", async () => {
+    const client = createMockClient()
+    const result = await getLineRange(client, {
+      project: "テストプロジェクト",
+      title: "サンプルページ",
+      start: 1,
+      end: 2,
+    })
+    expect(result.lines[0]?.text).toBe("サンプルページ")
+    expect(result.lines[1]?.text).toBe("本文1行目")
+  })
+
+  it("end が行数を超える場合は VALIDATION_ERROR をスローする", async () => {
+    const client = createMockClient()
+    await expect(
+      getLineRange(client, {
+        project: "テストプロジェクト",
+        title: "サンプルページ",
+        start: 2,
+        end: 99,
+      }),
+    ).rejects.toThrow("範囲外")
+  })
+
+  it("ページが存在しない場合は NotFoundError をスローする", async () => {
+    const client = createMockClient({
+      getPage: mock(async () => {
+        throw new NotFoundError("ページが見つかりません")
+      }),
+    })
+    await expect(
+      getLineRange(client, {
+        project: "テストプロジェクト",
+        title: "存在しないページ",
+        start: 1,
+        end: 1,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+})

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -11,6 +11,7 @@ import type { ScrapboxWriter } from "@/core/api/ws"
 import {
   appendToPage,
   createPage,
+  deleteLinesFromPage,
   deletePage,
   editPage,
   getCodeBlock,
@@ -21,6 +22,7 @@ import {
   pinPage,
   prependToPage,
   renamePage,
+  replaceLinesInPage,
   unpinPage,
 } from "@/core/pages"
 
@@ -415,6 +417,185 @@ describe("insertIntoPage", () => {
       { id: "l2", text: "本文", userId: "u1", created: 0, updated: 0 },
     ]
     expect(() => capturedUpdate?.(existingLines)).toThrow("範囲外")
+  })
+})
+
+/** update 関数をキャプチャするライター生成ヘルパー */
+function createUpdateCapturingWriter() {
+  let capturedUpdate:
+    | ((
+        lines: { id: string; text: string; userId: string; created: number; updated: number }[],
+      ) => string[] | Promise<string[]>)
+    | undefined
+  const writer = createMockWriter({
+    patch: mock(async (opts) => {
+      capturedUpdate = opts.update
+      return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
+    }),
+  })
+  return { writer, getUpdate: () => capturedUpdate }
+}
+
+/** 5 行のサンプルページ (タイトル + 4 行の本文) */
+const sampleLines = [
+  { id: "l0", text: "サンプルページ", userId: "u1", created: 0, updated: 0 },
+  { id: "l1", text: "本文1行目", userId: "u1", created: 0, updated: 0 },
+  { id: "l2", text: "本文2行目", userId: "u1", created: 0, updated: 0 },
+  { id: "l3", text: "本文3行目", userId: "u1", created: 0, updated: 0 },
+  { id: "l4", text: "本文4行目", userId: "u1", created: 0, updated: 0 },
+]
+
+describe("replaceLinesInPage", () => {
+  it("単一行 (start=end=3) を置換する", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 3,
+      end: 3,
+      lines: ["置換後3行目"],
+    })
+    const result = await getUpdate()?.(sampleLines)
+    // 3行目が置換され、他の行は変わらない
+    expect(result).toEqual(["サンプルページ", "本文1行目", "置換後3行目", "本文3行目", "本文4行目"])
+  })
+
+  it("範囲 (start=2, end=3) を 2 行で置換する (行数同等)", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 3,
+      lines: ["置換A", "置換B"],
+    })
+    const result = await getUpdate()?.(sampleLines)
+    expect(result).toEqual(["サンプルページ", "置換A", "置換B", "本文3行目", "本文4行目"])
+  })
+
+  it("1 行を 2 行に置換する (行数増加)", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 2,
+      lines: ["増加A", "増加B"],
+    })
+    const result = await getUpdate()?.(sampleLines)
+    expect(result).toEqual([
+      "サンプルページ",
+      "増加A",
+      "増加B",
+      "本文2行目",
+      "本文3行目",
+      "本文4行目",
+    ])
+  })
+
+  it("3 行を 1 行に置換する (行数減少)", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 4,
+      lines: ["凝縮行"],
+    })
+    const result = await getUpdate()?.(sampleLines)
+    expect(result).toEqual(["サンプルページ", "凝縮行", "本文4行目"])
+  })
+
+  it("end が行数を超える場合は update 関数が例外をスローする", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 99,
+      lines: ["行"],
+    })
+    expect(() => getUpdate()?.(sampleLines)).toThrow("範囲外")
+  })
+
+  it("start=1 (タイトル行) の場合は update 関数が例外をスローする", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 1,
+      end: 1,
+      lines: ["タイトル変更試み"],
+    })
+    expect(() => getUpdate()?.(sampleLines)).toThrow("タイトル行")
+  })
+
+  it("previewLines として新しい行を渡す", async () => {
+    let capturedPreviewLines: string[] | undefined
+    const writer = createMockWriter({
+      patch: mock(async (opts) => {
+        capturedPreviewLines = opts.previewLines
+        return { commitId: "replace-commit", pageId: "page1" }
+      }),
+    })
+    await replaceLinesInPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 2,
+      lines: ["新しい行"],
+      previewLines: ["新しい行"],
+    })
+    expect(capturedPreviewLines).toEqual(["新しい行"])
+  })
+})
+
+describe("deleteLinesFromPage", () => {
+  it("単一行 (start=end=3) を削除する", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await deleteLinesFromPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 3,
+      end: 3,
+    })
+    const result = await getUpdate()?.(sampleLines)
+    // 3行目が削除され、他の行は変わらない
+    expect(result).toEqual(["サンプルページ", "本文1行目", "本文3行目", "本文4行目"])
+  })
+
+  it("範囲 (start=2, end=4) を削除する", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await deleteLinesFromPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 4,
+    })
+    const result = await getUpdate()?.(sampleLines)
+    expect(result).toEqual(["サンプルページ", "本文4行目"])
+  })
+
+  it("end が行数を超える場合は update 関数が例外をスローする", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await deleteLinesFromPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 2,
+      end: 99,
+    })
+    expect(() => getUpdate()?.(sampleLines)).toThrow("範囲外")
+  })
+
+  it("start=1 (タイトル行) の場合は update 関数が例外をスローする", async () => {
+    const { writer, getUpdate } = createUpdateCapturingWriter()
+    await deleteLinesFromPage(writer, {
+      project: "proj",
+      title: "サンプルページ",
+      start: 1,
+      end: 2,
+    })
+    expect(() => getUpdate()?.(sampleLines)).toThrow("タイトル行")
   })
 })
 


### PR DESCRIPTION
## Summary

- `cos page line replace <title> --line N --text "..."` で指定行を置換
- `cos page line delete <title> --range a:b` で指定行範囲を削除
- `cos page line get <title> --line N` で指定行を取得 (読み取り専用)
- `--line N` (単行) と `--range a:b` (範囲) に対応
- `--text` と `--from-file` (stdin含む) の両入力方式に対応
- タイトル行 (行番号=1) は置換・削除不可、違反時は exit 5

## Test plan

- [x] `bun test tests/unit/commands/page/line/` — 21 件全 pass
- [x] `bun test tests/unit/core/page-line.test.ts` — 全 pass
- [x] `bun test tests/unit/core/pages.test.ts` — replaceLinesInPage / deleteLinesFromPage を追加検証
- [x] `bunx biome check src tests` — 警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ
- [x] `bun test` — 1053 pass / 0 fail

Refs #116 (PR1 の基盤を使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **New Features**
  * ページ行操作の3つの新しいサブコマンドを追加: `page line delete`、`page line get`、`page line replace` により、単一行または行範囲を指定しての削除・取得・置換が可能に
  * 各コマンドで `--line` (単一行)、`--range` (行範囲)、`--json` 出力をサポート

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->