### PR TITLE
refactor(sandbox): permission モデルを簡潔な設計に刷新する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,18 @@ src/
 - 両方指定時: enable で絞ってから disable で削る
 - 違反時: exit 7 (PolicyDenied)、stderr に `[denied] <command> is disabled by policy`
 
+config 経由の設定:
+- `agent.defaultEnableCommands`: グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)
+- `agent.defaultDisableCommands`: グローバルで禁止するコマンドリスト
+- `agent.defaultProjectPermission`: 未列挙プロジェクトへの既定権限 (`"read"` / `"readwrite"` / `"none"`)
+- `projects.<name>.enableCommands` / `disableCommands`: プロジェクト固有設定 (グローバルを完全上書き)
+
+優先順位: CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有 > `defaultProjectPermission` > グローバル既定
+
+プロジェクト名解決: `args.project` > `COS_PROJECT` 環境変数 (config.defaultProject はフォールバックとして使用しない)
+
+コマンド分類: `src/core/command-classification.ts` で read/write を一元管理
+
 ## 終了コード
 
 機械可読な一覧は `cos exit-codes --json` で取得できます（単一ソース: `src/core/exit-codes.ts`）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,12 +104,14 @@ src/
 - 違反時: exit 7 (PolicyDenied)、stderr に `[denied] <command> is disabled by policy`
 
 config 経由の設定:
-- `agent.defaultEnableCommands`: グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)
-- `agent.defaultDisableCommands`: グローバルで禁止するコマンドリスト
-- `agent.defaultProjectPermission`: 未列挙プロジェクトへの既定権限 (`"read"` / `"readwrite"` / `"none"`)
-- `projects.<name>.enableCommands` / `disableCommands`: プロジェクト固有設定 (グローバルを完全上書き)
+- `disableCommands`: 全プロジェクト共通の絶対禁止コマンドリスト (CLI フラグで上書き可能)
+- `defaultPermission`: 未列挙プロジェクトへの既定権限 (`"read"` / `"readwrite"` / `"none"`、プロジェクト指定時のみ有効)
+- `projects.<name>.permission`: プロジェクト固有の権限プリセット
+- `projects.<name>.enableCommands` / `disableCommands`: プロジェクト固有の細かい制御
 
-優先順位: CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有 > `defaultProjectPermission` > グローバル既定
+優先順位: CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有設定 > `defaultPermission` > 全許可
+
+`disableCommands` はプロジェクト設定の後に重ねて適用 (CLI/env 指定時は無視)。
 
 プロジェクト名解決: `args.project` > `COS_PROJECT` 環境変数 (config.defaultProject はフォールバックとして使用しない)
 

--- a/README.md
+++ b/README.md
@@ -294,13 +294,125 @@ cos auth login --no-input --sid "$COS_SID"
 
 ## 設定
 
-設定ファイルは JSON5 形式です。`cos config path` でパスを確認できます。
+### 設定ファイルの場所
+
+設定ファイルは **JSON5 形式** (コメント・末尾カンマ可) です。
+
+| OS | デフォルトパス |
+|---|---|
+| macOS / Linux | `~/.config/coscli/config.json5` |
+| XDG 環境 | `$XDG_CONFIG_HOME/coscli/config.json5` |
+
+```bash
+cos config path          # 現在の設定ファイルパスを確認
+cos config get <key>     # 設定値を取得
+cos config set <key> <value>  # 設定値を保存
+```
+
+### 設定リファレンス
+
+#### 基本設定
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `defaultProject` | string | `--project` 省略時のデフォルトプロジェクト名 |
+| `defaultProfile` | string | 認証プロファイル名 (未設定: `"default"`) |
+
+#### 出力設定 (`output`)
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `output.color` | `"auto"` \| `"always"` \| `"never"` | カラー出力モード (未設定: `"auto"`) |
+| `output.json` | boolean | 常に `--json` を有効にする |
+| `output.plain` | boolean | 常に `--plain` を有効にする |
+
+#### sandbox / エージェント設定 (`agent`)
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `agent.defaultEnableCommands` | string[] | グローバルで許可するコマンド (CLI/環境変数未指定時のデフォルト) |
+| `agent.defaultDisableCommands` | string[] | グローバルで禁止するコマンド |
+| `agent.defaultProjectPermission` | `"read"` \| `"readwrite"` \| `"none"` | `projects` に未列挙のプロジェクトへの既定権限 |
+| `agent.maxChangesPerCommit` | number | エージェント 1 コミットあたりの最大変更数 |
+
+`defaultProjectPermission` の意味:
+
+| 値 | 効果 |
+|---|---|
+| `"read"` | 読み取り系コマンドのみ許可 (page.get, page.list, search 等) |
+| `"readwrite"` | 全コマンドを許可 |
+| `"none"` | 全コマンドを拒否 |
+
+#### プロジェクト固有設定 (`projects.<name>`)
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `projects.<name>.defaultSort` | string | ページ一覧のデフォルトソート順 |
+| `projects.<name>.defaultLimit` | number | ページ一覧のデフォルト件数 |
+| `projects.<name>.enableCommands` | string[] | このプロジェクトで許可するコマンド (**グローバル設定を上書き**) |
+| `projects.<name>.disableCommands` | string[] | このプロジェクトで禁止するコマンド (**グローバル設定を上書き**) |
+
+#### 同期設定 (`sync`)
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `sync.dir` | string | ローカル同期ディレクトリ |
+| `sync.format` | `"txt"` | 同期ファイル形式 |
+| `sync.retries` | number (≥0) | 同期失敗時のリトライ回数 |
+
+### 設定例
+
+#### 個人利用 — よく使うプロジェクトを省略する
+
+```bash
+cos config set defaultProject myproject
+cos config set output.color always
+```
+
+これで `--project myproject` を毎回指定しなくてよくなります。
+
+#### AI エージェント向け — コマンドを絞る
+
+AI エージェントに coscli を使わせる際は sandbox 設定で権限を限定できます。
 
 ```json5
+// ~/.config/coscli/config.json5
 {
-  // デフォルトプロジェクト
   defaultProject: "myproject",
+  agent: {
+    // グローバルでは読み取り + ページ作成のみ許可
+    defaultEnableCommands: ["page.get", "page.list", "page.text", "search", "page.new"],
+    // projects に未列挙のプロジェクトは読み取り専用
+    defaultProjectPermission: "read",
+  },
+  projects: {
+    // myproject では全操作を許可し削除だけ禁止
+    myproject: {
+      enableCommands: ["*"],
+      disableCommands: ["page.delete"],
+    },
+    // sandbox プロジェクトはプリセット (read) が適用される
+  },
 }
+```
+
+プロジェクト固有の `enableCommands` / `disableCommands` が存在する場合、`agent.defaultEnableCommands` / `defaultDisableCommands` は**完全に無視**されます。
+
+sandbox の優先順位: **CLI フラグ > 環境変数 > プロジェクト固有設定 > `defaultProjectPermission` > グローバル設定**
+
+#### 設定値を CLI で確認・変更する
+
+```bash
+# 現在の設定を確認
+cos config get defaultProject
+cos config get agent.defaultProjectPermission
+
+# 配列は JSON 形式で渡す
+cos config set agent.defaultEnableCommands '["page.get","page.list","search"]'
+cos config set projects.myproject.disableCommands '["page.delete"]'
+
+# 設定ファイルを直接エディタで開く
+$EDITOR "$(cos config path)"
 ```
 
 ## 終了コード

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ cos config set <key> <value>  # 設定値を保存
 
 | キー | 型 | 説明 |
 |---|---|---|
-| `defaultProject` | string | `--project` 省略時のデフォルトプロジェクト名 |
+| `defaultProject` | string | `--project` 省略時のデフォルトプロジェクト名 (注: sandbox の権限解決では使用されない — `defaultPermission` はプロジェクトを明示指定した場合にのみ適用される) |
 | `defaultProfile` | string | 認証プロファイル名 (未設定: `"default"`) |
 
 #### 出力設定 (`output`)

--- a/README.md
+++ b/README.md
@@ -247,12 +247,40 @@ cos page list --project myproject --json | jq '.results[].title'
 ### sandbox でコマンドを制限
 
 ```bash
-# 読み取りのみ許可
+# 読み取りのみ許可 (CLI フラグ)
 cos --enable-commands "page.list,page.get,page.text,page.code" page list --project myproject
 
-# 削除を禁止
+# 削除を禁止 (CLI フラグ)
 cos --disable-commands "page.delete" page list --project myproject
 ```
+
+設定ファイルで永続化することもできます。
+
+```json5
+{
+  agent: {
+    // グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)
+    defaultEnableCommands: ["page.*", "search", "project.info"],
+    // グローバルで禁止するコマンドリスト
+    defaultDisableCommands: ["page.delete"],
+    // projects に未列挙のプロジェクトへの既定権限
+    // "read": 読み取り系コマンドのみ / "readwrite": 全許可 / "none": 全拒否
+    defaultProjectPermission: "read",
+  },
+  projects: {
+    // プロジェクト固有設定 (存在する場合はグローバル設定を完全に上書き)
+    myproject: {
+      enableCommands: ["*"],
+      disableCommands: ["page.delete"],
+    },
+    "read-only-project": {
+      enableCommands: ["page.get", "page.list", "search"],
+    },
+  },
+}
+```
+
+優先順位: **CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有設定 > `defaultProjectPermission` > グローバル既定**
 
 sandbox 違反時は exit code 7 で終了します。
 

