### PR TITLE
feat(project): cos project stream コマンドを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ cos page line get       指定行または範囲を取得
 cos page line replace   指定行または範囲を置換 (rm エイリアスあり)
 cos page line delete    指定行または範囲を削除
 
-cos project list  参加プロジェクト一覧を取得
-cos project info  プロジェクト情報を取得
+cos project list    参加プロジェクト一覧を取得
+cos project info    プロジェクト情報を取得
+cos project stream  プロジェクトの最近更新フィードを取得 (--watch でポーリング監視)
 
 cos search        全文検索
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ import { projectGraphCommand } from "@/commands/project/graph"
 import { projectInfoCommand } from "@/commands/project/info"
 // プロジェクトコマンド
 import { projectListCommand } from "@/commands/project/list"
+import { projectStreamCommand } from "@/commands/project/stream"
 
 // 検索コマンド
 import { searchCommand } from "@/commands/search"
@@ -129,6 +130,7 @@ const projectCommand = defineCommand({
     ls: projectListCommand,
     info: projectInfoCommand,
     graph: projectGraphCommand,
+    stream: projectStreamCommand,
   },
 })
 

--- a/src/commands/project/stream.ts
+++ b/src/commands/project/stream.ts
@@ -1,0 +1,337 @@
+/**
+ * project/stream.ts — `cos project stream [<name>]` コマンド。
+ *
+ * /api/stream/:projectname/ を叩いてプロジェクトの最近更新フィードを取得する。
+ * --watch フラグを指定すると一定間隔でポーリングし、新規イベントを NDJSON で流す。
+ *
+ * 終了コード:
+ *   0   正常終了 (SIGINT 含む)
+ *   2   認証エラー
+ *   3   権限エラー
+ *   4   プロジェクト未発見
+ *   5   バリデーションエラー
+ *   7   sandbox 違反
+ *   124 タイムアウト
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError, RateLimitError } from "@/core/api/rest"
+import { writeErrorJson, writeJson, writeJsonLine } from "@/presenter/json"
+import { writePlainTable, writeTsv } from "@/presenter/plain"
+import type { StreamResponse } from "@/schemas/stream"
+import { defineCommand } from "citty"
+
+/** ProjectStreamRestClient は stream コマンドが REST 呼び出しに使用する最小 interface。 */
+export interface ProjectStreamRestClient {
+  getProjectStream(project: string, opts?: { limit?: number }): Promise<StreamResponse>
+}
+
+/**
+ * ProjectStreamDeps は makeProjectStreamCommand に渡す依存オブジェクト。
+ *
+ * テスト時にモックを注入できるようにするための DI interface。
+ * 指定しないフィールドは本番実装にフォールバックする。
+ */
+export interface ProjectStreamDeps {
+  /** セッション ID 取得関数 (現在は buildRestClient 内部で使用) */
+  getSid?: (profile?: string) => Promise<string>
+  /** REST クライアント (省略時: buildRestClient で生成) */
+  restClient?: ProjectStreamRestClient
+  /** AbortSignal 対応 sleep (省略時: sleepWithSignal) */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>
+}
+
+/**
+ * sleepWithSignal は AbortSignal が abort されたとき即 resolve する sleep。
+ *
+ * watch モードのポーリング間隔の待機に使用する。
+ * abort 後は Promise を resolve して即座にループを抜けられるようにする。
+ */
+async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+/** formatTimestamp は UnixTime (秒) を ISO 8601 形式の文字列に変換する。 */
+function formatTimestamp(unixSec: number): string {
+  return new Date(unixSec * 1000).toISOString()
+}
+
+/**
+ * makeProjectStreamCommand は ProjectStreamDeps を受け取り、citty コマンドを返すファクトリ。
+ *
+ * deps を省略すると本番実装 (実際の REST API 呼び出し) を使用する。
+ * テスト時は deps にモックを渡してフローを検証する。
+ */
+export function makeProjectStreamCommand(deps: ProjectStreamDeps = {}) {
+  return defineCommand({
+    meta: {
+      name: "stream",
+      description: "プロジェクトの最近更新フィードを取得する (--watch でポーリング監視)",
+    },
+    args: {
+      ...commonArgs,
+      name: {
+        type: "positional",
+        description: "プロジェクト名 (省略時は --project フラグを使用)",
+        required: false,
+      },
+      limit: {
+        type: "string",
+        description: "取得件数の上限",
+      },
+      watch: {
+        type: "boolean",
+        description: "ポーリングして新規イベントを継続出力する",
+        default: false,
+      },
+      interval: {
+        type: "string",
+        description: "watch モードのポーリング間隔 (秒, デフォルト: 30)",
+        default: "30",
+      },
+      timeout: {
+        type: "string",
+        description: "watch モードのタイムアウト秒数 (0 = 無限, デフォルト: 0)",
+        default: "0",
+      },
+    },
+    async run({ args }) {
+      const a = args as CommonArgs & {
+        name?: string
+        limit?: string
+        watch: boolean
+        interval: string | number
+        timeout: string | number
+      }
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      // 1. sandbox チェック
+      checkSandbox("project.stream", a)
+
+      // 2. --limit バリデーション
+      let limitOpts: { limit?: number } = {}
+      if (a.limit !== undefined) {
+        const limitNum = Number(a.limit)
+        if (!Number.isInteger(limitNum) || limitNum < 1) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `--limit に不正な値が指定されました: "${a.limit}"`,
+            "--limit には 1 以上の整数を指定してください",
+          )
+          process.exit(5)
+          throw new Error("VALIDATION_ERROR")
+        }
+        limitOpts = { limit: limitNum }
+      }
+
+      // 3. watch モード固有のバリデーション
+      if (a.watch) {
+        const intervalSec = Number(a.interval)
+        if (Number.isNaN(intervalSec) || intervalSec < 1) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `--interval に不正な値が指定されました: "${a.interval}"`,
+            "--interval には 1 以上の数値を指定してください (レート保護のため最小 1 秒)",
+          )
+          process.exit(5)
+          throw new Error("VALIDATION_ERROR")
+        }
+        const timeoutSec = Number(a.timeout)
+        if (Number.isNaN(timeoutSec) || timeoutSec < 0) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `--timeout に不正な値が指定されました: "${a.timeout}"`,
+            "--timeout には 0 以上の数値を指定してください",
+          )
+          process.exit(5)
+          throw new Error("VALIDATION_ERROR")
+        }
+      }
+
+      // 4. プロジェクト名解決
+      const project = a.name ?? requireProject(a)
+
+      // 5. REST クライアント生成
+      const client: ProjectStreamRestClient =
+        deps.restClient !== undefined ? deps.restClient : await buildRestClient(a)
+      const sleepFn = deps.sleep ?? sleepWithSignal
+
+      // 6. snapshot モード
+      if (!a.watch) {
+        let result: StreamResponse
+        try {
+          result = await client.getProjectStream(project, limitOpts)
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            writeErrorJson(
+              "NOT_FOUND",
+              `プロジェクト "${project}" が見つかりません`,
+              "プロジェクト名を確認してください",
+            )
+            process.exit(4)
+            throw new Error("NOT_FOUND")
+          }
+          if (err instanceof AuthError) {
+            writeErrorJson("AUTH_ERROR", "認証が必要です", "`cos auth login` を実行してください")
+            process.exit(2)
+            throw new Error("AUTH_ERROR")
+          }
+          if (err instanceof ForbiddenError) {
+            writeErrorJson("FORBIDDEN", "このプロジェクトへのアクセス権限がありません")
+            process.exit(3)
+            throw new Error("FORBIDDEN")
+          }
+          throw err
+        }
+
+        if (a.json) {
+          writeJson(result, { command: "project.stream", startTime }, buildJsonOpts(a))
+          return
+        }
+
+        if (a.plain) {
+          writeTsv(
+            ["created", "type", "pageId", "userId"],
+            result.events.map((e) => [formatTimestamp(e.created), e.type, e.pageId, e.userId]),
+          )
+          return
+        }
+
+        writePlainTable(
+          ["作成日時", "種別", "ページID", "ユーザーID"],
+          result.events.map((e) => [formatTimestamp(e.created), e.type, e.pageId, e.userId]),
+        )
+        return
+      }
+
+      // 7. watch モード
+      const intervalSec = Number(a.interval)
+      const timeoutSec = Number(a.timeout)
+      const intervalMs = intervalSec * 1000
+
+      const ac = new AbortController()
+      let timedOut = false
+
+      const sigintHandler = () => {
+        ac.abort()
+      }
+      process.once("SIGINT", sigintHandler)
+
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+      if (timeoutSec > 0) {
+        timeoutHandle = setTimeout(() => {
+          timedOut = true
+          ac.abort()
+        }, timeoutSec * 1000)
+      }
+
+      // 既知イベント ID 集合 (重複排除) と最新 updated カーソル (UnixTime 秒)
+      const seenEventIds = new Set<string>()
+      let lastUpdated = 0
+
+      logger.info(`プロジェクト "${project}" のフィードを監視中... (Ctrl+C で停止)`)
+
+      try {
+        while (!ac.signal.aborted) {
+          let stream: StreamResponse
+          try {
+            stream = await client.getProjectStream(project, limitOpts)
+          } catch (err) {
+            if (err instanceof RateLimitError) {
+              // 429 は警告を出して次サイクルまで継続
+              writeJsonLine({
+                error: {
+                  code: "RATE_LIMITED",
+                  message: "レート制限を検出、次サイクルまで待機します",
+                },
+              })
+              await sleepFn(intervalMs, ac.signal)
+              continue
+            }
+            if (err instanceof AuthError) {
+              writeErrorJson("AUTH_ERROR", "認証が必要です")
+              process.exit(2)
+              throw new Error("AUTH_ERROR")
+            }
+            if (err instanceof ForbiddenError) {
+              writeErrorJson("FORBIDDEN", "このプロジェクトへのアクセス権限がありません")
+              process.exit(3)
+              throw new Error("FORBIDDEN")
+            }
+            if (err instanceof NotFoundError) {
+              writeErrorJson("NOT_FOUND", `プロジェクト "${project}" が見つかりません`)
+              process.exit(4)
+              throw new Error("NOT_FOUND")
+            }
+            throw err
+          }
+
+          if (lastUpdated === 0) {
+            // 初回: ベースライン化のみ (既存イベントは出力しない)
+            if (stream.events.length > 0) {
+              lastUpdated = Math.max(...stream.events.map((e) => e.updated))
+              for (const e of stream.events) {
+                seenEventIds.add(e.id)
+              }
+            }
+          } else {
+            // 差分検出: 新規イベントのみ updated 昇順で出力
+            const fresh = stream.events
+              .filter((e) => !seenEventIds.has(e.id) && e.updated > lastUpdated)
+              .sort((a, b) => a.updated - b.updated)
+
+            for (const event of fresh) {
+              if (a.plain) {
+                process.stdout.write(
+                  `${formatTimestamp(event.created)}\t${event.type}\t${event.pageId}\t${event.userId}\n`,
+                )
+              } else {
+                writeJsonLine(event)
+              }
+              seenEventIds.add(event.id)
+              if (event.updated > lastUpdated) lastUpdated = event.updated
+            }
+
+            // seenEventIds のメモリ抑制: lastUpdated より 1 時間以上古い ID を削除
+            for (const e of stream.events) {
+              if (e.updated < lastUpdated - 3600) {
+                seenEventIds.delete(e.id)
+              }
+            }
+          }
+
+          if (ac.signal.aborted) break
+          await sleepFn(intervalMs, ac.signal)
+        }
+      } finally {
+        clearTimeout(timeoutHandle)
+        process.removeListener("SIGINT", sigintHandler)
+      }
+
+      process.exit(timedOut ? 124 : 0)
+    },
+  })
+}
+
+/** projectStreamCommand は deps なしの本番実装コマンド。 */
+export const projectStreamCommand = makeProjectStreamCommand()

