### PR TITLE
feat(page/edit): 楽観ロックを有効化し --force / --expect-commit フラグを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,20 @@ cos page new --project myproject --title "新しいページ" --body "本文"
 ## コマンド一覧
 
 ```
-cos page list     ページ一覧を取得
-cos page get      ページ本文を取得
-cos page text     ページのテキスト (コードブロックなし) を取得
-cos page context  ページ起点の Smart Context (リンク先本文) を取得
-cos page code     ページのコードブロックを取得
-cos page url      ページの URL を表示
-cos page new      ページを作成
-cos page edit     ページを編集
-cos page append   ページ末尾に行を追記
-cos page delete   ページを削除
+cos page list           ページ一覧を取得
+cos page get            ページ本文を取得
+cos page text           ページのテキスト (コードブロックなし) を取得
+cos page context        ページ起点の Smart Context (リンク先本文) を取得
+cos page code           ページのコードブロックを取得
+cos page url            ページの URL を表示
+cos page new            ページを作成
+cos page edit           ページを編集 (楽観ロック付き)
+cos page append         ページ末尾に行を追記
+cos page delete         ページを削除
+
+cos page line get       指定行または範囲を取得
+cos page line replace   指定行または範囲を置換 (rm エイリアスあり)
+cos page line delete    指定行または範囲を削除
 
 cos project list  参加プロジェクト一覧を取得
 cos project info  プロジェクト情報を取得
@@ -170,6 +174,22 @@ cos page text "ページタイトル" --format=md --bold-style=heading
 
 ```bash
 cos page edit "ページタイトル" --from-file page.md --input-format=md