--- a/README.md
+++ b/README.md
@@ -258,29 +258,27 @@ cos --disable-commands "page.delete" page list --project myproject
 
 ```json5
 {
-  agent: {
-    // グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)
-    defaultEnableCommands: ["page.*", "search", "project.info"],
-    // グローバルで禁止するコマンドリスト
-    defaultDisableCommands: ["page.delete"],
-    // projects に未列挙のプロジェクトへの既定権限
-    // "read": 読み取り系コマンドのみ / "readwrite": 全許可 / "none": 全拒否
-    defaultProjectPermission: "read",
-  },
+  // 全プロジェクト共通の絶対禁止コマンド (CLI フラグで上書き可能)
+  disableCommands: ["page.delete"],
+  // projects に未列挙のプロジェクトへの既定権限
+  // "read": 読み取り系コマンドのみ / "readwrite": 全許可 / "none": 全拒否
+  defaultPermission: "read",
   projects: {
-    // プロジェクト固有設定 (存在する場合はグローバル設定を完全に上書き)
+    // プロジェクト固有設定 (defaultPermission を上書き)
     myproject: {
-      enableCommands: ["*"],
-      disableCommands: ["page.delete"],
+      permission: "readwrite",   // このプロジェクトは全許可 (disableCommands は引き続き適用)
     },
-    "read-only-project": {
-      enableCommands: ["page.get", "page.list", "search"],
+    "read-only-wiki": {
+      permission: "read",        // 読み取り専用
+    },
+    "locked-project": {
+      permission: "none",        // 完全ブロック
     },
   },
 }
 ```
 
-優先順位: **CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有設定 > `defaultProjectPermission` > グローバル既定**
+優先順位: **CLI フラグ > 環境変数 (`COS_ENABLE_COMMANDS` / `COS_DISABLE_COMMANDS`) > プロジェクト固有設定 > `defaultPermission` > 全許可**
 
 sandbox 違反時は exit code 7 で終了します。
 
@@ -326,16 +324,14 @@ cos config set <key> <value>  # 設定値を保存
 | `output.json` | boolean | 常に `--json` を有効にする |
 | `output.plain` | boolean | 常に `--plain` を有効にする |
 
-#### sandbox / エージェント設定 (`agent`)
+#### コマンド権限設定
 
 | キー | 型 | 説明 |
 |---|---|---|
-| `agent.defaultEnableCommands` | string[] | グローバルで許可するコマンド (CLI/環境変数未指定時のデフォルト) |
-| `agent.defaultDisableCommands` | string[] | グローバルで禁止するコマンド |
-| `agent.defaultProjectPermission` | `"read"` \| `"readwrite"` \| `"none"` | `projects` に未列挙のプロジェクトへの既定権限 |
-| `agent.maxChangesPerCommit` | number | エージェント 1 コミットあたりの最大変更数 |
+| `disableCommands` | string[] | 全プロジェクト共通の絶対禁止コマンドリスト |
+| `defaultPermission` | `"read"` \| `"readwrite"` \| `"none"` | `projects` に未列挙のプロジェクトへの既定権限 (プロジェクト指定時のみ有効) |
 
-`defaultProjectPermission` の意味:
+`defaultPermission` / `projects.<name>.permission` の値の意味:
 
 | 値 | 効果 |
 |---|---|
@@ -349,8 +345,9 @@ cos config set <key> <value>  # 設定値を保存
 |---|---|---|
 | `projects.<name>.defaultSort` | string | ページ一覧のデフォルトソート順 |
 | `projects.<name>.defaultLimit` | number | ページ一覧のデフォルト件数 |
-| `projects.<name>.enableCommands` | string[] | このプロジェクトで許可するコマンド (**グローバル設定を上書き**) |
-| `projects.<name>.disableCommands` | string[] | このプロジェクトで禁止するコマンド (**グローバル設定を上書き**) |
+| `projects.<name>.permission` | `"read"` \| `"readwrite"` \| `"none"` | このプロジェクトの権限プリセット |
+| `projects.<name>.enableCommands` | string[] | このプロジェクトで許可するコマンド (細かい制御が必要な場合) |
+| `projects.<name>.disableCommands` | string[] | このプロジェクトで禁止するコマンド (細かい制御が必要な場合) |
 
 #### 同期設定 (`sync`)
 
@@ -379,37 +376,34 @@ AI エージェントに coscli を使わせる際は sandbox 設定で権限を
 // ~/.config/coscli/config.json5
 {
   defaultProject: "myproject",
-  agent: {
-    // グローバルでは読み取り + ページ作成のみ許可
-    defaultEnableCommands: ["page.get", "page.list", "page.text", "search", "page.new"],
-    // projects に未列挙のプロジェクトは読み取り専用
-    defaultProjectPermission: "read",
-  },
+  // page.delete は全プロジェクトで絶対禁止
+  disableCommands: ["page.delete"],
+  // projects に未列挙のプロジェクトは読み取り専用
+  defaultPermission: "read",
   projects: {
-    // myproject では全操作を許可し削除だけ禁止
-    myproject: {
-      enableCommands: ["*"],
-      disableCommands: ["page.delete"],
-    },
-    // sandbox プロジェクトはプリセット (read) が適用される
+    // myproject は全操作を許可 (disableCommands の page.delete は引き続き禁止)
+    myproject: { permission: "readwrite" },
+    // private-notes は完全ブロック
+    "private-notes": { permission: "none" },
+    // 未列挙プロジェクト → defaultPermission: "read" が適用される
   },
 }
 ```
 
-プロジェクト固有の `enableCommands` / `disableCommands` が存在する場合、`agent.defaultEnableCommands` / `defaultDisableCommands` は**完全に無視**されます。
+sandbox の優先順位: **CLI フラグ > 環境変数 > プロジェクト固有設定 > `defaultPermission` > 全許可**
 
-sandbox の優先順位: **CLI フラグ > 環境変数 > プロジェクト固有設定 > `defaultProjectPermission` > グローバル設定**
+`disableCommands` は CLI フラグ (`--enable-commands`) で上書き可能な絶対禁止リストです。プロジェクトの `permission: "readwrite"` でも無効にはなりません。
 
 #### 設定値を CLI で確認・変更する
 
 ```bash
 # 現在の設定を確認
 cos config get defaultProject
-cos config get agent.defaultProjectPermission
+cos config get defaultPermission
 
 # 配列は JSON 形式で渡す