--- a/src/commands/project/stream.ts
+++ b/src/commands/project/stream.ts
@@ -41,8 +41,6 @@ export interface ProjectStreamRestClient {
  * 指定しないフィールドは本番実装にフォールバックする。
  */
 export interface ProjectStreamDeps {
-  /** セッション ID 取得関数 (現在は buildRestClient 内部で使用) */
-  getSid?: (profile?: string) => Promise<string>
   /** REST クライアント (省略時: buildRestClient で生成) */
   restClient?: ProjectStreamRestClient
   /** AbortSignal 対応 sleep (省略時: sleepWithSignal) */
@@ -245,8 +243,10 @@ export function makeProjectStreamCommand(deps: ProjectStreamDeps = {}) {
         }, timeoutSec * 1000)
       }
 
-      // 既知イベント ID 集合 (重複排除) と最新 updated カーソル (UnixTime 秒)
-      const seenEventIds = new Set<string>()
+      // 既知イベント ID → updated のマップ (重複排除 + TTL ベースのメモリ抑制)
+      const seenEvents = new Map<string, number>()
+      // ベースライン確立フラグ (初回 fetch 完了で true になる)
+      let baselined = false
       let lastUpdated = 0
 
       logger.info(`プロジェクト "${project}" のフィードを監視中... (Ctrl+C で停止)`)
@@ -286,38 +286,43 @@ export function makeProjectStreamCommand(deps: ProjectStreamDeps = {}) {
             throw err
           }
 
