### PR TITLE
feat(page/history): cos page history コマンドを追加する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import { pageContextCommand } from "@/commands/page/context"
 import { pageDeleteCommand } from "@/commands/page/delete"
 import { pageEditCommand } from "@/commands/page/edit"
 import { pageGetCommand } from "@/commands/page/get"
+import { pageHistoryCommand } from "@/commands/page/history"
 import { pageIconCommand } from "@/commands/page/icon"
 import { pageInsertCommand } from "@/commands/page/insert"
 import { pageLineDeleteCommand } from "@/commands/page/line/delete"
@@ -114,6 +115,7 @@ const pageCommand = defineCommand({
     pin: pagePinCommand,
     unpin: pageUnpinCommand,
     icon: pageIconCommand,
+    history: pageHistoryCommand,
     delete: pageDeleteCommand,
     rm: pageDeleteCommand,
     watch: pageWatchCommand,

--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -1,0 +1,127 @@
+/**
+ * page/history.ts — `cos page history <title>` コマンド。
+ *
+ * ページのコミット履歴 (GET /api/commits/:project/:pageid) を取得して出力する。
+ * まず getPage でタイトルから pageId を解決し、getPageCommits で履歴を取得する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { getPage, getPageCommits } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageHistoryCommand = defineCommand({
+  meta: { name: "history", description: "ページのコミット履歴を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    limit: {
+      type: "string",
+      alias: "n",
+      description: "取得するコミット数の上限 (CLI 側スライス)",
+    },
+    head: {
+      type: "string",
+      description: "先頭コミット ID (?head=<commitId> クエリに使用)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; limit?: string; head?: string }
+    checkSandbox("page.history", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // title の空文字チェック (positional は required でも空文字が来うる)
+    if (!a.title) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "title が指定されていません",
+        "ページタイトルを指定してください",
+      )
+      process.exit(5)
+      throw new Error("VALIDATION_ERROR")
+    }
+
+    // --limit の検証 (正の整数のみ受け付ける)
+    let limit: number | undefined
+    if (a.limit !== undefined) {
+      const parsed = Number(a.limit)
+      if (!Number.isInteger(parsed) || parsed <= 0 || String(parsed) !== a.limit) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--limit の値が不正です: ${a.limit}`,
+          "1 以上の整数を指定してください",
+        )
+        process.exit(5)
+        throw new Error("VALIDATION_ERROR")
+      }
+      limit = parsed
+    }
+
+    logger.info(`"${a.title}" のコミット履歴を取得中...`)
+
+    try {
+      const client = await buildRestClient(a)
+
+      // title → pageId 解決
+      const page = await getPage(client, { project, title: a.title })
+
+      // コミット履歴取得
+      const opts: { project: string; pageId: string; head?: string } = {
+        project,
+        pageId: page.id,
+      }
+      if (a.head !== undefined) opts.head = a.head
+
+      const commitsResponse = await getPageCommits(client, opts)
+
+      // --limit によるスライス
+      const commits =
+        limit !== undefined ? commitsResponse.commits.slice(0, limit) : commitsResponse.commits
+
+      if (a.json || !a.plain) {
+        writeJson({ commits }, { command: "page.history", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      // plain 出力: 1 コミット 1 行
+      for (const commit of commits) {
+        const date = new Date(commit.created * 1000).toISOString().replace("T", " ").slice(0, 19)
+        process.stdout.write(
+          `${commit.id}  ${date}  user=${commit.userId}  changes=${commit.changes.length}\n`,
+        )
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+        process.exit(2)
+        throw err
+      }
+      if (err instanceof ForbiddenError) {
+        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+        process.exit(3)
+        throw err
+      }
+      if (err instanceof NotFoundError) {
+        writeErrorJson("NOT_FOUND", err.message, "ページタイトルとプロジェクト名を確認してください")
+        process.exit(4)
+        throw err
+      }
+      throw err
+    }
+  },
+})

--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -19,6 +19,7 @@ import { getPage, getPageCommits } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
+/** pageHistoryCommand はページのコミット履歴を取得するコマンドを返す。 */
 export const pageHistoryCommand = defineCommand({
   meta: { name: "history", description: "ページのコミット履歴を取得する" },
   args: {

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -6,6 +6,8 @@
  */
 
 import { encodePageTitle } from "@/core/api/encoder"
+import { commitsResponseSchema } from "@/schemas/commit"
+import type { CommitsResponse } from "@/schemas/commit"
 import {
   PageListResponseSchema,
   PageSchema,
@@ -188,6 +190,26 @@ export class CosenseRestClient {
   async listProjects(): Promise<ProjectListResponse> {
     const data = await this.fetchJson(`${BASE_URL}/api/projects`)
     return ProjectListResponseSchema.parse(data)
+  }
+
+  /**
+   * getCommits は /api/commits/:project/:pageid を叩いてページのコミット履歴を返す。
+   *
+   * head を指定すると ?head=<commitId> クエリパラメータを付与して
+   * 指定コミットより前の履歴を取得できる。
+   */
+  async getCommits(
+    project: string,
+    pageId: string,
+    opts: { head?: string } = {},
+  ): Promise<CommitsResponse> {
+    const params = new URLSearchParams()
+    if (opts.head !== undefined) params.set("head", opts.head)
+    const query = params.size > 0 ? `?${params.toString()}` : ""
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/commits/${encodeURIComponent(project)}/${encodeURIComponent(pageId)}${query}`,
+    )
+    return commitsResponseSchema.parse(data)
   }
 
   /** getProjectStream は /api/stream/:project/ を叩いてプロジェクトの最近更新フィードを返す。 */

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -22,6 +22,7 @@ export const READ_COMMANDS: readonly string[] = [
   "page.code",
   "page.context",
   "page.get",
+  "page.history",
   "page.line.get",
   "page.list",
   "page.text",

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -47,6 +47,15 @@ export async function getCodeBlock(
   return client.getCodeBlock(opts.project, opts.title, opts.filename)
 }
 
+/** getPageCommits はページのコミット履歴を取得する。 */
+export async function getPageCommits(
+  client: CosenseRestClient,
+  opts: { project: string; pageId: string; head?: string },
+) {
+  const { project, pageId, head } = opts
+  return client.getCommits(project, pageId, head !== undefined ? { head } : {})
+}
+
 /** createPage は新規ページを作成する (WebSocket commit)。 */
 export async function createPage(
   writer: ScrapboxWriter,

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -47,7 +47,7 @@ export async function getCodeBlock(
   return client.getCodeBlock(opts.project, opts.title, opts.filename)
 }
 
-/** getPageCommits はページのコミット履歴を取得する。 */
+/** getPageCommits はページのコミット履歴を返す。 */
 export async function getPageCommits(
   client: CosenseRestClient,
   opts: { project: string; pageId: string; head?: string },

--- a/src/schemas/commit.ts
+++ b/src/schemas/commit.ts
@@ -1,0 +1,35 @@
+/**
+ * commit.ts — Scrapbox commits API レスポンスの zod スキーマ定義。
+ *
+ * GET /api/commits/:project/:pageid のレスポンスを検証する。
+ * changes フィールドはバリエーションが多いため汎用レコードで素通しする。
+ */
+
+import { z } from "zod"
+
+/**
+ * commitSchema は 1 件のコミットを表すスキーマ。
+ *
+ * parentId は最初のコミットでは存在しないため省略可能とする。
+ * changes は変更種別のユニオンが 15 種類超あるため汎用レコードで素通しする。
+ */
+export const commitSchema = z.object({
+  id: z.string(),
+  parentId: z.string().optional(),
+  pageId: z.string(),
+  userId: z.string(),
+  created: z.number(),
+  kind: z.literal("page"),
+  changes: z.array(z.record(z.unknown())).default([]),
+})
+
+/** commitsResponseSchema は commits API のレスポンス全体のスキーマ。 */
+export const commitsResponseSchema = z.object({
+  commits: z.array(commitSchema),
+})
+
+/** Commit は 1 件のコミットの型。 */
+export type Commit = z.infer<typeof commitSchema>
+
+/** CommitsResponse は commits API のレスポンス全体の型。 */
+export type CommitsResponse = z.infer<typeof commitsResponseSchema>

--- a/tests/fixtures/commits/page-history.json
+++ b/tests/fixtures/commits/page-history.json
@@ -1,0 +1,69 @@
+{
+  "commits": [
+    {
+      "id": "commit-id-2",
+      "parentId": "commit-id-1",
+      "pageId": "page-id-hello",
+      "userId": "user-id-1",
+      "created": 1700200000,
+      "kind": "page",
+      "changes": [
+        {
+          "type": "update",
+          "lines": [
+            {
+              "id": "line-id-1",
+              "text": "更新した行",
+              "userId": "user-id-1",
+              "created": 1700200000,
+              "updated": 1700200000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "commit-id-1",
+      "parentId": "commit-id-0",
+      "pageId": "page-id-hello",
+      "userId": "user-id-1",
+      "created": 1700100000,
+      "kind": "page",
+      "changes": [
+        {
+          "type": "insert",
+          "lines": [
+            {
+              "id": "line-id-1",
+              "text": "最初の行",
+              "userId": "user-id-1",
+              "created": 1700100000,
+              "updated": 1700100000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "commit-id-0",
+      "pageId": "page-id-hello",
+      "userId": "user-id-1",
+      "created": 1700000000,
+      "kind": "page",
+      "changes": [
+        {
+          "type": "insert",
+          "lines": [
+            {
+              "id": "line-id-title",
+              "text": "Hello World",
+              "userId": "user-id-1",
+              "created": 1700000000,
+              "updated": 1700000000
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/commands/page/history.test.ts
+++ b/tests/unit/commands/page/history.test.ts
@@ -1,0 +1,260 @@
+/**
+ * page/history.test.ts — `cos page history <title>` コマンドのテスト。
+ *
+ * Scrapbox commits API を叩いてページのコミット履歴を返すコマンドを検証する。
+ * - 正常系: コミット一覧が JSON で取れる
+ * - --limit によるスライス動作
+ * - --head がクエリパラメータに乗ること
+ * - 認証エラー → exit 2
+ * - 404 (ページ未存在) → exit 4
+ * - project 未指定 → exit 5
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageHistoryCommand } from "@/commands/page/history"
+import * as pages from "@/core/pages"
+import type { CommitsResponse } from "@/schemas/commit"
+import type { Page } from "@/schemas/page"
+import pageHistoryFixture from "../../../fixtures/commits/page-history.json"
+import pageDetailFixture from "../../../fixtures/page-detail.json"
+
+/** コマンド run ヘルパー */
+async function runHistory(args: Record<string, unknown>) {
+  await (
+    pageHistoryCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** デフォルトの正常系引数 */
+const defaultArgs = {
+  project: "テストプロジェクト",
+  title: "Hello World",
+  limit: undefined,
+  head: undefined,
+  json: true,
+  plain: false,
+  "results-only": false,
+  quiet: false,
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let getPageSpy: ReturnType<typeof spyOn>
+let getPageCommitsSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+
+  // getPage のモック (title → pageId 解決)
+  getPageSpy = spyOn(pages, "getPage").mockResolvedValue(pageDetailFixture as unknown as Page)
+
+  // getPageCommits のモック
+  getPageCommitsSpy = spyOn(pages, "getPageCommits").mockResolvedValue(
+    pageHistoryFixture as CommitsResponse,
+  )
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  getPageSpy.mockRestore()
+  getPageCommitsSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageHistoryCommand", () => {
+  describe("正常系", () => {
+    it("--json フラグ付きでコミット一覧が JSON 出力される", async () => {
+      try {
+        await runHistory(defaultArgs)
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+
+      // exit が呼ばれていない = エラーなし
+      expect(exitMock).not.toHaveBeenCalled()
+
+      // stdout に JSON envelope が書き込まれている
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      // writeJson の envelope 形式: { data: { commits: [...] }, meta: { ... } }
+      expect(json.data.commits).toHaveLength(3)
+      expect(json.data.commits[0].id).toBe("commit-id-2")
+    })
+
+    it("title に対応するページの pageId を使って getPageCommits が呼ばれる", async () => {
+      try {
+        await runHistory(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      expect(getPageCommitsSpy).toHaveBeenCalledTimes(1)
+      // getPage で取得した pageId (page-id-hello) が使われること
+      const callArgs = getPageCommitsSpy.mock.calls[0]
+      // 第2引数が opts オブジェクト (project + pageId + head)
+      expect(callArgs?.[1]).toMatchObject({ pageId: "page-id-hello" })
+    })
+  })
+
+  describe("--limit フラグ", () => {
+    it("--limit 2 で上位 2 件にスライスされる", async () => {
+      try {
+        await runHistory({ ...defaultArgs, limit: "2" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(2)
+    })
+
+    it("--limit がフィクスチャ件数より大きい場合は全件返す", async () => {
+      try {
+        await runHistory({ ...defaultArgs, limit: "100" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      // フィクスチャが 3 件なので全件
+      expect(json.data.commits).toHaveLength(3)
+    })
+
+    it("--limit abc (文字列) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runHistory({ ...defaultArgs, limit: "abc" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit -1 (負数) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runHistory({ ...defaultArgs, limit: "-1" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--limit 0 (ゼロ) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runHistory({ ...defaultArgs, limit: "0" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+  })
+
+  describe("--head フラグ", () => {
+    it("--head を指定すると getPageCommits に head が渡される", async () => {
+      try {
+        await runHistory({ ...defaultArgs, head: "commit-id-1" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const callArgs = getPageCommitsSpy.mock.calls[0]
+      // 第2引数の opts に head が含まれること
+      expect(callArgs?.[1]).toMatchObject({ head: "commit-id-1" })
+    })
+
+    it("--head を省略した場合は opts.head が undefined になる", async () => {
+      try {
+        await runHistory(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      const callArgs = getPageCommitsSpy.mock.calls[0]
+      // head が undefined (または存在しない) こと
+      expect((callArgs?.[1] as Record<string, unknown>)?.["head"]).toBeUndefined()
+    })
+  })
+
+  describe("エラー系", () => {
+    it("project 未指定は PROJECT_REQUIRED で exit 5 になる", async () => {
+      try {
+        await runHistory({
+          ...defaultArgs,
+          project: undefined,
+        })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("PROJECT_REQUIRED"))
+    })
+
+    it("title 未指定は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runHistory({
+          ...defaultArgs,
+          title: "",
+        })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("getPage が NotFoundError をスローした場合は exit 4 になる", async () => {
+      const { NotFoundError } = await import("@/core/api/rest")
+      getPageSpy.mockRejectedValue(new NotFoundError("Hello World"))
+
+      try {
+        await runHistory(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("getPage が AuthError をスローした場合は exit 2 になる", async () => {
+      const { AuthError } = await import("@/core/api/rest")
+      getPageSpy.mockRejectedValue(new AuthError())
+
+      try {
+        await runHistory(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `GET /api/commits/:project/:pageid` をラップして `cos page history <title>` コマンドを実装した
- title → pageId の解決は既存の `getPage` を再利用し、REST の一貫性を保った
- `--limit N` で取得件数を CLI 側でスライス、`--head <commitId>` でページネーションに対応
- `changes` フィールドは変更種別のユニオンが 15 種類超あるため `z.record(z.unknown())` で素通し

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/schemas/commit.ts` | CommitsResponse / Commit の zod スキーマ (新規) |
| `src/core/api/rest.ts` | `getCommits(project, pageId, { head? })` メソッドを追加 |
| `src/core/pages.ts` | `getPageCommits(client, { project, pageId, head? })` ユースケース関数を追加 |
| `src/commands/page/history.ts` | `cos page history` コマンド本体 (新規) |
| `src/cli.ts` | page サブグループへの登録を追加 |
| `src/core/command-classification.ts` | `READ_COMMANDS` に `page.history` を追加 |
| `tests/fixtures/commits/page-history.json` | テスト用フィクスチャ (新規) |
| `tests/unit/commands/page/history.test.ts` | ユニットテスト (新規、13 件) |

## 使い方

```
cos page history <title> [options]

Options:
  -p, --project <name>   プロジェクト名
  -n, --limit <N>        取得するコミット数の上限
      --head <commitId>  先頭コミット ID (?head= クエリに使用)
  -J, --json             JSON 出力
```

## Test plan

- [x] `bunx biome check src tests` — lint 警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ
- [x] `bun test` — 全 1162 件パス (新規 13 件含む)
- [x] CodeRabbit — No findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `cos page history <title>` コマンドを追加しました。ページのコミット履歴を取得・表示できるようになりました。`--json` フラグでJSON形式、`--limit/-n` オプションで結果を制限、`--head` オプションで特定のポイントから履歴を取得できます。

* **Tests**
  * ページ履歴コマンドの包括的なユニットテストスイートを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->