-cos config set agent.defaultEnableCommands '["page.get","page.list","search"]'
-cos config set projects.myproject.disableCommands '["page.delete"]'
+cos config set disableCommands '["page.delete"]'
+cos config set projects.myproject.permission readwrite
 
 # 設定ファイルを直接エディタで開く
 $EDITOR "$(cos config path)"

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -189,11 +189,15 @@ export function checkSandbox(commandName: string, args: CommonArgs): void {
   let enableStr: string | undefined
   let disableStr: string | undefined
 
-  if (cliEnable !== undefined || envEnable !== undefined) {
-    // CLI/env フラグが指定された場合は config を無視
+  const hasCliOrEnvOverride =
+    cliEnable !== undefined ||
+    envEnable !== undefined ||
+    cliDisable !== undefined ||
+    envDisable !== undefined
+
+  if (hasCliOrEnvOverride) {
+    // CLI/env フラグが指定された場合は config を無視 (enable と disable は独立して解決する)
     enableStr = cliEnable ?? envEnable
-  } else if (cliDisable !== undefined || envDisable !== undefined) {
-    // CLI/env disable が指定された場合も config を無視
     disableStr = cliDisable ?? envDisable
   } else {
     // config からプロジェクト固有 → defaultPermission の順で解決
@@ -201,6 +205,15 @@ export function checkSandbox(commandName: string, args: CommonArgs): void {
       const { enable, disable } = expandPermissionPreset(projectConfig.permission)
       enableStr = enable?.join(",")
       disableStr = disable?.join(",")
+      // permission プリセットに対して enableCommands/disableCommands を追加合成する
+      if (projectConfig.enableCommands?.length) {
+        const extra = projectConfig.enableCommands.join(",")
+        enableStr = enableStr ? `${enableStr},${extra}` : extra
+      }
+      if (projectConfig.disableCommands?.length) {
+        const extra = projectConfig.disableCommands.join(",")
+        disableStr = disableStr ? `${disableStr},${extra}` : extra
+      }
     } else if (
       projectConfig?.enableCommands !== undefined ||
       projectConfig?.disableCommands !== undefined

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -8,6 +8,7 @@
 import { CosenseRestClient } from "@/core/api/rest"
 import { createScrapboxWriter } from "@/core/api/ws"
 import { loadSession } from "@/core/auth/session"
+import { expandPermissionPreset } from "@/core/command-classification"
 import { PolicyError, createPolicy } from "@/core/sandbox"
 import { loadConfig } from "@/infra/config"
 import { createTokenStore } from "@/infra/keychain/index"
@@ -162,14 +163,56 @@ export function buildLogger(args: CommonArgs): Logger {
 /**
  * checkSandbox はサンドボックスポリシーを確認する。
  * 拒否された場合は exit 7 で終了する。
+ *
+ * 優先順位: CLI フラグ > 環境変数 > プロジェクト固有設定 > defaultProjectPermission > グローバル既定
+ *
+ * プロジェクト固有設定 (projects.<name>.enableCommands / disableCommands) が存在する場合は
+ * グローバル設定 (agent.defaultEnable/DisableCommands) を完全に上書きする。
+ * プロジェクト名は args.project > COS_PROJECT 環境変数 の順で解決し、
+ * config.defaultProject はフォールバックとして使用しない (グローバルコマンドへの意図しない適用を防ぐ)。
  */
 export function checkSandbox(commandName: string, args: CommonArgs): void {
   const config = loadConfig()
-  const enableStr = args["enable-commands"] ?? process.env["COS_ENABLE_COMMANDS"]
-  const disableStr =
-    args["disable-commands"] ??
-    process.env["COS_DISABLE_COMMANDS"] ??
-    config.agent?.defaultDisableCommands?.join(",")
+
+  // プロジェクト名解決: args > COS_PROJECT 環境変数 (config.defaultProject は使用しない)
+  const projectName = args.project ?? process.env["COS_PROJECT"]
+  const projectConfig = projectName ? (config.projects?.[projectName] ?? undefined) : undefined
+  const hasProjectOverride = !!(projectConfig?.enableCommands || projectConfig?.disableCommands)
+
+  const cliEnable = args["enable-commands"]
+  const envEnable = process.env["COS_ENABLE_COMMANDS"]
+  const cliDisable = args["disable-commands"]
+  const envDisable = process.env["COS_DISABLE_COMMANDS"]
+
+  // enable 優先順位: CLI > env > プロジェクト固有 > defaultProjectPermission プリセット > グローバル既定
+  let enableStr: string | undefined
+  if (cliEnable !== undefined) {
+    enableStr = cliEnable
+  } else if (envEnable !== undefined) {
+    enableStr = envEnable
+  } else if (hasProjectOverride) {
+    enableStr = projectConfig?.enableCommands?.join(",")
+  } else if (projectName && config.agent?.defaultProjectPermission) {
+    const { enable } = expandPermissionPreset(config.agent.defaultProjectPermission)
+    enableStr = enable?.join(",")
+  } else {
+    enableStr = config.agent?.defaultEnableCommands?.join(",")
+  }
+
+  // disable 優先順位: CLI > env > プロジェクト固有 > defaultProjectPermission プリセット > グローバル既定
+  let disableStr: string | undefined
+  if (cliDisable !== undefined) {
+    disableStr = cliDisable
+  } else if (envDisable !== undefined) {
+    disableStr = envDisable
+  } else if (hasProjectOverride) {
+    disableStr = projectConfig?.disableCommands?.join(",")
+  } else if (projectName && config.agent?.defaultProjectPermission) {
+    const { disable } = expandPermissionPreset(config.agent.defaultProjectPermission)
+    disableStr = disable?.join(",")
+  } else {
+    disableStr = config.agent?.defaultDisableCommands?.join(",")
+  }
 
   if (!enableStr && !disableStr) return
 

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -164,54 +164,60 @@ export function buildLogger(args: CommonArgs): Logger {
  * checkSandbox はサンドボックスポリシーを確認する。
  * 拒否された場合は exit 7 で終了する。
  *
- * 優先順位: CLI フラグ > 環境変数 > プロジェクト固有設定 > defaultProjectPermission > グローバル既定
+ * 優先順位: CLI フラグ > 環境変数 > プロジェクト固有設定 > defaultPermission > 全許可
  *
- * プロジェクト固有設定 (projects.<name>.enableCommands / disableCommands) が存在する場合は
- * グローバル設定 (agent.defaultEnable/DisableCommands) を完全に上書きする。
+ * - CLI/env フラグが指定された場合はそれのみを使用 (config の disableCommands も無視)
+ * - プロジェクト固有の permission / enableCommands / disableCommands はグローバルより優先
+ * - defaultPermission はプロジェクト指定時のみ有効 (未指定コマンドには無効)
+ * - disableCommands はプロジェクト設定に重ねて常に適用される絶対禁止リスト
+ *
  * プロジェクト名は args.project > COS_PROJECT 環境変数 の順で解決し、
- * config.defaultProject はフォールバックとして使用しない (グローバルコマンドへの意図しない適用を防ぐ)。
+ * config.defaultProject はフォールバックとして使用しない。
  */
 export function checkSandbox(commandName: string, args: CommonArgs): void {
   const config = loadConfig()
 
-  // プロジェクト名解決: args > COS_PROJECT 環境変数 (config.defaultProject は使用しない)
+  // プロジェクト名解決 (config.defaultProject は使用しない)
   const projectName = args.project ?? process.env["COS_PROJECT"]
   const projectConfig = projectName ? (config.projects?.[projectName] ?? undefined) : undefined
-  const hasProjectOverride = !!(projectConfig?.enableCommands || projectConfig?.disableCommands)
 
   const cliEnable = args["enable-commands"]
   const envEnable = process.env["COS_ENABLE_COMMANDS"]
   const cliDisable = args["disable-commands"]
   const envDisable = process.env["COS_DISABLE_COMMANDS"]
 
-  // enable 優先順位: CLI > env > プロジェクト固有 > defaultProjectPermission プリセット > グローバル既定
   let enableStr: string | undefined
-  if (cliEnable !== undefined) {
-    enableStr = cliEnable
-  } else if (envEnable !== undefined) {
-    enableStr = envEnable
-  } else if (hasProjectOverride) {
-    enableStr = projectConfig?.enableCommands?.join(",")
-  } else if (projectName && config.agent?.defaultProjectPermission) {
-    const { enable } = expandPermissionPreset(config.agent.defaultProjectPermission)
-    enableStr = enable?.join(",")
-  } else {
-    enableStr = config.agent?.defaultEnableCommands?.join(",")
-  }
-
-  // disable 優先順位: CLI > env > プロジェクト固有 > defaultProjectPermission プリセット > グローバル既定
   let disableStr: string | undefined
-  if (cliDisable !== undefined) {
-    disableStr = cliDisable
-  } else if (envDisable !== undefined) {
-    disableStr = envDisable
-  } else if (hasProjectOverride) {
-    disableStr = projectConfig?.disableCommands?.join(",")
-  } else if (projectName && config.agent?.defaultProjectPermission) {
-    const { disable } = expandPermissionPreset(config.agent.defaultProjectPermission)
-    disableStr = disable?.join(",")
+
+  if (cliEnable !== undefined || envEnable !== undefined) {
+    // CLI/env フラグが指定された場合は config を無視
+    enableStr = cliEnable ?? envEnable
+  } else if (cliDisable !== undefined || envDisable !== undefined) {
+    // CLI/env disable が指定された場合も config を無視
+    disableStr = cliDisable ?? envDisable
   } else {
-    disableStr = config.agent?.defaultDisableCommands?.join(",")
+    // config からプロジェクト固有 → defaultPermission の順で解決
+    if (projectConfig?.permission) {
+      const { enable, disable } = expandPermissionPreset(projectConfig.permission)
+      enableStr = enable?.join(",")
+      disableStr = disable?.join(",")
+    } else if (
+      projectConfig?.enableCommands !== undefined ||
+      projectConfig?.disableCommands !== undefined
+    ) {
+      enableStr = projectConfig.enableCommands?.join(",")
+      disableStr = projectConfig.disableCommands?.join(",")
+    } else if (projectName && config.defaultPermission) {
+      const { enable, disable } = expandPermissionPreset(config.defaultPermission)
+      enableStr = enable?.join(",")
+      disableStr = disable?.join(",")
+    }
+
+    // 絶対禁止リストを重ねる (CLI/env 未指定時のみ)
+    if (config.disableCommands?.length) {
+      const globalDisable = config.disableCommands.join(",")
+      disableStr = disableStr ? `${disableStr},${globalDisable}` : globalDisable
+    }
   }
 
   if (!enableStr && !disableStr) return

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -70,13 +70,7 @@ export interface PresetExpansion {
   disable: string[] | undefined
 }
 
-/**
- * expandPermissionPreset はプリセット名を PolicyOptions 相当の展開値に変換する。
- *
- * "read"      → enable: READ_COMMANDS, disable: undefined
- * "readwrite" → enable: ["*"],          disable: undefined
- * "none"      → enable: undefined,      disable: ["*"]
- */
+/** expandPermissionPreset はプリセット名を enable/disable 配列に展開した PresetExpansion を返す。 */
 export function expandPermissionPreset(preset: PermissionPreset): PresetExpansion {
   switch (preset) {
     case "read":

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -1,0 +1,89 @@
+/**
+ * command-classification.ts — coscli の全コマンドを read/write に分類するテーブルと
+ * プロジェクト権限プリセット展開ヘルパー。
+ *
+ * read: Cosense に対して読み取りのみ行うコマンド
+ * write: Cosense・設定・認証などに書き込みを行うコマンド
+ *
+ * プリセット展開:
+ *   "read"      → read 系コマンドのみ enable
+ *   "readwrite" → 全コマンド enable ("*")
+ *   "none"      → 全コマンド disable ("*")
+ */
+
+/** READ_COMMANDS は読み取り系コマンドの一覧。 */
+export const READ_COMMANDS: readonly string[] = [
+  "auth.whoami",
+  "config.get",
+  "config.path",
+  "convert",
+  "exit-codes",
+  "notation",
+  "page.code",
+  "page.context",
+  "page.get",
+  "page.line.get",
+  "page.list",
+  "page.text",
+  "page.url",
+  "page.watch",
+  "project.graph",
+  "project.info",
+  "project.list",
+  "schema",
+  "search",
+  "sync.diff",
+  "sync.pull",
+]
+
+/** WRITE_COMMANDS は書き込み系コマンドの一覧。 */
+export const WRITE_COMMANDS: readonly string[] = [
+  "auth.login",
+  "auth.logout",
+  "config.set",
+  "page.append",
+  "page.delete",
+  "page.edit",
+  "page.icon",
+  "page.insert",
+  "page.line.delete",
+  "page.line.replace",
+  "page.new",
+  "page.pin",
+  "page.prepend",
+  "page.rename",
+  "page.unpin",
+  "serve.rest",
+  "sync.push",
+]
+
+/** PermissionPreset はプロジェクト権限プリセットの型。 */
+export type PermissionPreset = "read" | "readwrite" | "none"
+
+/**
+ * PresetExpansion はプリセット展開結果の型。
+ * enable / disable はそれぞれ PolicyOptions に渡す配列。
+ * undefined の場合はその制約を設けない。
+ */
+export interface PresetExpansion {
+  enable: string[] | undefined
+  disable: string[] | undefined
+}
+
+/**
+ * expandPermissionPreset はプリセット名を PolicyOptions 相当の展開値に変換する。
+ *
+ * "read"      → enable: READ_COMMANDS, disable: undefined
+ * "readwrite" → enable: ["*"],          disable: undefined
+ * "none"      → enable: undefined,      disable: ["*"]
+ */
+export function expandPermissionPreset(preset: PermissionPreset): PresetExpansion {
+  switch (preset) {
+    case "read":
+      return { enable: [...READ_COMMANDS], disable: undefined }
+    case "readwrite":
+      return { enable: ["*"], disable: undefined }
+    case "none":
+      return { enable: undefined, disable: ["*"] }
+  }
+}

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -11,30 +11,24 @@ import { dirname, join } from "node:path"
 import JSON5 from "json5"
 import { z } from "zod"
 
+/** PermissionPreset はプロジェクトに適用できる権限プリセット。 */
+const PermissionPresetSchema = z.enum(["read", "readwrite", "none"])
+
 /** ProjectConfig はプロジェクト固有の設定。 */
 const ProjectConfigSchema = z.object({
   defaultSort: z.string().optional(),
   defaultLimit: z.number().optional(),
-  /** このプロジェクトで許可するコマンドリスト。設定時はグローバル設定を完全に上書きする。 */
-  enableCommands: z.array(z.string()).optional(),
-  /** このプロジェクトで禁止するコマンドリスト。設定時はグローバル設定を完全に上書きする。 */
-  disableCommands: z.array(z.string()).optional(),
-})
-
-/** AgentConfig は AI エージェント向けの設定。 */
-const AgentConfigSchema = z.object({
-  defaultDisableCommands: z.array(z.string()).optional(),
-  /** グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)。 */
-  defaultEnableCommands: z.array(z.string()).optional(),
   /**
-   * projects に未列挙のプロジェクトへの既定権限プリセット。
+   * このプロジェクトの権限プリセット。
    * "read": 読み取り系コマンドのみ許可。
    * "readwrite": 全コマンド許可。
    * "none": 全コマンド拒否。
-   * 未設定: グローバル enable/disable のみ適用 (後方互換)。
    */
-  defaultProjectPermission: z.enum(["read", "readwrite", "none"]).optional(),
-  maxChangesPerCommit: z.number().optional(),
+  permission: PermissionPresetSchema.optional(),
+  /** このプロジェクトで許可するコマンドリスト (permission より細かい制御が必要な場合)。 */
+  enableCommands: z.array(z.string()).optional(),
+  /** このプロジェクトで禁止するコマンドリスト (permission より細かい制御が必要な場合)。 */
+  disableCommands: z.array(z.string()).optional(),
 })
 
 /** SyncConfig はローカル同期に関する設定。 */
@@ -48,8 +42,15 @@ const SyncConfigSchema = z.object({
 export const CoscliConfigSchema = z.object({
   defaultProject: z.string().optional(),
   defaultProfile: z.string().optional(),
+  /**
+   * projects に未列挙のプロジェクトへの既定権限プリセット。
+   * プロジェクト指定時のみ適用される (プロジェクト未指定コマンドには無効)。
+   * 未設定: 全コマンド許可 (後方互換)。
+   */
+  defaultPermission: PermissionPresetSchema.optional(),
+  /** 全プロジェクト共通の絶対禁止コマンドリスト。CLI フラグで上書き可能。 */
+  disableCommands: z.array(z.string()).optional(),
   projects: z.record(z.string(), ProjectConfigSchema).optional(),
-  agent: AgentConfigSchema.optional(),
   output: z
     .object({
       color: z.enum(["auto", "always", "never"]).optional(),

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -15,11 +15,25 @@ import { z } from "zod"
 const ProjectConfigSchema = z.object({
   defaultSort: z.string().optional(),
   defaultLimit: z.number().optional(),
+  /** このプロジェクトで許可するコマンドリスト。設定時はグローバル設定を完全に上書きする。 */
+  enableCommands: z.array(z.string()).optional(),
+  /** このプロジェクトで禁止するコマンドリスト。設定時はグローバル設定を完全に上書きする。 */
+  disableCommands: z.array(z.string()).optional(),
 })
 
 /** AgentConfig は AI エージェント向けの設定。 */
 const AgentConfigSchema = z.object({
   defaultDisableCommands: z.array(z.string()).optional(),
+  /** グローバルで許可するコマンドリスト (CLI/env 未指定時のデフォルト)。 */
+  defaultEnableCommands: z.array(z.string()).optional(),
+  /**
+   * projects に未列挙のプロジェクトへの既定権限プリセット。
+   * "read": 読み取り系コマンドのみ許可。
+   * "readwrite": 全コマンド許可。
+   * "none": 全コマンド拒否。
+   * 未設定: グローバル enable/disable のみ適用 (後方互換)。
+   */
+  defaultProjectPermission: z.enum(["read", "readwrite", "none"]).optional(),
   maxChangesPerCommit: z.number().optional(),
 })
 

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -14,6 +14,18 @@ import { z } from "zod"
 /** PermissionPreset はプロジェクトに適用できる権限プリセット。 */
 const PermissionPresetSchema = z.enum(["read", "readwrite", "none"])
 
+/**
+ * CommandPatternSchema はコマンドパターン文字列のバリデーションスキーマ。
+ * 許容形式: "*" / "all" / "noun" / "noun.verb" / "noun.*" / "noun.noun.verb" 等
+ */
+const CommandPatternSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-z*][a-z0-9.*]*$|^all$/,
+    "コマンドパターンは noun.verb 形式、または * / all を指定してください (例: page.list)",
+  )
+
 /** ProjectConfig はプロジェクト固有の設定。 */
 const ProjectConfigSchema = z.object({
   defaultSort: z.string().optional(),
@@ -26,9 +38,9 @@ const ProjectConfigSchema = z.object({
    */
   permission: PermissionPresetSchema.optional(),
   /** このプロジェクトで許可するコマンドリスト (permission より細かい制御が必要な場合)。 */
-  enableCommands: z.array(z.string()).optional(),
+  enableCommands: z.array(CommandPatternSchema).optional(),
   /** このプロジェクトで禁止するコマンドリスト (permission より細かい制御が必要な場合)。 */
-  disableCommands: z.array(z.string()).optional(),
+  disableCommands: z.array(CommandPatternSchema).optional(),
 })
 
 /** SyncConfig はローカル同期に関する設定。 */
@@ -49,7 +61,7 @@ export const CoscliConfigSchema = z.object({
    */
   defaultPermission: PermissionPresetSchema.optional(),
   /** 全プロジェクト共通の絶対禁止コマンドリスト。CLI フラグで上書き可能。 */
-  disableCommands: z.array(z.string()).optional(),
+  disableCommands: z.array(CommandPatternSchema).optional(),
   projects: z.record(z.string(), ProjectConfigSchema).optional(),
   output: z
     .object({

--- a/tests/unit/commands/sandbox-policy.test.ts
+++ b/tests/unit/commands/sandbox-policy.test.ts
@@ -44,6 +44,7 @@ function writeTestConfig(config: CoscliConfig): void {
 
 let exitMock: ReturnType<typeof spyOn>
 let stderrMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
 
 beforeEach(() => {
   process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
@@ -52,11 +53,13 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stderrMock.mockRestore()
+  stdoutMock.mockRestore()
   Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
   try {
     rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
@@ -70,6 +73,9 @@ describe("checkSandbox - グローバル disableCommands", () => {
     writeTestConfig({ disableCommands: ["page.delete"] })
     expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
+    // stdout に拒否メッセージが JSON として出力されることを確認する (writeErrorJson は stdout に書く)
+    const stdoutOutput = stdoutMock.mock.calls.map((args: unknown[]) => String(args[0])).join("")
+    expect(stdoutOutput).toContain("[denied] page.delete is disabled by policy")
   })
 
   it("disableCommands に含まれないコマンドは通過する", () => {
@@ -209,6 +215,30 @@ describe("checkSandbox - defaultPermission (未設定プロジェクトの既定
   })
 })
 
+describe("checkSandbox - permission と enableCommands/disableCommands の合成", () => {
+  it("permission: read と disableCommands の組み合わせで特定の read コマンドを追加禁止できる", () => {
+    writeTestConfig({
+      projects: { 制限プロジェクト: { permission: "read", disableCommands: ["page.text"] } },
+    })
+    // page.get は read 系なので通過する
+    expect(() => checkSandbox("page.get", makeArgs({ project: "制限プロジェクト" }))).not.toThrow()
+    // page.text は read 系だが disableCommands で追加禁止されているので拒否される
+    expect(() => checkSandbox("page.text", makeArgs({ project: "制限プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("permission: readwrite と disableCommands の組み合わせで特定コマンドを禁止できる", () => {
+    writeTestConfig({
+      projects: { 安全プロジェクト: { permission: "readwrite", disableCommands: ["page.delete"] } },
+    })
+    // page.new は通過する
+    expect(() => checkSandbox("page.new", makeArgs({ project: "安全プロジェクト" }))).not.toThrow()
+    // page.delete は disableCommands で禁止されているので拒否される
+    expect(() => checkSandbox("page.delete", makeArgs({ project: "安全プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})
+
 describe("checkSandbox - COS_PROJECT 環境変数", () => {
   it("COS_PROJECT 環境変数でプロジェクトを指定してプロジェクト設定を適用できる", () => {
     writeTestConfig({
@@ -256,6 +286,26 @@ describe("checkSandbox - CLI フラグ優先度", () => {
       checkSandbox("page.delete", makeArgs({ "enable-commands": "page.delete" })),
     ).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("CLI --enable-commands と --disable-commands を同時指定した場合に両方が適用される", () => {
+    // enable に page.get と page.list を指定し、page.list だけ disable する
+    // → page.get は許可、page.list は拒否されるはず
+    expect(() =>
+      checkSandbox(
+        "page.get",
+        makeArgs({ "enable-commands": "page.get,page.list", "disable-commands": "page.list" }),
+      ),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+
+    expect(() =>
+      checkSandbox(
+        "page.list",
+        makeArgs({ "enable-commands": "page.get,page.list", "disable-commands": "page.list" }),
+      ),
+    ).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
   })
 })
 

--- a/tests/unit/commands/sandbox-policy.test.ts
+++ b/tests/unit/commands/sandbox-policy.test.ts
@@ -1,0 +1,295 @@
+/**
+ * sandbox-policy.test.ts — checkSandbox の config 連携テスト。
+ *
+ * 設定ファイル経由のグローバル / プロジェクト単位の
+ * コマンド許可・拒否ポリシーを検証する。
+ *
+ * テスト設計:
+ *  - XDG_CONFIG_HOME を一時ディレクトリに向け、saveConfig でテスト用設定を書き込む
+ *  - process.exit をモックして exit code をキャプチャする
+ *  - 各テスト後に環境変数と mock をクリアする
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { CommonArgs } from "@/commands/_shared"
+import { checkSandbox } from "@/commands/_shared"
+import type { CoscliConfig } from "@/infra/config"
+import { saveConfig } from "@/infra/config"
+
+/** 一時設定ディレクトリ */
+const TEST_CONFIG_DIR = join(tmpdir(), `coscli-sandbox-policy-test-${Date.now()}`)
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+/** テスト用デフォルト CommonArgs を生成するヘルパー */
+function makeArgs(overrides: Partial<CommonArgs> = {}): CommonArgs {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: false,
+    ...overrides,
+  }
+}
+
+/**
+ * テスト用設定ファイルを書き込む。
+ * XDG_CONFIG_HOME を TEST_CONFIG_DIR に向けることで loadConfig() に読み込ませる。
+ */
+function writeTestConfig(config: CoscliConfig): void {
+  saveConfig(config, TEST_CONFIG_FILE)
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+  // テスト用設定ファイルを削除する
+  try {
+    rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+  } catch {
+    // クリーンアップ失敗は無視する
+  }
+})
+
+describe("checkSandbox - グローバル設定 (agent.defaultEnableCommands)", () => {
+  it("agent.defaultEnableCommands に含まれるコマンドは通過する", () => {
+    writeTestConfig({ agent: { defaultEnableCommands: ["page.get", "page.list"] } })
+    // page.get は許可リストに含まれるため通過する
+    expect(() => checkSandbox("page.get", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("agent.defaultEnableCommands に含まれないコマンドは exit 7 で拒否される", () => {
+    writeTestConfig({ agent: { defaultEnableCommands: ["page.get", "page.list"] } })
+    // page.delete は許可リストに含まれないため拒否される
+    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("agent.defaultDisableCommands に含まれるコマンドは exit 7 で拒否される", () => {
+    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
+    // page.delete は禁止リストに含まれるため拒否される
+    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("agent.defaultDisableCommands に含まれないコマンドは通過する", () => {
+    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
+    // page.get は禁止リストに含まれないため通過する
+    expect(() => checkSandbox("page.get", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("checkSandbox - プロジェクト固有設定", () => {
+  it("projects.<name>.disableCommands に含まれるコマンドはそのプロジェクトで拒否される", () => {
+    writeTestConfig({
+      projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete", "page.new"] } },
+    })
+    // 読み取り専用プロジェクト向けの page.delete は拒否される
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ project: "読み取り専用プロジェクト" })),
+    ).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("projects.<name>.disableCommands に含まれないコマンドは通過する", () => {
+    writeTestConfig({
+      projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete"] } },
+    })
+    // page.get は禁止リストに含まれないため通過する
+    expect(() =>
+      checkSandbox("page.get", makeArgs({ project: "読み取り専用プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("projects.<name>.enableCommands に含まれるコマンドのみ許可される", () => {
+    writeTestConfig({
+      projects: { 制限プロジェクト: { enableCommands: ["page.get", "page.list"] } },
+    })
+    // page.get は enable リストに含まれるため通過する
+    expect(() => checkSandbox("page.get", makeArgs({ project: "制限プロジェクト" }))).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("projects.<name>.enableCommands に含まれないコマンドは拒否される", () => {
+    writeTestConfig({
+      projects: { 制限プロジェクト: { enableCommands: ["page.get", "page.list"] } },
+    })
+    // page.delete は enable リストに含まれないため拒否される
+    expect(() => checkSandbox("page.delete", makeArgs({ project: "制限プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("プロジェクト設定がグローバルの agent.defaultDisableCommands を上書きする", () => {
+    writeTestConfig({
+      agent: { defaultDisableCommands: ["page.delete"] },
+      projects: {
+        // このプロジェクトでは page.delete を許可する (enableCommands で全許可)
+        書き込み可能プロジェクト: { enableCommands: ["*"] },
+      },
+    })
+    // グローバルでは page.delete 禁止だが、プロジェクト設定で全許可されているので通過する
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ project: "書き込み可能プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("プロジェクト設定がグローバルの agent.defaultEnableCommands を上書きする", () => {
+    writeTestConfig({
+      agent: { defaultEnableCommands: ["page.get"] },
+      projects: {
+        // このプロジェクトでは page.delete も許可する (上書き)
+        上書きプロジェクト: { enableCommands: ["page.get", "page.delete"] },
+      },
+    })
+    // グローバルでは page.delete は enable リスト外で拒否されるが、
+    // プロジェクト固有で許可されているため通過する
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ project: "上書きプロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("別プロジェクトの制限は対象プロジェクト以外に影響しない", () => {
+    writeTestConfig({
+      projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete"] } },
+    })
+    // 別プロジェクトを指定した場合は制限が適用されない
+    expect(() => checkSandbox("page.delete", makeArgs({ project: "別プロジェクト" }))).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("checkSandbox - COS_PROJECT 環境変数によるプロジェクト特定", () => {
+  it("COS_PROJECT 環境変数でプロジェクトを指定してプロジェクト設定を適用できる", () => {
+    writeTestConfig({
+      projects: { 環境変数プロジェクト: { disableCommands: ["page.delete"] } },
+    })
+    process.env["COS_PROJECT"] = "環境変数プロジェクト"
+    // COS_PROJECT 経由でプロジェクト設定が適用される
+    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})
+
+describe("checkSandbox - agent.defaultProjectPermission プリセット", () => {
+  it('"read" プリセットが未設定プロジェクトの write コマンドを拒否する', () => {
+    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
+    // 未設定プロジェクトの page.new は write 系コマンドなので read プリセットで拒否される
+    expect(() => checkSandbox("page.new", makeArgs({ project: "未設定プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it('"read" プリセットが未設定プロジェクトの read コマンドを許可する', () => {
+    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
+    // page.get は read 系コマンドなので通過する
+    expect(() =>
+      checkSandbox("page.get", makeArgs({ project: "未設定プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it('"none" プリセットが未設定プロジェクトの全コマンドを拒否する', () => {
+    writeTestConfig({ agent: { defaultProjectPermission: "none" } })
+    // read 系も write 系もすべて拒否される
+    expect(() => checkSandbox("page.get", makeArgs({ project: "未設定プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it('"readwrite" プリセットは全コマンドを許可する', () => {
+    writeTestConfig({ agent: { defaultProjectPermission: "readwrite" } })
+    // write 系コマンドも許可される
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ project: "未設定プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("明示的に設定されたプロジェクトには defaultProjectPermission が適用されない", () => {
+    writeTestConfig({
+      agent: { defaultProjectPermission: "read" },
+      projects: {
+        // 明示設定で全許可
+        明示設定プロジェクト: { enableCommands: ["*"] },
+      },
+    })
+    // 明示設定のプロジェクトには read プリセットが適用されず page.new も許可される
+    expect(() =>
+      checkSandbox("page.new", makeArgs({ project: "明示設定プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("checkSandbox - CLI フラグ優先度", () => {
+  it("CLI --enable-commands フラグはプロジェクト設定より優先される", () => {
+    writeTestConfig({
+      projects: { 制限プロジェクト: { enableCommands: ["page.get"] } },
+    })
+    // CLI フラグで page.delete を明示的に許可する
+    expect(() =>
+      checkSandbox(
+        "page.delete",
+        makeArgs({ project: "制限プロジェクト", "enable-commands": "page.delete" }),
+      ),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("CLI --disable-commands フラグはプロジェクト設定より優先される", () => {
+    writeTestConfig({
+      projects: { 全許可プロジェクト: { enableCommands: ["*"] } },
+    })
+    // プロジェクトは全許可だが CLI フラグで page.delete を禁止する
+    expect(() =>
+      checkSandbox(
+        "page.delete",
+        makeArgs({ project: "全許可プロジェクト", "disable-commands": "page.delete" }),
+      ),
+    ).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})
+
+describe("checkSandbox - プロジェクト未指定の場合", () => {
+  it("プロジェクト未指定ではプロジェクト固有設定が適用されず全コマンドを許可する", () => {
+    writeTestConfig({
+      projects: { マイプロジェクト: { disableCommands: ["page.delete"] } },
+    })
+    // project が args にも env にもない場合は設定ファイルの projects を参照しない
+    expect(() => checkSandbox("page.delete", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("プロジェクト未指定でも agent.defaultDisableCommands は適用される", () => {
+    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
+    // グローバル設定は project 未指定でも適用される
+    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("プロジェクト未指定では defaultProjectPermission が適用されない", () => {
+    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
+    // project が指定されていないため read プリセットが適用されず write コマンドも許可される
+    expect(() => checkSandbox("page.new", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/commands/sandbox-policy.test.ts
+++ b/tests/unit/commands/sandbox-policy.test.ts
@@ -58,7 +58,6 @@ afterEach(() => {
   exitMock.mockRestore()
   stderrMock.mockRestore()
   Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
-  // テスト用設定ファイルを削除する
   try {
     rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
   } catch {
@@ -66,183 +65,165 @@ afterEach(() => {
   }
 })
 
-describe("checkSandbox - グローバル設定 (agent.defaultEnableCommands)", () => {
-  it("agent.defaultEnableCommands に含まれるコマンドは通過する", () => {
-    writeTestConfig({ agent: { defaultEnableCommands: ["page.get", "page.list"] } })
-    // page.get は許可リストに含まれるため通過する
-    expect(() => checkSandbox("page.get", makeArgs())).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
-  })
-
-  it("agent.defaultEnableCommands に含まれないコマンドは exit 7 で拒否される", () => {
-    writeTestConfig({ agent: { defaultEnableCommands: ["page.get", "page.list"] } })
-    // page.delete は許可リストに含まれないため拒否される
+describe("checkSandbox - グローバル disableCommands", () => {
+  it("disableCommands に含まれるコマンドは exit 7 で拒否される", () => {
+    writeTestConfig({ disableCommands: ["page.delete"] })
     expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it("agent.defaultDisableCommands に含まれるコマンドは exit 7 で拒否される", () => {
-    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
-    // page.delete は禁止リストに含まれるため拒否される
+  it("disableCommands に含まれないコマンドは通過する", () => {
+    writeTestConfig({ disableCommands: ["page.delete"] })
+    expect(() => checkSandbox("page.get", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("disableCommands はプロジェクト指定なしでも適用される", () => {
+    writeTestConfig({ disableCommands: ["page.delete"] })
     expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it("agent.defaultDisableCommands に含まれないコマンドは通過する", () => {
-    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
-    // page.get は禁止リストに含まれないため通過する
-    expect(() => checkSandbox("page.get", makeArgs())).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
+  it("disableCommands はプロジェクト permission: readwrite でも適用される", () => {
+    writeTestConfig({
+      disableCommands: ["page.delete"],
+      projects: { 全許可プロジェクト: { permission: "readwrite" } },
+    })
+    // readwrite でも disableCommands は絶対禁止リストとして機能する
+    expect(() => checkSandbox("page.delete", makeArgs({ project: "全許可プロジェクト" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
   })
 })
 
-describe("checkSandbox - プロジェクト固有設定", () => {
+describe("checkSandbox - プロジェクト固有 permission", () => {
+  it("projects.<name>.permission: read が write コマンドを拒否する", () => {
+    writeTestConfig({ projects: { 読み取り専用: { permission: "read" } } })
+    expect(() => checkSandbox("page.new", makeArgs({ project: "読み取り専用" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
+  it("projects.<name>.permission: read が read コマンドを許可する", () => {
+    writeTestConfig({ projects: { 読み取り専用: { permission: "read" } } })
+    expect(() => checkSandbox("page.get", makeArgs({ project: "読み取り専用" }))).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("projects.<name>.permission: readwrite が全コマンドを許可する", () => {
+    writeTestConfig({ projects: { 全許可プロジェクト: { permission: "readwrite" } } })
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ project: "全許可プロジェクト" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("projects.<name>.permission: none が全コマンドを拒否する", () => {
+    writeTestConfig({ projects: { 完全ブロック: { permission: "none" } } })
+    expect(() => checkSandbox("page.get", makeArgs({ project: "完全ブロック" }))).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+
   it("projects.<name>.disableCommands に含まれるコマンドはそのプロジェクトで拒否される", () => {
     writeTestConfig({
       projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete", "page.new"] } },
     })
-    // 読み取り専用プロジェクト向けの page.delete は拒否される
     expect(() =>
       checkSandbox("page.delete", makeArgs({ project: "読み取り専用プロジェクト" })),
     ).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it("projects.<name>.disableCommands に含まれないコマンドは通過する", () => {
-    writeTestConfig({
-      projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete"] } },
-    })
-    // page.get は禁止リストに含まれないため通過する
-    expect(() =>
-      checkSandbox("page.get", makeArgs({ project: "読み取り専用プロジェクト" })),
-    ).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
-  })
-
-  it("projects.<name>.enableCommands に含まれるコマンドのみ許可される", () => {
-    writeTestConfig({
-      projects: { 制限プロジェクト: { enableCommands: ["page.get", "page.list"] } },
-    })
-    // page.get は enable リストに含まれるため通過する
-    expect(() => checkSandbox("page.get", makeArgs({ project: "制限プロジェクト" }))).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
-  })
-
   it("projects.<name>.enableCommands に含まれないコマンドは拒否される", () => {
     writeTestConfig({
       projects: { 制限プロジェクト: { enableCommands: ["page.get", "page.list"] } },
     })
-    // page.delete は enable リストに含まれないため拒否される
     expect(() => checkSandbox("page.delete", makeArgs({ project: "制限プロジェクト" }))).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it("プロジェクト設定がグローバルの agent.defaultDisableCommands を上書きする", () => {
+  it("projects.<name>.enableCommands に含まれるコマンドは許可される", () => {
     writeTestConfig({
-      agent: { defaultDisableCommands: ["page.delete"] },
-      projects: {
-        // このプロジェクトでは page.delete を許可する (enableCommands で全許可)
-        書き込み可能プロジェクト: { enableCommands: ["*"] },
-      },
+      projects: { 制限プロジェクト: { enableCommands: ["page.get", "page.list"] } },
     })
-    // グローバルでは page.delete 禁止だが、プロジェクト設定で全許可されているので通過する
-    expect(() =>
-      checkSandbox("page.delete", makeArgs({ project: "書き込み可能プロジェクト" })),
-    ).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
-  })
-
-  it("プロジェクト設定がグローバルの agent.defaultEnableCommands を上書きする", () => {
-    writeTestConfig({
-      agent: { defaultEnableCommands: ["page.get"] },
-      projects: {
-        // このプロジェクトでは page.delete も許可する (上書き)
-        上書きプロジェクト: { enableCommands: ["page.get", "page.delete"] },
-      },
-    })
-    // グローバルでは page.delete は enable リスト外で拒否されるが、
-    // プロジェクト固有で許可されているため通過する
-    expect(() =>
-      checkSandbox("page.delete", makeArgs({ project: "上書きプロジェクト" })),
-    ).not.toThrow()
+    expect(() => checkSandbox("page.get", makeArgs({ project: "制限プロジェクト" }))).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
   })
 
   it("別プロジェクトの制限は対象プロジェクト以外に影響しない", () => {
     writeTestConfig({
-      projects: { 読み取り専用プロジェクト: { disableCommands: ["page.delete"] } },
+      projects: { 読み取り専用プロジェクト: { permission: "read" } },
     })
-    // 別プロジェクトを指定した場合は制限が適用されない
     expect(() => checkSandbox("page.delete", makeArgs({ project: "別プロジェクト" }))).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
   })
 })
 
-describe("checkSandbox - COS_PROJECT 環境変数によるプロジェクト特定", () => {
-  it("COS_PROJECT 環境変数でプロジェクトを指定してプロジェクト設定を適用できる", () => {
-    writeTestConfig({
-      projects: { 環境変数プロジェクト: { disableCommands: ["page.delete"] } },
-    })
-    process.env["COS_PROJECT"] = "環境変数プロジェクト"
-    // COS_PROJECT 経由でプロジェクト設定が適用される
-    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
-    expect(exitMock).toHaveBeenCalledWith(7)
-  })
-})
-
-describe("checkSandbox - agent.defaultProjectPermission プリセット", () => {
-  it('"read" プリセットが未設定プロジェクトの write コマンドを拒否する', () => {
-    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
-    // 未設定プロジェクトの page.new は write 系コマンドなので read プリセットで拒否される
+describe("checkSandbox - defaultPermission (未設定プロジェクトの既定権限)", () => {
+  it("defaultPermission: read が未設定プロジェクトの write コマンドを拒否する", () => {
+    writeTestConfig({ defaultPermission: "read" })
     expect(() => checkSandbox("page.new", makeArgs({ project: "未設定プロジェクト" }))).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it('"read" プリセットが未設定プロジェクトの read コマンドを許可する', () => {
-    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
-    // page.get は read 系コマンドなので通過する
+  it("defaultPermission: read が未設定プロジェクトの read コマンドを許可する", () => {
+    writeTestConfig({ defaultPermission: "read" })
     expect(() =>
       checkSandbox("page.get", makeArgs({ project: "未設定プロジェクト" })),
     ).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
   })
 
-  it('"none" プリセットが未設定プロジェクトの全コマンドを拒否する', () => {
-    writeTestConfig({ agent: { defaultProjectPermission: "none" } })
-    // read 系も write 系もすべて拒否される
+  it("defaultPermission: none が未設定プロジェクトの全コマンドを拒否する", () => {
+    writeTestConfig({ defaultPermission: "none" })
     expect(() => checkSandbox("page.get", makeArgs({ project: "未設定プロジェクト" }))).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
 
-  it('"readwrite" プリセットは全コマンドを許可する', () => {
-    writeTestConfig({ agent: { defaultProjectPermission: "readwrite" } })
-    // write 系コマンドも許可される
+  it("defaultPermission: readwrite が未設定プロジェクトの全コマンドを許可する", () => {
+    writeTestConfig({ defaultPermission: "readwrite" })
     expect(() =>
       checkSandbox("page.delete", makeArgs({ project: "未設定プロジェクト" })),
     ).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
   })
 
-  it("明示的に設定されたプロジェクトには defaultProjectPermission が適用されない", () => {
+  it("明示的に設定されたプロジェクトには defaultPermission が適用されない", () => {
     writeTestConfig({
-      agent: { defaultProjectPermission: "read" },
+      defaultPermission: "read",
       projects: {
         // 明示設定で全許可
-        明示設定プロジェクト: { enableCommands: ["*"] },
+        明示設定プロジェクト: { permission: "readwrite" },
       },
     })
-    // 明示設定のプロジェクトには read プリセットが適用されず page.new も許可される
+    // 明示設定のプロジェクトには defaultPermission が適用されず page.new も許可される
     expect(() =>
       checkSandbox("page.new", makeArgs({ project: "明示設定プロジェクト" })),
     ).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("プロジェクト未指定では defaultPermission が適用されない", () => {
+    writeTestConfig({ defaultPermission: "read" })
+    // project が指定されていないため defaultPermission が適用されず write コマンドも許可される
+    expect(() => checkSandbox("page.new", makeArgs())).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("checkSandbox - COS_PROJECT 環境変数", () => {
+  it("COS_PROJECT 環境変数でプロジェクトを指定してプロジェクト設定を適用できる", () => {
+    writeTestConfig({
+      projects: { 環境変数プロジェクト: { permission: "read" } },
+    })
+    process.env["COS_PROJECT"] = "環境変数プロジェクト"
+    expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
+    expect(exitMock).toHaveBeenCalledWith(7)
   })
 })
 
 describe("checkSandbox - CLI フラグ優先度", () => {
   it("CLI --enable-commands フラグはプロジェクト設定より優先される", () => {
     writeTestConfig({
-      projects: { 制限プロジェクト: { enableCommands: ["page.get"] } },
+      projects: { 制限プロジェクト: { permission: "read" } },
     })
     // CLI フラグで page.delete を明示的に許可する
     expect(() =>
@@ -256,7 +237,7 @@ describe("checkSandbox - CLI フラグ優先度", () => {
 
   it("CLI --disable-commands フラグはプロジェクト設定より優先される", () => {
     writeTestConfig({
-      projects: { 全許可プロジェクト: { enableCommands: ["*"] } },
+      projects: { 全許可プロジェクト: { permission: "readwrite" } },
     })
     // プロジェクトは全許可だが CLI フラグで page.delete を禁止する
     expect(() =>
@@ -267,29 +248,30 @@ describe("checkSandbox - CLI フラグ優先度", () => {
     ).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
   })
+
+  it("CLI --enable-commands フラグはグローバル disableCommands より優先される", () => {
+    writeTestConfig({ disableCommands: ["page.delete"] })
+    // CLI フラグで page.delete を明示的に許可する
+    expect(() =>
+      checkSandbox("page.delete", makeArgs({ "enable-commands": "page.delete" })),
+    ).not.toThrow()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
 })
 
-describe("checkSandbox - プロジェクト未指定の場合", () => {
+describe("checkSandbox - プロジェクト未指定", () => {
   it("プロジェクト未指定ではプロジェクト固有設定が適用されず全コマンドを許可する", () => {
     writeTestConfig({
-      projects: { マイプロジェクト: { disableCommands: ["page.delete"] } },
+      projects: { マイプロジェクト: { permission: "read" } },
     })
     // project が args にも env にもない場合は設定ファイルの projects を参照しない
     expect(() => checkSandbox("page.delete", makeArgs())).not.toThrow()
     expect(exitMock).not.toHaveBeenCalled()
   })
 
-  it("プロジェクト未指定でも agent.defaultDisableCommands は適用される", () => {
-    writeTestConfig({ agent: { defaultDisableCommands: ["page.delete"] } })
-    // グローバル設定は project 未指定でも適用される
+  it("プロジェクト未指定でも disableCommands は適用される", () => {
+    writeTestConfig({ disableCommands: ["page.delete"] })
     expect(() => checkSandbox("page.delete", makeArgs())).toThrow()
     expect(exitMock).toHaveBeenCalledWith(7)
-  })
-
-  it("プロジェクト未指定では defaultProjectPermission が適用されない", () => {
-    writeTestConfig({ agent: { defaultProjectPermission: "read" } })
-    // project が指定されていないため read プリセットが適用されず write コマンドも許可される
-    expect(() => checkSandbox("page.new", makeArgs())).not.toThrow()
-    expect(exitMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/core/command-classification.test.ts
+++ b/tests/unit/core/command-classification.test.ts
@@ -63,6 +63,13 @@ describe("READ_COMMANDS", () => {
 })
 
 describe("WRITE_COMMANDS", () => {
+  it("READ_COMMANDS と重複しない", () => {
+    const overlap = READ_COMMANDS.filter((command) =>
+      (WRITE_COMMANDS as readonly string[]).includes(command),
+    )
+    expect(overlap).toHaveLength(0)
+  })
+
   it("ページ書き込み系コマンドを含む", () => {
     expect(WRITE_COMMANDS).toContain("page.new")
     expect(WRITE_COMMANDS).toContain("page.delete")

--- a/tests/unit/core/command-classification.test.ts
+++ b/tests/unit/core/command-classification.test.ts
@@ -1,0 +1,124 @@
+/**
+ * command-classification.test.ts — コマンドの read/write 分類テーブルと
+ * プリセット展開関数のテスト。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  READ_COMMANDS,
+  WRITE_COMMANDS,
+  expandPermissionPreset,
+} from "@/core/command-classification"
+
+describe("READ_COMMANDS", () => {
+  it("ページ取得系コマンドを含む", () => {
+    expect(READ_COMMANDS).toContain("page.get")
+    expect(READ_COMMANDS).toContain("page.list")
+    expect(READ_COMMANDS).toContain("page.text")
+    expect(READ_COMMANDS).toContain("page.code")
+    expect(READ_COMMANDS).toContain("page.context")
+    expect(READ_COMMANDS).toContain("page.url")
+    expect(READ_COMMANDS).toContain("page.watch")
+    expect(READ_COMMANDS).toContain("page.line.get")
+  })
+
+  it("プロジェクト取得系コマンドを含む", () => {
+    expect(READ_COMMANDS).toContain("project.info")
+    expect(READ_COMMANDS).toContain("project.list")
+    expect(READ_COMMANDS).toContain("project.graph")
+  })
+
+  it("ユーティリティ系読み取りコマンドを含む", () => {
+    expect(READ_COMMANDS).toContain("search")
+    expect(READ_COMMANDS).toContain("auth.whoami")
+    expect(READ_COMMANDS).toContain("config.get")
+    expect(READ_COMMANDS).toContain("config.path")
+    expect(READ_COMMANDS).toContain("schema")
+    expect(READ_COMMANDS).toContain("exit-codes")
+    expect(READ_COMMANDS).toContain("notation")
+    expect(READ_COMMANDS).toContain("convert")
+    expect(READ_COMMANDS).toContain("sync.diff")
+    expect(READ_COMMANDS).toContain("sync.pull")
+  })
+
+  it("書き込みコマンドを含まない", () => {
+    expect(READ_COMMANDS).not.toContain("page.new")
+    expect(READ_COMMANDS).not.toContain("page.delete")
+    expect(READ_COMMANDS).not.toContain("page.edit")
+    expect(READ_COMMANDS).not.toContain("page.append")
+    expect(READ_COMMANDS).not.toContain("page.prepend")
+    expect(READ_COMMANDS).not.toContain("page.insert")
+    expect(READ_COMMANDS).not.toContain("page.rename")
+    expect(READ_COMMANDS).not.toContain("page.line.replace")
+    expect(READ_COMMANDS).not.toContain("page.line.delete")
+    expect(READ_COMMANDS).not.toContain("page.pin")
+    expect(READ_COMMANDS).not.toContain("page.unpin")
+    expect(READ_COMMANDS).not.toContain("page.icon")
+    expect(READ_COMMANDS).not.toContain("auth.login")
+    expect(READ_COMMANDS).not.toContain("auth.logout")
+    expect(READ_COMMANDS).not.toContain("config.set")
+    expect(READ_COMMANDS).not.toContain("sync.push")
+    expect(READ_COMMANDS).not.toContain("serve.rest")
+  })
+})
+
+describe("WRITE_COMMANDS", () => {
+  it("ページ書き込み系コマンドを含む", () => {
+    expect(WRITE_COMMANDS).toContain("page.new")
+    expect(WRITE_COMMANDS).toContain("page.delete")
+    expect(WRITE_COMMANDS).toContain("page.edit")
+    expect(WRITE_COMMANDS).toContain("page.append")
+    expect(WRITE_COMMANDS).toContain("page.prepend")
+    expect(WRITE_COMMANDS).toContain("page.insert")
+    expect(WRITE_COMMANDS).toContain("page.rename")
+    expect(WRITE_COMMANDS).toContain("page.line.replace")
+    expect(WRITE_COMMANDS).toContain("page.line.delete")
+    expect(WRITE_COMMANDS).toContain("page.pin")
+    expect(WRITE_COMMANDS).toContain("page.unpin")
+    expect(WRITE_COMMANDS).toContain("page.icon")
+  })
+
+  it("認証・設定・同期系書き込みコマンドを含む", () => {
+    expect(WRITE_COMMANDS).toContain("auth.login")
+    expect(WRITE_COMMANDS).toContain("auth.logout")
+    expect(WRITE_COMMANDS).toContain("config.set")
+    expect(WRITE_COMMANDS).toContain("sync.push")
+    expect(WRITE_COMMANDS).toContain("serve.rest")
+  })
+
+  it("読み取りコマンドを含まない", () => {
+    expect(WRITE_COMMANDS).not.toContain("page.get")
+    expect(WRITE_COMMANDS).not.toContain("page.list")
+    expect(WRITE_COMMANDS).not.toContain("search")
+    expect(WRITE_COMMANDS).not.toContain("auth.whoami")
+  })
+})
+
+describe("expandPermissionPreset", () => {
+  it('"read" プリセットは read 系コマンドのみを enable に展開する', () => {
+    const result = expandPermissionPreset("read")
+    // enable に read コマンドが含まれる
+    expect(result.enable).toContain("page.get")
+    expect(result.enable).toContain("page.list")
+    expect(result.enable).toContain("search")
+    // write コマンドは含まれない
+    expect(result.enable).not.toContain("page.delete")
+    expect(result.enable).not.toContain("page.new")
+    // disable は指定しない
+    expect(result.disable).toBeUndefined()
+  })
+
+  it('"readwrite" プリセットは全コマンドを enable する', () => {
+    const result = expandPermissionPreset("readwrite")
+    // * で全許可
+    expect(result.enable).toContain("*")
+    expect(result.disable).toBeUndefined()
+  })
+
+  it('"none" プリセットは全コマンドを disable する', () => {
+    const result = expandPermissionPreset("none")
+    // enable は制限なし、disable で全拒否
+    expect(result.enable).toBeUndefined()
+    expect(result.disable).toContain("*")
+  })
+})

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -170,6 +170,51 @@ describe("setConfigValue", () => {
   })
 })
 
+describe("setConfigValue - 新規 sandbox 設定フィールド", () => {
+  it("agent.defaultEnableCommands にコマンドリストを設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "agent.defaultEnableCommands", ["page.get", "page.list"])
+    expect(updated.agent?.defaultEnableCommands).toEqual(["page.get", "page.list"])
+  })
+
+  it("agent.defaultProjectPermission に read を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "agent.defaultProjectPermission", "read")
+    expect(updated.agent?.defaultProjectPermission).toBe("read")
+  })
+
+  it("agent.defaultProjectPermission に readwrite を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "agent.defaultProjectPermission", "readwrite")
+    expect(updated.agent?.defaultProjectPermission).toBe("readwrite")
+  })
+
+  it("agent.defaultProjectPermission に none を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "agent.defaultProjectPermission", "none")
+    expect(updated.agent?.defaultProjectPermission).toBe("none")
+  })
+
+  it("agent.defaultProjectPermission に不正な値を設定するとエラーになる", () => {
+    const config = {}
+    expect(() => setConfigValue(config, "agent.defaultProjectPermission", "admin")).toThrow()
+  })
+
+  it("projects.<name>.enableCommands にコマンドリストを設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "projects.マイプロジェクト.enableCommands", ["page.get"])
+    expect(updated.projects?.["マイプロジェクト"]?.enableCommands).toEqual(["page.get"])
+  })
+
+  it("projects.<name>.disableCommands にコマンドリストを設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "projects.マイプロジェクト.disableCommands", [
+      "page.delete",
+    ])
+    expect(updated.projects?.["マイプロジェクト"]?.disableCommands).toEqual(["page.delete"])
+  })
+})
+
 describe("prototype 汚染への防御", () => {
   afterAll(() => {
     // RED フェーズで汚染が発生した場合に備えてクリーンアップする

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -170,34 +170,45 @@ describe("setConfigValue", () => {
   })
 })
 
-describe("setConfigValue - 新規 sandbox 設定フィールド", () => {
-  it("agent.defaultEnableCommands にコマンドリストを設定できる", () => {
+describe("setConfigValue - permission/disableCommands 設定フィールド", () => {
+  it("defaultPermission に read を設定できる", () => {
     const config = {}
-    const updated = setConfigValue(config, "agent.defaultEnableCommands", ["page.get", "page.list"])
-    expect(updated.agent?.defaultEnableCommands).toEqual(["page.get", "page.list"])
+    const updated = setConfigValue(config, "defaultPermission", "read")
+    expect(updated.defaultPermission).toBe("read")
   })
 
-  it("agent.defaultProjectPermission に read を設定できる", () => {
+  it("defaultPermission に readwrite を設定できる", () => {
     const config = {}
-    const updated = setConfigValue(config, "agent.defaultProjectPermission", "read")
-    expect(updated.agent?.defaultProjectPermission).toBe("read")
+    const updated = setConfigValue(config, "defaultPermission", "readwrite")
+    expect(updated.defaultPermission).toBe("readwrite")
   })
 
-  it("agent.defaultProjectPermission に readwrite を設定できる", () => {
+  it("defaultPermission に none を設定できる", () => {
     const config = {}
-    const updated = setConfigValue(config, "agent.defaultProjectPermission", "readwrite")
-    expect(updated.agent?.defaultProjectPermission).toBe("readwrite")
+    const updated = setConfigValue(config, "defaultPermission", "none")
+    expect(updated.defaultPermission).toBe("none")
   })
 
-  it("agent.defaultProjectPermission に none を設定できる", () => {
+  it("defaultPermission に不正な値を設定するとエラーになる", () => {
     const config = {}
-    const updated = setConfigValue(config, "agent.defaultProjectPermission", "none")
-    expect(updated.agent?.defaultProjectPermission).toBe("none")
+    expect(() => setConfigValue(config, "defaultPermission", "admin")).toThrow()
   })
 
-  it("agent.defaultProjectPermission に不正な値を設定するとエラーになる", () => {
+  it("disableCommands にコマンドリストを設定できる", () => {
     const config = {}
-    expect(() => setConfigValue(config, "agent.defaultProjectPermission", "admin")).toThrow()
+    const updated = setConfigValue(config, "disableCommands", ["page.delete", "page.new"])
+    expect(updated.disableCommands).toEqual(["page.delete", "page.new"])
+  })
+
+  it("projects.<name>.permission に read を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "projects.マイプロジェクト.permission", "read")
+    expect(updated.projects?.["マイプロジェクト"]?.permission).toBe("read")
+  })
+
+  it("projects.<name>.permission に不正な値を設定するとエラーになる", () => {
+    const config = {}
+    expect(() => setConfigValue(config, "projects.マイプロジェクト.permission", "admin")).toThrow()
   })
 
   it("projects.<name>.enableCommands にコマンドリストを設定できる", () => {


### PR DESCRIPTION
## Summary

- `agent.*` 設定を廃止し、`defaultPermission` / `disableCommands` をルートレベルに昇格
- `projects.<name>.permission` プリセット (`read` / `readwrite` / `none`) を追加
- `disableCommands` を全プロジェクト共通の絶対禁止リストとして実装（`permission: "readwrite"` のプロジェクトでも適用される）
- `defaultPermission` はプロジェクト指定時のみ有効（プロジェクト未指定コマンドには無効）

## 新しい設定例

```json5
{
  disableCommands: ["page.delete"],      // 絶対禁止 (全プロジェクト共通)
  defaultPermission: "read",             // 未列挙プロジェクトの既定
  projects: {
    "my-wiki": { permission: "readwrite" },
    "private": { permission: "none" },
  }
}
```

## 優先順位

CLI フラグ > 環境変数 > プロジェクト固有設定 > `defaultPermission` > 全許可

`disableCommands` は CLI/env 未指定時、プロジェクト設定の後に重ねて適用。

## Test plan

- [x] `bun test` 1104 pass / 0 fail
- [x] `bunx biome check src tests` エラーなし
- [x] `bun run typecheck` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 設定ファイルでサンドボックスのコマンド制限を永続化できるようになりました。プロジェクト別の権限プリセット（読み取り/読み書き/制限）とコマンドの許可/禁止リストに対応しました。
  * CLI フラグ、環境変数、プロジェクト設定、デフォルト設定による明確な優先順位を確立しました。

* **Documentation**
  * サンドボックス設定の詳細なガイドと具体例を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->