+```
+
+> **v0.4.0 非互換変更**: `page edit` はデフォルトで楽観ロックを有効化しました。
+> 編集中に他者がページを更新した場合は **exit 6** で停止します。
+> 従来の上書き挙動に戻すには `--force` を指定してください。
+
+```bash
+# デフォルト: 競合を検知したら exit 6 で停止する
+cos page edit "ページタイトル" --from-file new-content.txt
+
+# --force: 他者の編集を上書きする (従来挙動)
+cos page edit "ページタイトル" --from-file new-content.txt --force
+
+# --expect-commit: 取得時の commitId を指定して、ページが変わっていれば止める
+COMMIT=$(cos page get "ページタイトル" --json | jq -r '.result.commitId')
+cos page edit "ページタイトル" --from-file new-content.txt --expect-commit "$COMMIT"
 ```
 
 ### ページ本文のラウンドトリップ (取得→編集)

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -5,6 +5,9 @@
  * --from-file でファイルから、- で stdin から新しい本文を読み込む。
  * --input-format=md を指定すると Markdown ファイルを Scrapbox 記法に変換して書き込む。
  * --dry-run で変更内容のプレビューのみ表示する。
+ *
+ * デフォルトで楽観ロックが有効。編集中に他者がページを更新した場合は exit 6 で停止する。
+ * --force で従来の上書き挙動に戻す。--expect-commit で期待 commitId を明示指定できる。
  */
 
 import {
@@ -22,6 +25,7 @@ import {
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
+import { CommitConflictError } from "@/core/errors"
 import { convert } from "@/core/format/index"
 import { lintNotation } from "@/core/notation/lint"
 import { editPage } from "@/core/pages"
@@ -53,6 +57,15 @@ export const pageEditCommand = defineCommand({
       description: "入力ファイルのフォーマット (txt | md)",
       default: "txt",
     },
+    force: {
+      type: "boolean",
+      description: "楽観ロックを無効化して上書きする (競合時も続行)",
+      default: false,
+    },
+    "expect-commit": {
+      type: "string",
+      description: "期待する commitId (不一致なら exit 6 で停止)",
+    },
   },
   async run({ args }) {
     const a = args as WriteCommonArgs &
@@ -61,6 +74,8 @@ export const pageEditCommand = defineCommand({
         "from-file": string
         "input-format": string
         "allow-unsafe-read": boolean
+        force: boolean
+        "expect-commit"?: string
       }
     checkSandbox("page.edit", a)
     const logger = buildLogger(a)
@@ -137,7 +152,23 @@ export const pageEditCommand = defineCommand({
     logger.info(`"${a.title}" を編集中...`)
 
     const writer = await buildWriter(a)
-    const result = await editPage(writer, { project, title: a.title, lines })
+    let result: Awaited<ReturnType<typeof editPage>>
+    try {
+      result = await editPage(writer, {
+        project,
+        title: a.title,
+        lines,
+        force: a.force,
+        ...(a["expect-commit"] !== undefined && { expectCommitId: a["expect-commit"] }),
+      })
+    } catch (err) {
+      if (err instanceof CommitConflictError) {
+        writeErrorJson("CONFLICT", err.message)
+        process.exit(6)
+        return
+      }
+      throw err
+    }
 
     if (a.json || a["dry-run"]) {
       writeJson(result, { command: "page.edit", startTime, warnings }, buildJsonOpts(a))

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -7,7 +7,7 @@
 
 import type { CosenseRestClient } from "@/core/api/rest"
 import type { ScrapboxWriter } from "@/core/api/ws"
-import { PageLineError } from "@/core/errors"
+import { CommitConflictError, PageLineError } from "@/core/errors"
 
 /** listPages はプロジェクトのページ一覧を取得する。 */
 export async function listPages(
@@ -72,15 +72,48 @@ export async function appendToPage(
   })
 }
 
-/** editPage はページの内容を全置換する (WebSocket commit)。 */
+/**
+ * editPage はページの内容を全置換する (WebSocket commit)。
+ *
+ * デフォルトで楽観ロックを有効化する。`metadata.attempts > 0` は @cosense/std が
+ * リトライを発生させたことを示し、他者の編集と競合したとみなして CommitConflictError を throw する。
+ * `--force` を指定すると楽観ロックを無効化して上書きを許可する。
+ * `expectCommitId` を指定すると、サーバーの現在の commitId と一致しない場合も CommitConflictError を throw する。
+ */
 export async function editPage(
   writer: ScrapboxWriter,
-  opts: { project: string; title: string; lines: string[] },
+  opts: {
+    project: string
+    title: string
+    lines: string[]
+    /** true の場合、楽観ロックを無効化して上書きを許可する。 */
+    force?: boolean
+    /** 期待する commitId。サーバーの値と不一致の場合に CommitConflictError を throw する。 */
+    expectCommitId?: string
+  },
 ) {
   return writer.patch({
     project: opts.project,
     title: opts.title,
-    update: () => [opts.title, ...opts.lines],
+    update: (_existing, meta) => {
+      if (!opts.force) {
+        // リトライが発生した = 他者がページを更新した
+        if (meta && meta.attempts > 0) {
+          throw new CommitConflictError(
+            `編集中に他者がページを更新しました (attempts=${meta.attempts})`,
+          )
+        }
+        // 明示的な commitId チェック
+        if (opts.expectCommitId && meta?.commitId && meta.commitId !== opts.expectCommitId) {
+          throw new CommitConflictError(
+            `期待 commit ${opts.expectCommitId} と現在 ${meta.commitId} が異なります`,
+            opts.expectCommitId,
+            meta.commitId,
+          )
+        }
+      }
+      return [opts.title, ...opts.lines]
+    },
     previewLines: opts.lines,
   })
 }

--- a/tests/unit/commands/page/edit.test.ts
+++ b/tests/unit/commands/page/edit.test.ts
@@ -2,7 +2,8 @@
  * page/edit.test.ts — `cos page edit <title>` コマンドのテスト。
  *
  * バリデーション (--input-format の無効値、空コンテンツ) と
- * Cosense 記法 lint 統合 (warnings / --strict-notation) を検証する。
+ * Cosense 記法 lint 統合 (warnings / --strict-notation) および
+ * 楽観ロック (CommitConflictError → exit 6 / --force / --expect-commit) を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -10,9 +11,12 @@ import { writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pageEditCommand } from "@/commands/page/edit"
+import { CommitConflictError } from "@/core/errors"
+import * as pages from "@/core/pages"
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
+let editPageSpy: ReturnType<typeof spyOn> | undefined
 
 async function runEdit(args: Record<string, unknown>) {
   await (
@@ -37,6 +41,8 @@ beforeEach(() => {
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
+  editPageSpy?.mockRestore()
+  editPageSpy = undefined
   Reflect.deleteProperty(process.env, "COS_SID")
 })
 
@@ -180,6 +186,64 @@ describe("pageEditCommand", () => {
       expect(exitMock).toHaveBeenCalledWith(5)
       const out = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
       expect(out).toContain("NOTATION_LINT")
+    })
+  })
+
+  describe("楽観ロック", () => {
+    /** 楽観ロックテスト用の共通 args (--dry-run は使わず editPage をモックする) */
+    function makeConflictArgs(extra: Record<string, unknown> = {}) {
+      const tmpFile = join(tmpdir(), `cos-test-edit-conflict-${Date.now()}.txt`)
+      writeFileSync(tmpFile, "テスト本文\n")
+      return {
+        title: "テストページ",
+        "from-file": tmpFile,
+        "input-format": "txt",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        "strict-notation": false,
+        quiet: false,
+        ...extra,
+      }
+    }
+
+    it("editPage が CommitConflictError をスローした場合は exit 6 で終了する", async () => {
+      // editPage をモックして CommitConflictError を投げさせる
+      editPageSpy = spyOn(pages, "editPage").mockImplementation(async () => {
+        throw new CommitConflictError("編集中に他者がページを更新しました (attempts=1)")
+      })
+      try {
+        await runEdit(makeConflictArgs())
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(6)
+      const out = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(out).toContain("CONFLICT")
+    })
+
+    it("--force を指定した場合は editPage が force: true で呼ばれる", async () => {
+      // --force 時は楽観ロックを無効化して呼び出すこと
+      const capturedForce: (boolean | undefined)[] = []
+      editPageSpy = spyOn(pages, "editPage").mockImplementation(async (_writer, opts) => {
+        capturedForce.push(opts.force)
+        return { commitId: "コミット", pageId: "ページ" }
+      })
+      await runEdit(makeConflictArgs({ force: true }))
+      expect(capturedForce[0]).toBe(true)
+    })
+
+    it("--expect-commit を指定した場合は editPage が expectCommitId 付きで呼ばれる", async () => {
+      // --expect-commit で指定した commitId が editPage に伝播すること
+      const capturedExpectCommitId: (string | undefined)[] = []
+      editPageSpy = spyOn(pages, "editPage").mockImplementation(async (_writer, opts) => {
+        capturedExpectCommitId.push(opts.expectCommitId)
+        return { commitId: "コミット", pageId: "ページ" }
+      })
+      await runEdit(makeConflictArgs({ "expect-commit": "abc123" }))
+      expect(capturedExpectCommitId[0]).toBe("abc123")
     })
   })
 })

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -7,7 +7,8 @@
 
 import { describe, expect, it, mock } from "bun:test"
 import type { CosenseRestClient } from "@/core/api/rest"
-import type { ScrapboxWriter } from "@/core/api/ws"
+import type { PatchMetadata, ScrapboxWriter } from "@/core/api/ws"
+import { CommitConflictError } from "@/core/errors"
 import {
   appendToPage,
   createPage,
@@ -199,6 +200,18 @@ describe("getCodeBlock", () => {
   })
 })
 
+/** update クロージャを実際に呼び出すモックライター生成ヘルパー */
+function createMetadataInvokingWriter(metadata: PatchMetadata) {
+  const writer = createMockWriter({
+    patch: mock(async (opts) => {
+      // @cosense/std の retry 動作をシミュレートするため update を metadata 付きで呼び出す
+      await opts.update([], metadata)
+      return { commitId: "更新後コミット", pageId: "page1" }
+    }),
+  })
+  return writer
+}
+
 describe("editPage", () => {
   it("Writer の patch を呼んでページを全置換する", async () => {
     const writer = createMockWriter()
@@ -216,6 +229,57 @@ describe("editPage", () => {
     })
     await editPage(writer, { project: "proj", title: "既存ページ", lines: ["新しい内容"] })
     expect(capturedPreviewLines).toEqual(["新しい内容"])
+  })
+
+  it("force: false (デフォルト), attempts: 0 の場合は正常に完了する", async () => {
+    // リトライなし (attempts=0) は競合なしとみなして正常終了すること
+    const writer = createMetadataInvokingWriter({ attempts: 0, commitId: "コミット" })
+    await expect(
+      editPage(writer, { project: "proj", title: "ページ", lines: ["内容"] }),
+    ).resolves.toMatchObject({ commitId: "更新後コミット" })
+  })
+
+  it("force: false, attempts: 1 の場合は CommitConflictError をスローする (楽観ロック)", async () => {
+    // attempts=1 は他者がページを更新してリトライが発生したことを示す → CommitConflictError
+    const writer = createMetadataInvokingWriter({ attempts: 1, commitId: "競合コミット" })
+    await expect(
+      editPage(writer, { project: "proj", title: "ページ", lines: ["内容"], force: false }),
+    ).rejects.toBeInstanceOf(CommitConflictError)
+  })
+
+  it("force: true, attempts: 1 の場合は CommitConflictError をスローしない (上書き許可)", async () => {
+    // --force 時は楽観ロックを無効化して上書きを許可する
+    const writer = createMetadataInvokingWriter({ attempts: 1, commitId: "競合コミット" })
+    await expect(
+      editPage(writer, { project: "proj", title: "ページ", lines: ["内容"], force: true }),
+    ).resolves.toMatchObject({ commitId: "更新後コミット" })
+  })
+
+  it("expectCommitId が一致する場合は正常に完了する", async () => {
+    // --expect-commit で指定した commitId とサーバーの commitId が一致 → 正常
+    const writer = createMetadataInvokingWriter({ attempts: 0, commitId: "期待コミット" })
+    await expect(
+      editPage(writer, {
+        project: "proj",
+        title: "ページ",
+        lines: ["内容"],
+        expectCommitId: "期待コミット",
+      }),
+    ).resolves.toMatchObject({ commitId: "更新後コミット" })
+  })
+
+  it("expectCommitId が不一致の場合は CommitConflictError をスローする", async () => {
+    // --expect-commit の値とサーバーの commitId が不一致 → CommitConflictError
+    const writer = createMetadataInvokingWriter({ attempts: 0, commitId: "実際のコミット" })
+    const err = await editPage(writer, {
+      project: "proj",
+      title: "ページ",
+      lines: ["内容"],
+      expectCommitId: "期待コミット",
+    }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(CommitConflictError)
+    expect((err as CommitConflictError).expectedCommitId).toBe("期待コミット")
+    expect((err as CommitConflictError).actualCommitId).toBe("実際のコミット")
   })
 })
 


### PR DESCRIPTION
## Summary

- `page edit` のデフォルト挙動を楽観ロックで保護: `metadata.attempts > 0`（@cosense/std のリトライ = 他者が更新したことを検知）→ `CommitConflictError` → exit 6
- `--expect-commit <id>`: 取得時の commitId と現在値が不一致なら exit 6 で停止
- `--force`: 楽観ロックを無効化し、従来の上書き挙動を復元
- README にコマンド一覧（`page line *`）と楽観ロックの使い方セクションを追記

## BREAKING CHANGE

**v0.4.0 非互換変更**: `page edit` はデフォルトで競合時に exit 6 で停止します。

| 変更前 | 変更後 |
|---|---|
| 常に上書き | 競合を検知したら exit 6 で停止 |

従来の挙動に戻す: `cos page edit <title> --from-file content.txt --force`

## Test plan

- [x] `pages.test.ts`: `force:false/attempts:1` → `CommitConflictError` / `force:true` → 正常 / `expectCommitId` 一致/不一致
- [x] `edit.test.ts`: `CommitConflictError` → exit 6 / `--force` / `--expect-commit` 伝播
- [x] `bun run typecheck` 型エラーゼロ
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun test` 1061 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)