-          if (lastUpdated === 0) {
+          if (!baselined) {
             // 初回: ベースライン化のみ (既存イベントは出力しない)
+            baselined = true
             if (stream.events.length > 0) {
               lastUpdated = Math.max(...stream.events.map((e) => e.updated))
               for (const e of stream.events) {
-                seenEventIds.add(e.id)
+                seenEvents.set(e.id, e.updated)
               }
             }
+            // イベントがない場合は lastUpdated を 0 のままにする
+            // (次ポーリングで差分検出ブランチに入り全イベントを出力する)
           } else {
             // 差分検出: 新規イベントのみ updated 昇順で出力
             const fresh = stream.events
-              .filter((e) => !seenEventIds.has(e.id) && e.updated > lastUpdated)
+              .filter((e) => !seenEvents.has(e.id) && e.updated >= lastUpdated)
               .sort((a, b) => a.updated - b.updated)
 
             for (const event of fresh) {
               if (a.plain) {
-                process.stdout.write(
-                  `${formatTimestamp(event.created)}\t${event.type}\t${event.pageId}\t${event.userId}\n`,
+                writeTsv(
+                  ["created", "type", "pageId", "userId"],
+                  [[formatTimestamp(event.created), event.type, event.pageId, event.userId]],
+                  { noHeader: true },
                 )
               } else {
                 writeJsonLine(event)
               }
-              seenEventIds.add(event.id)
+              seenEvents.set(event.id, event.updated)
               if (event.updated > lastUpdated) lastUpdated = event.updated
             }
 
-            // seenEventIds のメモリ抑制: lastUpdated より 1 時間以上古い ID を削除
-            for (const e of stream.events) {
-              if (e.updated < lastUpdated - 3600) {
-                seenEventIds.delete(e.id)
-              }
+            // seenEvents のメモリ抑制: lastUpdated より 1 時間以上古い ID を削除
+            const toEvict: string[] = []
+            for (const [id, updated] of seenEvents) {
+              if (updated < lastUpdated - 3600) toEvict.push(id)
             }
+            for (const id of toEvict) seenEvents.delete(id)
           }
 
           if (ac.signal.aborted) break

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -15,6 +15,8 @@ import {
 import type { Page, PageListResponse, SearchResult, TitleSearchResult } from "@/schemas/page"
 import { ProjectListResponseSchema, ProjectSchema } from "@/schemas/project"
 import type { Project, ProjectListResponse } from "@/schemas/project"
+import { StreamResponseSchema } from "@/schemas/stream"
+import type { StreamResponse } from "@/schemas/stream"
 import { type Me, MeSchema } from "@/schemas/user"
 import { z } from "zod"
 
@@ -186,6 +188,17 @@ export class CosenseRestClient {
   async listProjects(): Promise<ProjectListResponse> {
     const data = await this.fetchJson(`${BASE_URL}/api/projects`)
     return ProjectListResponseSchema.parse(data)
+  }
+
+  /** getProjectStream は /api/stream/:project/ を叩いてプロジェクトの最近更新フィードを返す。 */
+  async getProjectStream(project: string, opts: { limit?: number } = {}): Promise<StreamResponse> {
+    const params = new URLSearchParams()
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit))
+    const query = params.size > 0 ? `?${params.toString()}` : ""
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/stream/${encodeURIComponent(project)}/${query}`,
+    )
+    return StreamResponseSchema.parse(data)
   }
 
   private buildHeaders(): Record<string, string> {

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -30,6 +30,7 @@ export const READ_COMMANDS: readonly string[] = [
   "project.graph",
   "project.info",
   "project.list",
+  "project.stream",
   "schema",
   "search",
   "sync.diff",

--- a/src/schemas/stream.ts
+++ b/src/schemas/stream.ts
@@ -1,0 +1,67 @@
+/**
+ * stream.ts — /api/stream/:projectname/ レスポンスの zod スキーマ定義。
+ *
+ * プロジェクト全体の最近更新フィードを検証する。
+ * - StreamResponseSchema: フィード全体 (pages + events)
+ * - ProjectUpdatesStreamEventSchema: 7 種のプロジェクトイベント判別共用体
+ */
+
+import { PageSummarySchema } from "@/schemas/page"
+import { z } from "zod"
+
+/**
+ * ProjectEventBaseSchema はすべてのプロジェクトイベントに共通するフィールド定義。
+ *
+ * @cosense/types の ProjectEvent interface に対応する。
+ */
+const ProjectEventBaseSchema = z.object({
+  id: z.string(),
+  pageId: z.string(),
+  userId: z.string(),
+  projectId: z.string(),
+  created: z.number(),
+  updated: z.number(),
+})
+
+/**
+ * ProjectUpdatesStreamEventSchema は /api/stream/:project/ の events 配列要素を表す。
+ *
+ * @cosense/types/stream-event.ts の ProjectUpdatesStreamEvent 判別共用体に対応する。
+ * type フィールドで 7 種のイベントを識別する。
+ */
+export const ProjectUpdatesStreamEventSchema = z.discriminatedUnion("type", [
+  ProjectEventBaseSchema.extend({
+    type: z.literal("page.delete"),
+    data: z.object({ titleLc: z.string() }),
+  }),
+  ProjectEventBaseSchema.extend({ type: z.literal("member.join") }),
+  ProjectEventBaseSchema.extend({ type: z.literal("member.add") }),
+  ProjectEventBaseSchema.extend({ type: z.literal("invitation.reset") }),
+  ProjectEventBaseSchema.extend({
+    type: z.literal("admin.add"),
+    targetUserId: z.string(),
+  }),
+  ProjectEventBaseSchema.extend({
+    type: z.literal("admin.delete"),
+    targetUserId: z.string(),
+  }),
+  ProjectEventBaseSchema.extend({
+    type: z.literal("owner.set"),
+    targetUserId: z.string(),
+  }),
+])
+export type ProjectUpdatesStreamEvent = z.infer<typeof ProjectUpdatesStreamEventSchema>
+
+/**
+ * StreamResponseSchema は /api/stream/:projectname/ のレスポンス全体を表す。
+ *
+ * @cosense/types/api/stream/project.ts の Stream interface に対応する。
+ * pages は PageSummarySchema で受ける (実 API は詳細な Page 型ではなく概要形式を返すため)。
+ */
+export const StreamResponseSchema = z.object({
+  projectName: z.string(),
+  end: z.number(),
+  pages: z.array(PageSummarySchema),
+  events: z.array(ProjectUpdatesStreamEventSchema),
+})
+export type StreamResponse = z.infer<typeof StreamResponseSchema>

--- a/tests/fixtures/project-stream.json
+++ b/tests/fixtures/project-stream.json
@@ -1,0 +1,87 @@
+{
+  "projectName": "テストプロジェクト",
+  "end": 1700000000,
+  "pages": [
+    {
+      "id": "ページID-001",
+      "title": "テストページ1",
+      "updated": 1700000000,
+      "created": 1699900000
+    },
+    {
+      "id": "ページID-002",
+      "title": "テストページ2",
+      "updated": 1699950000,
+      "created": 1699800000
+    }
+  ],
+  "events": [
+    {
+      "id": "イベントID-001",
+      "pageId": "ページID-001",
+      "userId": "ユーザーID-001",
+      "projectId": "プロジェクトID-001",
+      "created": 1700000001,
+      "updated": 1700000001,
+      "type": "page.delete",
+      "data": { "titleLc": "テストページ1" }
+    },
+    {
+      "id": "イベントID-002",
+      "pageId": "ページID-002",
+      "userId": "ユーザーID-002",
+      "projectId": "プロジェクトID-001",
+      "created": 1699990001,
+      "updated": 1699990001,
+      "type": "member.join"
+    },
+    {
+      "id": "イベントID-003",
+      "pageId": "ページID-003",
+      "userId": "ユーザーID-003",
+      "projectId": "プロジェクトID-001",
+      "created": 1699980001,
+      "updated": 1699980001,
+      "type": "member.add"
+    },
+    {
+      "id": "イベントID-004",
+      "pageId": "ページID-004",
+      "userId": "ユーザーID-001",
+      "projectId": "プロジェクトID-001",
+      "created": 1699970001,
+      "updated": 1699970001,
+      "type": "invitation.reset"
+    },
+    {
+      "id": "イベントID-005",
+      "pageId": "ページID-005",
+      "userId": "ユーザーID-001",
+      "projectId": "プロジェクトID-001",
+      "created": 1699960001,
+      "updated": 1699960001,
+      "type": "admin.add",
+      "targetUserId": "ユーザーID-002"
+    },
+    {
+      "id": "イベントID-006",
+      "pageId": "ページID-006",
+      "userId": "ユーザーID-001",
+      "projectId": "プロジェクトID-001",
+      "created": 1699950001,
+      "updated": 1699950001,
+      "type": "admin.delete",
+      "targetUserId": "ユーザーID-003"
+    },
+    {
+      "id": "イベントID-007",
+      "pageId": "ページID-007",
+      "userId": "ユーザーID-001",
+      "projectId": "プロジェクトID-001",
+      "created": 1699940001,
+      "updated": 1699940001,
+      "type": "owner.set",
+      "targetUserId": "ユーザーID-002"
+    }
+  ]
+}

--- a/tests/unit/commands/project/stream.test.ts
+++ b/tests/unit/commands/project/stream.test.ts
@@ -131,7 +131,6 @@ const defaultArgs: Record<string, unknown> = {
 /** createMockDeps はモック依存を生成する。個別フィールドを上書き可能。 */
 function createMockDeps(overrides: Partial<ProjectStreamDeps> = {}): ProjectStreamDeps {
   return {
-    getSid: async () => "テストSID",
     restClient: createMockRestClient(),
     sleep: createImmediateSleep(),
     ...overrides,
@@ -353,6 +352,37 @@ describe("makeProjectStreamCommand", () => {
 
       // イベントの NDJSON 行は 0 件 (ベースライン化のみ)
       expect(captureEventLines(captureStdout())).toHaveLength(0)
+    })
+
+    it("初回レスポンスが空のとき 2 回目の新規イベントを取りこぼさない (baselined フラグ)", async () => {
+      // 1 回目: events が空 → baselined = true になるが lastUpdated はタイムスタンプに設定
+      // 2 回目: 新しいイベントが出現 → 出力されるべき
+      const newEvent = {
+        id: "イベントID-新規A",
+        pageId: "ページID-新規",
+        userId: "ユーザーID-001",
+        projectId: "プロジェクトID-001",
+        created: 1700100000,
+        updated: 1700100000,
+        type: "member.join" as const,
+      }
+      const emptyResponse: StreamResponse = { ...mockStreamResponse, events: [] }
+      const secondResponse: StreamResponse = { ...mockStreamResponse, events: [newEvent] }
+
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          restClient: createMockRestClient([emptyResponse, secondResponse]),
+          // 2 回目の sleep で SIGINT を発行する
+          sleep: createWatchSleep(2),
+        }),
+      )
+
+      // 2 回目のポーリングで baselined が true になって差分検出に入り、newEvent が出力される
+      const eventLines = captureEventLines(captureStdout())
+      expect(eventLines.length).toBeGreaterThanOrEqual(1)
+      const parsed = JSON.parse(eventLines[0] ?? "null") as { id: string }
+      expect(parsed.id).toBe("イベントID-新規A")
     })
 
     it("2 回目に新規イベントが追加されると NDJSON で出力する", async () => {

--- a/tests/unit/commands/project/stream.test.ts
+++ b/tests/unit/commands/project/stream.test.ts
@@ -1,0 +1,550 @@
+/**
+ * project/stream.test.ts — `cos project stream` コマンドのテスト。
+ *
+ * DI (deps) を使って REST クライアントをモック注入し、
+ * snapshot モード・watch モード・エラー系・バリデーションを検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import {
+  type ProjectStreamDeps,
+  type ProjectStreamRestClient,
+  makeProjectStreamCommand,
+} from "@/commands/project/stream"
+import { AuthError, ForbiddenError, NotFoundError, RateLimitError } from "@/core/api/rest"
+import type { StreamResponse } from "@/schemas/stream"
+
+// ----- モックデータ -----
+
+/** 基本 StreamResponse (snapshot 用) */
+const mockStreamResponse: StreamResponse = {
+  projectName: "テストプロジェクト",
+  end: 1700000000,
+  pages: [
+    { id: "ページID-001", title: "テストページ1", updated: 1700000000, created: 1699900000 },
+    { id: "ページID-002", title: "テストページ2", updated: 1699950000, created: 1699800000 },
+  ],
+  events: [
+    {
+      id: "イベントID-001",
+      pageId: "ページID-001",
+      userId: "ユーザーID-001",
+      projectId: "プロジェクトID-001",
+      created: 1700000001,
+      updated: 1700000001,
+      type: "page.delete",
+      data: { titleLc: "テストページ1" },
+    },
+    {
+      id: "イベントID-002",
+      pageId: "ページID-002",
+      userId: "ユーザーID-002",
+      projectId: "プロジェクトID-001",
+      created: 1699990001,
+      updated: 1699990001,
+      type: "member.join",
+    },
+  ],
+}
+
+// ----- モックファクトリ -----
+
+/** createMockRestClient はモック REST クライアントを生成する。 */
+function createMockRestClient(
+  responses: StreamResponse[] | (() => StreamResponse) = [mockStreamResponse],
+  opts: { throwError?: Error } = {},
+): ProjectStreamRestClient {
+  let callCount = 0
+  return {
+    async getProjectStream() {
+      if (opts.throwError) throw opts.throwError
+      if (typeof responses === "function") return responses()
+      const response = responses[callCount] ?? responses[responses.length - 1]
+      callCount++
+      return response as StreamResponse
+    },
+  }
+}
+
+/**
+ * createImmediateSleep は即座に resolve する sleep モックを返す。
+ * watch モードのポーリング間隔を待機なしで実行できる。
+ */
+function createImmediateSleep(): (ms: number, signal: AbortSignal) => Promise<void> {
+  return async (_ms, signal) => {
+    if (signal.aborted) return
+    // マクロタスクを 1 つ挟んで非同期にする (abort チェックのため)
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+/**
+ * createWatchSleep は n 回目の sleep 呼び出しで SIGINT を発行する sleep モックを返す。
+ *
+ * コマンド内部の AbortController は外部から直接 abort できないため、
+ * SIGINT 経由でコマンドの sigintHandler を呼び出し、ループを終了させる。
+ * n 回目未満の呼び出しは即 resolve する。
+ */
+function createWatchSleep(
+  sigintAfterCalls = 1,
+): (ms: number, signal: AbortSignal) => Promise<void> {
+  let callCount = 0
+  return async (_ms, signal) => {
+    callCount++
+    if (signal.aborted) return
+    if (callCount >= sigintAfterCalls) {
+      // SIGINT を発行してコマンド内部の sigintHandler を呼び出す
+      process.emit("SIGINT", "SIGINT")
+      // abort signal が立つまで待つ
+      return new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve()
+          return
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true })
+      })
+    }
+    // まだ n 回目に達していないなら即 resolve して次の fetch へ
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+/** defaultArgs は全テストで共通の基本引数。 */
+const defaultArgs: Record<string, unknown> = {
+  name: "テストプロジェクト",
+  project: undefined,
+  limit: undefined,
+  watch: false,
+  interval: "30",
+  timeout: "0",
+  json: false,
+  plain: false,
+  "results-only": false,
+  select: undefined,
+  "enable-commands": undefined,
+  "disable-commands": undefined,
+  verbose: undefined,
+  quiet: false,
+  profile: undefined,
+}
+
+/** createMockDeps はモック依存を生成する。個別フィールドを上書き可能。 */
+function createMockDeps(overrides: Partial<ProjectStreamDeps> = {}): ProjectStreamDeps {
+  return {
+    getSid: async () => "テストSID",
+    restClient: createMockRestClient(),
+    sleep: createImmediateSleep(),
+    ...overrides,
+  }
+}
+
+/** runStream は makeProjectStreamCommand の run を呼び出すヘルパー。 */
+async function runStream(args: Record<string, unknown>, deps?: ProjectStreamDeps): Promise<void> {
+  const cmd = makeProjectStreamCommand(deps)
+  await (cmd.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** process.exit のモック後に継続実行で throw される例外を握り潰してコマンドを実行する */
+async function runAndIgnoreExit(
+  args: Record<string, unknown>,
+  deps?: ProjectStreamDeps,
+): Promise<void> {
+  try {
+    await runStream(args, deps)
+  } catch {
+    // process.exit モック後の継続による throw は想定内
+  }
+}
+
+// ----- セットアップ -----
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+const writtenChunks: string[] = []
+
+beforeEach(() => {
+  writtenChunks.length = 0
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writtenChunks.push(String(chunk))
+    return true
+  })
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+/** 書き出された全出力を結合して返す */
+function captureStdout(): string {
+  return writtenChunks.join("")
+}
+
+/** captureEventLines は stdout 出力から JSON イベント行 (error キーなし) を抽出する。 */
+function captureEventLines(out: string): string[] {
+  return out
+    .split("\n")
+    .filter((l) => l.trim())
+    .filter((l) => {
+      try {
+        const p = JSON.parse(l) as Record<string, unknown>
+        return "id" in p && !("error" in p)
+      } catch {
+        return false
+      }
+    })
+}
+
+// ----- テスト -----
+
+describe("makeProjectStreamCommand", () => {
+  describe("バリデーション", () => {
+    it("プロジェクト名未指定 (name も --project も環境変数もなし) の場合は exit 5 で終了する", async () => {
+      await runAndIgnoreExit(
+        { ...defaultArgs, name: undefined, project: undefined },
+        createMockDeps(),
+      )
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--limit に負数を指定すると exit 5 で終了する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, limit: "-1" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--limit に 0 を指定すると exit 5 で終了する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, limit: "0" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--limit に非数値を指定すると exit 5 で終了する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, limit: "abc" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--interval に 0 を指定すると exit 5 で終了する (レート保護: 最小 1 秒)", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, watch: true, interval: "0" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--interval に負数を指定すると exit 5 で終了する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, watch: true, interval: "-5" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--timeout に負数を指定すると exit 5 で終了する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, watch: true, timeout: "-1" }, createMockDeps())
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("sandbox 違反", () => {
+    it("--disable-commands=project.stream の場合は exit 7 で終了する", async () => {
+      await runAndIgnoreExit(
+        { ...defaultArgs, "disable-commands": "project.stream" },
+        createMockDeps(),
+      )
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe("snapshot モード (デフォルト)", () => {
+    it("getProjectStream が 1 回だけ呼ばれる", async () => {
+      let callCount = 0
+      const deps = createMockDeps({
+        restClient: {
+          async getProjectStream() {
+            callCount++
+            return mockStreamResponse
+          },
+        },
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(callCount).toBe(1)
+    })
+
+    it("--json の場合は envelope 形式で projectName/end/pages/events を含む JSON を出力する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, json: true }, createMockDeps())
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as { data: StreamResponse; meta: { command: string } }
+      expect(parsed.data.projectName).toBe("テストプロジェクト")
+      expect(parsed.data.end).toBe(1700000000)
+      expect(Array.isArray(parsed.data.pages)).toBe(true)
+      expect(Array.isArray(parsed.data.events)).toBe(true)
+      expect(parsed.meta.command).toBe("project.stream")
+    })
+
+    it("--results-only の場合は data のみ出力する (meta なし)", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, json: true, "results-only": true }, createMockDeps())
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as StreamResponse
+      expect(parsed.projectName).toBe("テストプロジェクト")
+      expect(Array.isArray(parsed.events)).toBe(true)
+    })
+
+    it("--select=events[].type の場合は event type 配列のみ出力する", async () => {
+      await runAndIgnoreExit(
+        { ...defaultArgs, json: true, "results-only": true, select: "events[].type" },
+        createMockDeps(),
+      )
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as string[]
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed).toContain("page.delete")
+      expect(parsed).toContain("member.join")
+    })
+
+    it("--plain の場合は TSV 形式で出力する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, plain: true }, createMockDeps())
+
+      const out = captureStdout()
+      // TSV なのでタブ区切りの行が含まれる
+      expect(out).toContain("\t")
+    })
+
+    it("NotFoundError の場合は exit 4 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient([], {
+          throwError: new NotFoundError("/api/stream/存在しないプロジェクト/"),
+        }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("AuthError の場合は exit 2 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient([], { throwError: new AuthError() }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+
+    it("ForbiddenError の場合は exit 3 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient([], { throwError: new ForbiddenError() }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(3)
+    })
+  })
+
+  describe("watch モード", () => {
+    it("初回呼び出しはベースライン化のみで stdout に何も出力しない", async () => {
+      // 1 回目の fetch 後 (ベースライン化) に sleep で SIGINT を発行して終了する
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          sleep: createWatchSleep(1),
+        }),
+      )
+
+      // イベントの NDJSON 行は 0 件 (ベースライン化のみ)
+      expect(captureEventLines(captureStdout())).toHaveLength(0)
+    })
+
+    it("2 回目に新規イベントが追加されると NDJSON で出力する", async () => {
+      // 1 回目: ベースラインのイベント (updated=1700000001)
+      // 2 回目: 新規イベント (updated=1700100000) が追加されている
+      const newEvent = {
+        id: "イベントID-新規",
+        pageId: "ページID-新規",
+        userId: "ユーザーID-001",
+        projectId: "プロジェクトID-001",
+        created: 1700100000,
+        updated: 1700100000,
+        type: "member.join" as const,
+      }
+      const secondResponse: StreamResponse = {
+        ...mockStreamResponse,
+        events: [newEvent, ...mockStreamResponse.events],
+      }
+
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          restClient: createMockRestClient([mockStreamResponse, secondResponse]),
+          // 2 回目の sleep で SIGINT を発行してループを終了させる
+          sleep: createWatchSleep(2),
+        }),
+      )
+
+      const eventLines = captureEventLines(captureStdout())
+      expect(eventLines.length).toBeGreaterThanOrEqual(1)
+      const parsed = JSON.parse(eventLines[0] ?? "null") as { id: string; type: string }
+      // 新規イベント 1 件が NDJSON で出力されていることを確認
+      expect(parsed.id).toBe("イベントID-新規")
+    })
+
+    it("同じ id のイベントが 2 回目にも含まれていても 1 度しか出力しない (重複排除)", async () => {
+      // 1 回目と 2 回目で同じ events を返す (新しい updated のイベントなし)
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          restClient: createMockRestClient([mockStreamResponse, mockStreamResponse]),
+          sleep: createWatchSleep(2),
+        }),
+      )
+
+      // 2 周しても既存イベントは出力されない (ベースライン確立後の重複排除)
+      expect(captureEventLines(captureStdout())).toHaveLength(0)
+    })
+
+    it("複数の新規イベントが updated 昇順で出力される", async () => {
+      // 2 回目: updated が降順混在で返る新規イベント (event1=最新, event3=中, event2=最古)
+      const event1: (typeof mockStreamResponse.events)[0] = {
+        id: "イベントID-A",
+        pageId: "ページID-A",
+        userId: "ユーザーID-001",
+        projectId: "プロジェクトID-001",
+        created: 1700200000,
+        updated: 1700200000,
+        type: "member.join",
+      }
+      const event2: (typeof mockStreamResponse.events)[0] = {
+        id: "イベントID-B",
+        pageId: "ページID-B",
+        userId: "ユーザーID-002",
+        projectId: "プロジェクトID-001",
+        created: 1700100000,
+        updated: 1700100000,
+        type: "member.add",
+      }
+      const event3: (typeof mockStreamResponse.events)[0] = {
+        id: "イベントID-C",
+        pageId: "ページID-C",
+        userId: "ユーザーID-003",
+        projectId: "プロジェクトID-001",
+        created: 1700150000,
+        updated: 1700150000,
+        type: "invitation.reset",
+      }
+      // API が降順混在で返す想定 (event1=新しい, event3, event2=古い)
+      const secondResponse: StreamResponse = {
+        ...mockStreamResponse,
+        events: [event1, event3, event2, ...mockStreamResponse.events],
+      }
+
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          restClient: createMockRestClient([mockStreamResponse, secondResponse]),
+          sleep: createWatchSleep(2),
+        }),
+      )
+
+      const eventLines = captureEventLines(captureStdout())
+      expect(eventLines.length).toBeGreaterThanOrEqual(3)
+      const parsedEvents = eventLines.map((l) => JSON.parse(l) as { id: string; updated: number })
+      // updated 昇順になっていることを確認 (event2 → event3 → event1)
+      for (let i = 1; i < parsedEvents.length; i++) {
+        expect((parsedEvents[i]?.updated ?? 0) >= (parsedEvents[i - 1]?.updated ?? 0)).toBe(true)
+      }
+    })
+
+    it("SIGINT を受け取ると exit 0 で終了する", async () => {
+      // sleep 中に SIGINT を発生させるシナリオ
+      const deps = createMockDeps({
+        sleep: async (_ms, signal) => {
+          if (signal.aborted) return
+          // abort されるまで待機 (SIGINT で abort される)
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 200)
+            signal.addEventListener("abort", () => {
+              clearTimeout(timer)
+              resolve()
+            })
+          })
+        },
+      })
+
+      const promise = runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "30", timeout: "0" },
+        deps,
+      )
+
+      // 1 回目の fetch (ベースライン) が終わり sleep に入るのを待ってから SIGINT
+      await new Promise((r) => setTimeout(r, 20))
+      process.emit("SIGINT", "SIGINT")
+
+      await promise
+      expect(exitMock).toHaveBeenCalledWith(0)
+    })
+
+    it("--timeout で指定した秒数後に exit 124 で終了する", async () => {
+      const deps = createMockDeps({
+        sleep: async (_ms, signal) => {
+          if (signal.aborted) return
+          // 十分長い時間待機 (timeout=0.05 秒で abort される)
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 5000)
+            signal.addEventListener("abort", () => {
+              clearTimeout(timer)
+              resolve()
+            })
+          })
+        },
+      })
+
+      await runAndIgnoreExit({ ...defaultArgs, watch: true, interval: "1", timeout: "0.05" }, deps)
+      expect(exitMock).toHaveBeenCalledWith(124)
+    })
+
+    it("RateLimitError の場合は警告を出力して次サイクルまで継続する", async () => {
+      // 1 回目: RateLimitError → sleep (1回目) → 2 回目: 正常取得 → sleep (2回目) で SIGINT
+      let callCount = 0
+      const restClient: ProjectStreamRestClient = {
+        async getProjectStream() {
+          callCount++
+          if (callCount === 1) throw new RateLimitError()
+          return mockStreamResponse
+        },
+      }
+
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({
+          restClient,
+          sleep: createWatchSleep(2),
+        }),
+      )
+
+      // 2 回目まで実行されていること (exit 2/3/4 では終了していないこと)
+      expect(callCount).toBeGreaterThanOrEqual(2)
+      expect(exitMock).not.toHaveBeenCalledWith(2)
+      expect(exitMock).not.toHaveBeenCalledWith(3)
+      expect(exitMock).not.toHaveBeenCalledWith(4)
+    })
+
+    it("AuthError の場合は即 exit 2 で終了する (継続しない)", async () => {
+      let callCount = 0
+      const restClient: ProjectStreamRestClient = {
+        async getProjectStream() {
+          callCount++
+          throw new AuthError()
+        },
+      }
+
+      await runAndIgnoreExit(
+        { ...defaultArgs, watch: true, interval: "1", timeout: "0" },
+        createMockDeps({ restClient }),
+      )
+
+      // 1 回しか呼ばれていない (継続しない)
+      expect(callCount).toBe(1)
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+  })
+})

--- a/tests/unit/core/api/rest.stream.test.ts
+++ b/tests/unit/core/api/rest.stream.test.ts
@@ -1,0 +1,151 @@
+/**
+ * rest.stream.test.ts — CosenseRestClient.getProjectStream のテスト。
+ *
+ * msw でモックサーバーを立て、/api/stream/:project/ の挙動を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import {
+  AuthError,
+  CosenseRestClient,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} from "@/core/api/rest"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import streamFixture from "../../../fixtures/project-stream.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_SID = "s%3Atest-connect-sid"
+
+/** 最後にキャプチャしたリクエスト URL */
+let capturedUrl = ""
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/stream/:project/`, ({ request, params }) => {
+    capturedUrl = request.url
+
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+
+    const project = decodeURIComponent(params["project"] as string)
+    if (project === TEST_PROJECT) {
+      return HttpResponse.json(streamFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+afterEach(() => {
+  server.resetHandlers()
+  capturedUrl = ""
+})
+
+/** 認証済みクライアントを生成するヘルパー */
+function makeClient(opts?: { timeout?: number }): CosenseRestClient {
+  return new CosenseRestClient({ sid: TEST_SID, ...opts })
+}
+
+describe("CosenseRestClient.getProjectStream", () => {
+  describe("正常系", () => {
+    it("StreamResponse をパースして返す", async () => {
+      const client = makeClient()
+      const result = await client.getProjectStream(TEST_PROJECT)
+
+      expect(result.projectName).toBe("テストプロジェクト")
+      expect(result.end).toBe(1700000000)
+      expect(result.pages).toHaveLength(2)
+      expect(result.events).toHaveLength(7)
+    })
+
+    it("URL が末尾スラッシュ付きの /api/stream/:project/ 形式になっている", async () => {
+      const client = makeClient()
+      await client.getProjectStream(TEST_PROJECT)
+
+      // /api/stream/テストプロジェクト/ のように末尾スラッシュが付いていることを確認
+      expect(capturedUrl).toContain(`/api/stream/${encodeURIComponent(TEST_PROJECT)}/`)
+    })
+
+    it("日本語プロジェクト名が URL エンコードされる", async () => {
+      const client = makeClient()
+      await client.getProjectStream(TEST_PROJECT)
+
+      // 日本語がパーセントエンコードされていることを確認
+      expect(capturedUrl).toContain(encodeURIComponent(TEST_PROJECT))
+    })
+
+    it("--limit を指定すると URL クエリに limit パラメータが付く", async () => {
+      const client = makeClient()
+      // limit パラメータを受け付けるモックに差し替え
+      server.use(
+        http.get(`${BASE_URL}/api/stream/:project/`, ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(streamFixture)
+        }),
+      )
+      await client.getProjectStream(TEST_PROJECT, { limit: 10 })
+
+      const url = new URL(capturedUrl)
+      expect(url.searchParams.get("limit")).toBe("10")
+    })
+  })
+
+  describe("エラー系", () => {
+    it("401 は AuthError になる", async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/stream/:project/`, () => {
+          return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+        }),
+      )
+      const client = makeClient()
+      await expect(client.getProjectStream(TEST_PROJECT)).rejects.toBeInstanceOf(AuthError)
+    })
+
+    it("403 は ForbiddenError になる", async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/stream/:project/`, () => {
+          return HttpResponse.json({ message: "Forbidden" }, { status: 403 })
+        }),
+      )
+      const client = makeClient()
+      await expect(client.getProjectStream(TEST_PROJECT)).rejects.toBeInstanceOf(ForbiddenError)
+    })
+
+    it("404 は NotFoundError になる", async () => {
+      const client = makeClient()
+      // 存在しないプロジェクト (サーバーが 404 を返す)
+      await expect(client.getProjectStream("存在しないプロジェクト名")).rejects.toBeInstanceOf(
+        NotFoundError,
+      )
+    })
+
+    it("429 は RateLimitError になる", async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/stream/:project/`, () => {
+          return HttpResponse.json({ message: "Too Many Requests" }, { status: 429 })
+        }),
+      )
+      const client = makeClient()
+      await expect(client.getProjectStream(TEST_PROJECT)).rejects.toBeInstanceOf(RateLimitError)
+    })
+
+    it("タイムアウトで AbortError が発生する", async () => {
+      // 応答を遅延させてタイムアウトを誘発
+      server.use(
+        http.get(`${BASE_URL}/api/stream/:project/`, async () => {
+          await new Promise((r) => setTimeout(r, 200))
+          return HttpResponse.json(streamFixture)
+        }),
+      )
+      const client = makeClient({ timeout: 50 })
+      await expect(client.getProjectStream(TEST_PROJECT)).rejects.toThrow()
+    })
+  })
+})

--- a/tests/unit/schemas/stream.test.ts
+++ b/tests/unit/schemas/stream.test.ts
@@ -1,0 +1,187 @@
+/**
+ * stream.test.ts — stream スキーマの検証テスト。
+ *
+ * /api/stream/:projectname/ のレスポンスを検証する。
+ * - StreamResponseSchema: プロジェクト更新フィード全体
+ * - ProjectUpdatesStreamEventSchema: 7 種の判別共用体
+ */
+
+import { describe, expect, it } from "bun:test"
+import { ProjectUpdatesStreamEventSchema, StreamResponseSchema } from "@/schemas/stream"
+
+describe("StreamResponseSchema", () => {
+  it("最小ペイロード (pages と events が空) をパースできる", () => {
+    const result = StreamResponseSchema.parse({
+      projectName: "テストプロジェクト",
+      end: 1700000000,
+      pages: [],
+      events: [],
+    })
+    expect(result.projectName).toBe("テストプロジェクト")
+    expect(result.end).toBe(1700000000)
+    expect(result.pages).toHaveLength(0)
+    expect(result.events).toHaveLength(0)
+  })
+
+  it("7 種の event type をすべて含むペイロードをパースできる", () => {
+    // 各 event type が正しく discriminatedUnion でパースされることを確認
+    const result = StreamResponseSchema.parse({
+      projectName: "テストプロジェクト",
+      end: 1700000000,
+      pages: [
+        { id: "ページID-001", title: "テストページ", updated: 1700000000, created: 1699900000 },
+      ],
+      events: [
+        {
+          id: "イベントID-001",
+          pageId: "ページID-001",
+          userId: "ユーザーID-001",
+          projectId: "プロジェクトID-001",
+          created: 1700000001,
+          updated: 1700000001,
+          type: "page.delete",
+          data: { titleLc: "テストページ" },
+        },
+        {
+          id: "イベントID-002",
+          pageId: "ページID-002",
+          userId: "ユーザーID-002",
+          projectId: "プロジェクトID-001",
+          created: 1699990001,
+          updated: 1699990001,
+          type: "member.join",
+        },
+        {
+          id: "イベントID-003",
+          pageId: "ページID-003",
+          userId: "ユーザーID-003",
+          projectId: "プロジェクトID-001",
+          created: 1699980001,
+          updated: 1699980001,
+          type: "member.add",
+        },
+        {
+          id: "イベントID-004",
+          pageId: "ページID-004",
+          userId: "ユーザーID-001",
+          projectId: "プロジェクトID-001",
+          created: 1699970001,
+          updated: 1699970001,
+          type: "invitation.reset",
+        },
+        {
+          id: "イベントID-005",
+          pageId: "ページID-005",
+          userId: "ユーザーID-001",
+          projectId: "プロジェクトID-001",
+          created: 1699960001,
+          updated: 1699960001,
+          type: "admin.add",
+          targetUserId: "ユーザーID-002",
+        },
+        {
+          id: "イベントID-006",
+          pageId: "ページID-006",
+          userId: "ユーザーID-001",
+          projectId: "プロジェクトID-001",
+          created: 1699950001,
+          updated: 1699950001,
+          type: "admin.delete",
+          targetUserId: "ユーザーID-003",
+        },
+        {
+          id: "イベントID-007",
+          pageId: "ページID-007",
+          userId: "ユーザーID-001",
+          projectId: "プロジェクトID-001",
+          created: 1699940001,
+          updated: 1699940001,
+          type: "owner.set",
+          targetUserId: "ユーザーID-002",
+        },
+      ],
+    })
+
+    expect(result.events).toHaveLength(7)
+    const types = result.events.map((e) => e.type)
+    expect(types).toContain("page.delete")
+    expect(types).toContain("member.join")
+    expect(types).toContain("member.add")
+    expect(types).toContain("invitation.reset")
+    expect(types).toContain("admin.add")
+    expect(types).toContain("admin.delete")
+    expect(types).toContain("owner.set")
+  })
+
+  it("end が文字列の場合はパースエラーになる", () => {
+    expect(() =>
+      StreamResponseSchema.parse({
+        projectName: "テストプロジェクト",
+        end: "not-a-number",
+        pages: [],
+        events: [],
+      }),
+    ).toThrow()
+  })
+
+  it("projectName が省略された場合はパースエラーになる", () => {
+    expect(() =>
+      StreamResponseSchema.parse({
+        end: 1700000000,
+        pages: [],
+        events: [],
+      }),
+    ).toThrow()
+  })
+})
+
+describe("ProjectUpdatesStreamEventSchema", () => {
+  it("未知の type はパースエラーになる (discriminatedUnion の安全性)", () => {
+    // 将来追加されうる未知 type が混入しても安全にエラーになることを確認
+    expect(() =>
+      ProjectUpdatesStreamEventSchema.parse({
+        id: "イベントID-001",
+        pageId: "ページID-001",
+        userId: "ユーザーID-001",
+        projectId: "プロジェクトID-001",
+        created: 1700000001,
+        updated: 1700000001,
+        type: "unknown.event",
+      }),
+    ).toThrow()
+  })
+
+  it("page.delete は data.titleLc を含む", () => {
+    const result = ProjectUpdatesStreamEventSchema.parse({
+      id: "イベントID-001",
+      pageId: "ページID-001",
+      userId: "ユーザーID-001",
+      projectId: "プロジェクトID-001",
+      created: 1700000001,
+      updated: 1700000001,
+      type: "page.delete",
+      data: { titleLc: "削除されたページ" },
+    })
+    expect(result.type).toBe("page.delete")
+    if (result.type === "page.delete") {
+      expect(result.data.titleLc).toBe("削除されたページ")
+    }
+  })
+
+  it("admin.add は targetUserId を含む", () => {
+    const result = ProjectUpdatesStreamEventSchema.parse({
+      id: "イベントID-005",
+      pageId: "ページID-005",
+      userId: "ユーザーID-001",
+      projectId: "プロジェクトID-001",
+      created: 1699960001,
+      updated: 1699960001,
+      type: "admin.add",
+      targetUserId: "管理者ユーザーID",
+    })
+    expect(result.type).toBe("admin.add")
+    if (result.type === "admin.add") {
+      expect(result.targetUserId).toBe("管理者ユーザーID")
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- `/api/stream/:projectname/` を叩いてプロジェクトの最近更新フィードを取得する `cos project stream <name>` コマンドを新設する
- **snapshot モード** (デフォルト): 1 回叩いて JSON envelope / TSV / テーブルで出力
- **watch モード** (`--watch`): 一定間隔でポーリングし、新規イベントのみ NDJSON で出力
- `--limit` / `--interval` / `--timeout` フラグ対応

## 変更ファイル

| ファイル | 役割 |
|---|---|
| `src/schemas/stream.ts` | zod スキーマ (7 種の `discriminatedUnion`) |
| `src/core/api/rest.ts` | `getProjectStream` メソッド追加 |
| `src/commands/project/stream.ts` | コマンド本体 (DI ファクトリ方式) |
| `src/core/command-classification.ts` | `READ_COMMANDS` に `project.stream` 追加 |
| `src/cli.ts` | `projectCommand` に `stream` 登録 |
| `README.md` | コマンド一覧に `cos project stream` を追記 |
| `tests/fixtures/project-stream.json` | sanitize 済みフィクスチャ |
| `tests/unit/schemas/stream.test.ts` | スキーマテスト (8 件) |
| `tests/unit/core/api/rest.stream.test.ts` | MSW REST テスト (8 件) |
| `tests/unit/commands/project/stream.test.ts` | DI モックコマンドテスト (24 件) |

## テスト結果

```
1148 pass / 16 skip / 0 fail (40 件追加)
```

Lint・型チェック・CodeRabbit いずれもクリア。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `cos project stream` コマンドを追加しました。プロジェクトの更新フィードを取得でき、`--watch` オプションでポーリング監視が可能です。JSON、NDJSON、TSV 形式での出力に対応しています。

* **Documentation**
  * README のコマンド一覧にプロジェクト関連サブコマンドの説明を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->