### PR TITLE
feat(page/snapshot): cos page snapshot list/get コマンドを追加する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,8 @@ import { pageNewCommand } from "@/commands/page/new"
 import { pagePinCommand } from "@/commands/page/pin"
 import { pagePrependCommand } from "@/commands/page/prepend"
 import { pageRenameCommand } from "@/commands/page/rename"
+import { pageSnapshotGetCommand } from "@/commands/page/snapshot/get"
+import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
 import { pageTextCommand } from "@/commands/page/text"
 import { pageUnpinCommand } from "@/commands/page/unpin"
 import { pageUrlCommand } from "@/commands/page/url"
@@ -93,6 +95,16 @@ const pageLineCommand = defineCommand({
   },
 })
 
+/** page snapshot サブコマンドグループ */
+const pageSnapshotCommand = defineCommand({
+  meta: { name: "snapshot", description: "ページのスナップショット (list / get)" },
+  subCommands: {
+    list: pageSnapshotListCommand,
+    ls: pageSnapshotListCommand,
+    get: pageSnapshotGetCommand,
+  },
+})
+
 /** page サブコマンドグループ */
 const pageCommand = defineCommand({
   meta: { name: "page", description: "ページ操作コマンド" },
@@ -116,6 +128,7 @@ const pageCommand = defineCommand({
     unpin: pageUnpinCommand,
     icon: pageIconCommand,
     history: pageHistoryCommand,
+    snapshot: pageSnapshotCommand,
     delete: pageDeleteCommand,
     rm: pageDeleteCommand,
     watch: pageWatchCommand,

--- a/src/commands/page/snapshot/get.ts
+++ b/src/commands/page/snapshot/get.ts
@@ -1,0 +1,156 @@
+/**
+ * page/snapshot/get.ts — `cos page snapshot get <title> <timestampId>` コマンド。
+ *
+ * 特定スナップショット (GET /api/page-snapshots/:project/:pageid/:timestampid) を取得して出力する。
+ * まず getPage でタイトルから pageId を解決し、getPageSnapshot でスナップショットを取得する。
+ *
+ * 出力モード:
+ * - デフォルト / --json: { page, snapshot } の JSON envelope
+ * - --plain: 人間向け meta + 本文テキスト
+ * - --text: snapshot.lines[].text のみを改行区切りで出力 (cos page text 相当)
+ * --text と --plain は排他。同時指定は VALIDATION_ERROR (exit 5)。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { getPage, getPageSnapshot } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** pageSnapshotGetCommand はページの特定スナップショットを取得するコマンドを返す。 */
+export const pageSnapshotGetCommand = defineCommand({
+  meta: { name: "get", description: "ページの特定スナップショットを取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    timestampId: {
+      type: "positional",
+      description: "スナップショットの timestamp ID",
+      required: true,
+    },
+    text: {
+      type: "boolean",
+      default: false,
+      description: "スナップショット本文のみをテキスト出力する (--plain と排他)",
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; timestampId: string; text: boolean }
+    checkSandbox("page.snapshot.get", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // title の空文字チェック
+    if (!a.title) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "title が指定されていません",
+        "ページタイトルを指定してください",
+      )
+      process.exit(5)
+      throw new Error("VALIDATION_ERROR")
+    }
+
+    // timestampId の空文字チェック
+    if (!a.timestampId) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "timestampId が指定されていません",
+        "スナップショットの timestamp ID を指定してください",
+      )
+      process.exit(5)
+      throw new Error("VALIDATION_ERROR")
+    }
+
+    // --text と --plain の排他チェック
+    if (a.text && a.plain) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "--text と --plain を同時に指定することはできません",
+        "--text か --plain のどちらか一方を指定してください",
+      )
+      process.exit(5)
+      throw new Error("VALIDATION_ERROR")
+    }
+
+    logger.info(`"${a.title}" のスナップショット (${a.timestampId}) を取得中...`)
+
+    try {
+      const client = await buildRestClient(a)
+
+      // title → pageId 解決
+      const page = await getPage(client, { project, title: a.title })
+
+      // スナップショット取得
+      const result = await getPageSnapshot(client, {
+        project,
+        pageId: page.id,
+        timestampId: a.timestampId,
+      })
+
+      // --text: 本文のみをテキスト出力
+      if (a.text) {
+        for (const line of result.snapshot.lines) {
+          process.stdout.write(`${line.text}\n`)
+        }
+        return
+      }
+
+      // --plain: 人間向けメタ + 本文
+      if (a.plain) {
+        const date = new Date(result.snapshot.created * 1000)
+          .toISOString()
+          .replace("T", " ")
+          .slice(0, 19)
+        process.stdout.write(`# ${result.snapshot.title}\n`)
+        process.stdout.write(`created: ${date}\n`)
+        process.stdout.write("\n")
+        for (const line of result.snapshot.lines) {
+          process.stdout.write(`${line.text}\n`)
+        }
+        return
+      }
+
+      // デフォルト / --json: JSON envelope 出力
+      writeJson(
+        { page: result.page, snapshot: result.snapshot },
+        { command: "page.snapshot.get", startTime },
+        buildJsonOpts(a),
+      )
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+        process.exit(2)
+        throw err
+      }
+      if (err instanceof ForbiddenError) {
+        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+        process.exit(3)
+        throw err
+      }
+      if (err instanceof NotFoundError) {
+        writeErrorJson(
+          "NOT_FOUND",
+          err.message,
+          "ページタイトルとプロジェクト名、もしくは timestampId を確認してください",
+        )
+        process.exit(4)
+        throw err
+      }
+      throw err
+    }
+  },
+})

--- a/src/commands/page/snapshot/list.ts
+++ b/src/commands/page/snapshot/list.ts
@@ -1,0 +1,95 @@
+/**
+ * page/snapshot/list.ts — `cos page snapshot list <title>` コマンド。
+ *
+ * ページのスナップショット一覧 (GET /api/page-snapshots/:project/:pageid) を取得して出力する。
+ * まず getPage でタイトルから pageId を解決し、getPageSnapshotList でスナップショット一覧を取得する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { getPage, getPageSnapshotList } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** pageSnapshotListCommand はページのスナップショット一覧を取得するコマンドを返す。 */
+export const pageSnapshotListCommand = defineCommand({
+  meta: { name: "list", description: "ページのスナップショット一覧を取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string }
+    checkSandbox("page.snapshot.list", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    // title の空文字チェック (positional は required でも空文字が来うる)
+    if (!a.title) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "title が指定されていません",
+        "ページタイトルを指定してください",
+      )
+      process.exit(5)
+      throw new Error("VALIDATION_ERROR")
+    }
+
+    logger.info(`"${a.title}" のスナップショット一覧を取得中...`)
+
+    try {
+      const client = await buildRestClient(a)
+
+      // title → pageId 解決
+      const page = await getPage(client, { project, title: a.title })
+
+      // スナップショット一覧取得
+      const snapshotList = await getPageSnapshotList(client, { project, pageId: page.id })
+
+      if (a.json || !a.plain) {
+        writeJson(
+          { pageId: snapshotList.pageId, timestamps: snapshotList.timestamps },
+          { command: "page.snapshot.list", startTime },
+          buildJsonOpts(a),
+        )
+        return
+      }
+
+      // plain 出力: 1 スナップショット 1 行 (<timestampId>  <YYYY-MM-DD HH:MM:SS>)
+      for (const ts of snapshotList.timestamps) {
+        const date = new Date(ts.created * 1000).toISOString().replace("T", " ").slice(0, 19)
+        process.stdout.write(`${ts.id}  ${date}\n`)
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+        process.exit(2)
+        throw err
+      }
+      if (err instanceof ForbiddenError) {
+        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+        process.exit(3)
+        throw err
+      }
+      if (err instanceof NotFoundError) {
+        writeErrorJson("NOT_FOUND", err.message, "ページタイトルとプロジェクト名を確認してください")
+        process.exit(4)
+        throw err
+      }
+      throw err
+    }
+  },
+})

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -17,6 +17,8 @@ import {
 import type { Page, PageListResponse, SearchResult, TitleSearchResult } from "@/schemas/page"
 import { ProjectListResponseSchema, ProjectSchema } from "@/schemas/project"
 import type { Project, ProjectListResponse } from "@/schemas/project"
+import { PageSnapshotListSchema, PageSnapshotResultSchema } from "@/schemas/snapshot"
+import type { PageSnapshotList, PageSnapshotResult } from "@/schemas/snapshot"
 import { StreamResponseSchema } from "@/schemas/stream"
 import type { StreamResponse } from "@/schemas/stream"
 import { type Me, MeSchema } from "@/schemas/user"
@@ -210,6 +212,29 @@ export class CosenseRestClient {
       `${BASE_URL}/api/commits/${encodeURIComponent(project)}/${encodeURIComponent(pageId)}${query}`,
     )
     return commitsResponseSchema.parse(data)
+  }
+
+  /** getSnapshotList は /api/page-snapshots/:project/:pageId を叩いてスナップショット一覧を返す。 */
+  async getSnapshotList(project: string, pageId: string): Promise<PageSnapshotList> {
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/page-snapshots/${encodeURIComponent(project)}/${encodeURIComponent(pageId)}`,
+    )
+    return PageSnapshotListSchema.parse(data)
+  }
+
+  /**
+   * getSnapshot は /api/page-snapshots/:project/:pageId/:timestampId を叩いて
+   * 指定タイムスタンプのスナップショット詳細を返す。
+   */
+  async getSnapshot(
+    project: string,
+    pageId: string,
+    timestampId: string,
+  ): Promise<PageSnapshotResult> {
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/page-snapshots/${encodeURIComponent(project)}/${encodeURIComponent(pageId)}/${encodeURIComponent(timestampId)}`,
+    )
+    return PageSnapshotResultSchema.parse(data)
   }
 
   /** getProjectStream は /api/stream/:project/ を叩いてプロジェクトの最近更新フィードを返す。 */

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -25,6 +25,8 @@ export const READ_COMMANDS: readonly string[] = [
   "page.history",
   "page.line.get",
   "page.list",
+  "page.snapshot.get",
+  "page.snapshot.list",
   "page.text",
   "page.url",
   "page.watch",

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -56,6 +56,22 @@ export async function getPageCommits(
   return client.getCommits(project, pageId, head !== undefined ? { head } : {})
 }
 
+/** getPageSnapshotList はページのスナップショット一覧 (timestamp ID 群) を返す。 */
+export async function getPageSnapshotList(
+  client: CosenseRestClient,
+  opts: { project: string; pageId: string },
+) {
+  return client.getSnapshotList(opts.project, opts.pageId)
+}
+
+/** getPageSnapshot は指定 timestampId のスナップショット詳細を返す。 */
+export async function getPageSnapshot(
+  client: CosenseRestClient,
+  opts: { project: string; pageId: string; timestampId: string },
+) {
+  return client.getSnapshot(opts.project, opts.pageId, opts.timestampId)
+}
+
 /** createPage は新規ページを作成する (WebSocket commit)。 */
 export async function createPage(
   writer: ScrapboxWriter,

--- a/src/schemas/snapshot.ts
+++ b/src/schemas/snapshot.ts
@@ -1,0 +1,63 @@
+/**
+ * snapshot.ts — Scrapbox page-snapshots API レスポンスの zod スキーマ定義。
+ *
+ * - GET /api/page-snapshots/:project/:pageId            → PageSnapshotList
+ * - GET /api/page-snapshots/:project/:pageId/:timestampId → PageSnapshotResult
+ */
+
+import { LineSchema } from "@/schemas/page"
+import { z } from "zod"
+
+/** SnapshotTimestamp はスナップショットのタイムスタンプ 1 件を表す。 */
+export const SnapshotTimestampSchema = z.object({
+  id: z.string(),
+  created: z.number(),
+})
+export type SnapshotTimestamp = z.infer<typeof SnapshotTimestampSchema>
+
+/** PageSnapshotList は /api/page-snapshots/:project/:pageId のレスポンス全体。 */
+export const PageSnapshotListSchema = z.object({
+  pageId: z.string(),
+  timestamps: z.array(SnapshotTimestampSchema),
+})
+export type PageSnapshotList = z.infer<typeof PageSnapshotListSchema>
+
+/**
+ * SnapshotSchema は特定時点のページコンテンツ (タイトル・行) を表す。
+ *
+ * lines は BaseLine 相当であり既存 LineSchema を再利用する。
+ */
+export const SnapshotSchema = z.object({
+  title: z.string(),
+  created: z.number(),
+  lines: z.array(LineSchema),
+})
+export type Snapshot = z.infer<typeof SnapshotSchema>
+
+/**
+ * PageSnapshotResult は /api/page-snapshots/:project/:pageId/:timestampId のレスポンス全体。
+ *
+ * page はスナップショット取得時点のページメタ情報。
+ * BasePage の各フィールドは API によって欠落する場合があるため省略可能とする。
+ */
+export const PageSnapshotResultSchema = z.object({
+  page: z.object({
+    id: z.string(),
+    title: z.string(),
+    commitId: z.string().optional(),
+    image: z.string().nullable().optional(),
+    descriptions: z.array(z.string()).optional(),
+    pin: z.number().optional(),
+    created: z.number(),
+    updated: z.number(),
+    accessed: z.number().optional(),
+    snapshotCreated: z.number().nullable().optional(),
+    views: z.number().optional(),
+    linked: z.number().optional(),
+    pageRank: z.number().optional(),
+    user: z.object({ id: z.string() }),
+    lastupdateUser: z.object({ id: z.string() }).nullable(),
+  }),
+  snapshot: SnapshotSchema,
+})
+export type PageSnapshotResult = z.infer<typeof PageSnapshotResultSchema>

--- a/tests/fixtures/snapshots/page-snapshot-result.json
+++ b/tests/fixtures/snapshots/page-snapshot-result.json
@@ -1,0 +1,46 @@
+{
+  "page": {
+    "id": "page-id-hello",
+    "title": "Hello World",
+    "image": null,
+    "descriptions": ["最初の行", "2行目"],
+    "user": { "id": "user-id-1" },
+    "lastupdateUser": { "id": "user-id-1" },
+    "pin": 0,
+    "views": 10,
+    "linked": 3,
+    "commitId": "commit-abc",
+    "created": 1700000000,
+    "updated": 1700100000,
+    "accessed": 1700200000,
+    "snapshotCreated": 1700000000,
+    "pageRank": 0.5
+  },
+  "snapshot": {
+    "title": "Hello World",
+    "created": 1700000000,
+    "lines": [
+      {
+        "id": "line-id-1",
+        "text": "Hello World",
+        "userId": "user-id-1",
+        "created": 1700000000,
+        "updated": 1700000000
+      },
+      {
+        "id": "line-id-2",
+        "text": "最初の行のスナップショット内容",
+        "userId": "user-id-1",
+        "created": 1700000000,
+        "updated": 1700000000
+      },
+      {
+        "id": "line-id-3",
+        "text": "2行目のスナップショット内容",
+        "userId": "user-id-1",
+        "created": 1700000000,
+        "updated": 1700000000
+      }
+    ]
+  }
+}

--- a/tests/fixtures/snapshots/page-snapshots-list.json
+++ b/tests/fixtures/snapshots/page-snapshots-list.json
@@ -1,0 +1,8 @@
+{
+  "pageId": "page-id-hello",
+  "timestamps": [
+    { "id": "1700000000-snap2", "created": 1700000000 },
+    { "id": "1690000000-snap1", "created": 1690000000 },
+    { "id": "1680000000-snap0", "created": 1680000000 }
+  ]
+}

--- a/tests/unit/commands/page/snapshot/get.test.ts
+++ b/tests/unit/commands/page/snapshot/get.test.ts
@@ -1,0 +1,242 @@
+/**
+ * page/snapshot/get.test.ts — `cos page snapshot get <title> <timestampId>` コマンドのテスト。
+ *
+ * - 正常系: スナップショット詳細が JSON で取れる
+ * - getPage が呼ばれて pageId と timestampId が getPageSnapshot に渡ること
+ * - --text でスナップショット本文 (lines[].text) のみが改行区切りで出力される
+ * - --plain でメタ情報 + 本文が出力される
+ * - --text と --plain の同時指定は VALIDATION_ERROR (exit 5)
+ * - title 空 / timestampId 空 → VALIDATION_ERROR (exit 5)
+ * - project 未指定 → exit 5
+ * - 認証エラー → exit 2
+ * - 404 (ページ未存在) → exit 4
+ * - 403 (権限なし) → exit 3
+ * - sandbox 違反 → exit 7
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageSnapshotGetCommand } from "@/commands/page/snapshot/get"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import * as pages from "@/core/pages"
+import type { Page } from "@/schemas/page"
+import type { PageSnapshotResult } from "@/schemas/snapshot"
+import pageDetailFixture from "../../../../fixtures/page-detail.json"
+import pageSnapshotResultFixture from "../../../../fixtures/snapshots/page-snapshot-result.json"
+
+/** コマンド run ヘルパー */
+async function runSnapshotGet(args: Record<string, unknown>) {
+  await (
+    pageSnapshotGetCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** デフォルトの正常系引数 */
+const defaultArgs = {
+  project: "テストプロジェクト",
+  title: "Hello World",
+  timestampId: "1700000000-snap2",
+  json: true,
+  plain: false,
+  text: false,
+  "results-only": false,
+  quiet: false,
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let getPageSpy: ReturnType<typeof spyOn>
+let getPageSnapshotSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+
+  // getPage のモック (title → pageId 解決)
+  getPageSpy = spyOn(pages, "getPage").mockResolvedValue(pageDetailFixture as unknown as Page)
+
+  // getPageSnapshot のモック
+  getPageSnapshotSpy = spyOn(pages, "getPageSnapshot").mockResolvedValue(
+    pageSnapshotResultFixture as PageSnapshotResult,
+  )
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  getPageSpy.mockRestore()
+  getPageSnapshotSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageSnapshotGetCommand", () => {
+  describe("正常系", () => {
+    it("--json でスナップショット詳細が { page, snapshot } envelope で出力される", async () => {
+      try {
+        await runSnapshotGet(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(stdoutMock).toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const parsed = JSON.parse(output)
+      expect(parsed.data.page.title).toBe("Hello World")
+      expect(parsed.data.snapshot.title).toBe("Hello World")
+      expect(parsed.data.snapshot.lines).toHaveLength(3)
+    })
+
+    it("getPage → getPageSnapshot の順で pageId と timestampId が渡ること", async () => {
+      try {
+        await runSnapshotGet(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      expect(getPageSpy).toHaveBeenCalledTimes(1)
+      const getPageOpts = getPageSpy.mock.calls[0]?.[1] as { project: string; title: string }
+      expect(getPageOpts.title).toBe("Hello World")
+
+      expect(getPageSnapshotSpy).toHaveBeenCalledTimes(1)
+      const snapshotOpts = getPageSnapshotSpy.mock.calls[0]?.[1] as {
+        project: string
+        pageId: string
+        timestampId: string
+      }
+      expect(snapshotOpts.pageId).toBe(pageDetailFixture.id)
+      expect(snapshotOpts.timestampId).toBe("1700000000-snap2")
+    })
+
+    it("--text でスナップショット本文 (lines[].text) のみが改行区切りで出力される", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, json: false, plain: false, text: true })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const writtenLines = stdoutMock.mock.calls.map((c: unknown[]) => c[0] as string)
+      // snapshot.lines は 3 件
+      expect(writtenLines).toHaveLength(3)
+      expect(writtenLines[0]).toBe("Hello World\n")
+      expect(writtenLines[1]).toBe("最初の行のスナップショット内容\n")
+      expect(writtenLines[2]).toBe("2行目のスナップショット内容\n")
+    })
+
+    it("--plain でページタイトルと作成日時と本文が出力される", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, json: false, plain: true, text: false })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const writtenLines = stdoutMock.mock.calls.map((c: unknown[]) => c[0] as string)
+      const allOutput = writtenLines.join("")
+      // タイトルが含まれること
+      expect(allOutput).toContain("Hello World")
+      // 本文の行が含まれること
+      expect(allOutput).toContain("最初の行のスナップショット内容")
+    })
+  })
+
+  describe("バリデーションエラー", () => {
+    it("project 未指定は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, project: undefined })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("title が空文字は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, title: "" })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("timestampId が空文字は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, timestampId: "" })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("--text と --plain の同時指定は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotGet({ ...defaultArgs, json: false, plain: true, text: true })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("API エラー", () => {
+    it("AuthError は exit 2 になる", async () => {
+      getPageSpy.mockRejectedValue(new AuthError())
+      try {
+        await runSnapshotGet(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+
+    it("NotFoundError は exit 4 になる", async () => {
+      getPageSpy.mockRejectedValue(new NotFoundError("テストページ"))
+      try {
+        await runSnapshotGet(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("ForbiddenError は exit 3 になる", async () => {
+      getPageSpy.mockRejectedValue(new ForbiddenError())
+      try {
+        await runSnapshotGet(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(3)
+    })
+  })
+
+  describe("sandbox", () => {
+    it("--disable-commands page.snapshot.get は exit 7 になる", async () => {
+      try {
+        await runSnapshotGet({
+          ...defaultArgs,
+          "enable-commands": undefined,
+          "disable-commands": "page.snapshot.get",
+        })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+})

--- a/tests/unit/commands/page/snapshot/list.test.ts
+++ b/tests/unit/commands/page/snapshot/list.test.ts
@@ -1,0 +1,206 @@
+/**
+ * page/snapshot/list.test.ts — `cos page snapshot list <title>` コマンドのテスト。
+ *
+ * - 正常系: スナップショット一覧が JSON で取れる
+ * - getPage が呼ばれて pageId が getPageSnapshotList に正しく渡ること
+ * - --plain で <id>  <created_date> 形式の 1 行が出力される
+ * - project 未指定 → exit 5
+ * - title 空 → exit 5
+ * - 認証エラー → exit 2
+ * - 404 (ページ未存在) → exit 4
+ * - 403 (権限なし) → exit 3
+ * - sandbox 違反 → exit 7
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import * as pages from "@/core/pages"
+import type { Page } from "@/schemas/page"
+import type { PageSnapshotList } from "@/schemas/snapshot"
+import pageDetailFixture from "../../../../fixtures/page-detail.json"
+import pageSnapshotsListFixture from "../../../../fixtures/snapshots/page-snapshots-list.json"
+
+/** コマンド run ヘルパー */
+async function runSnapshotList(args: Record<string, unknown>) {
+  await (
+    pageSnapshotListCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** デフォルトの正常系引数 */
+const defaultArgs = {
+  project: "テストプロジェクト",
+  title: "Hello World",
+  json: true,
+  plain: false,
+  "results-only": false,
+  quiet: false,
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let getPageSpy: ReturnType<typeof spyOn>
+let getPageSnapshotListSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+
+  // getPage のモック (title → pageId 解決)
+  getPageSpy = spyOn(pages, "getPage").mockResolvedValue(pageDetailFixture as unknown as Page)
+
+  // getPageSnapshotList のモック
+  getPageSnapshotListSpy = spyOn(pages, "getPageSnapshotList").mockResolvedValue(
+    pageSnapshotsListFixture as PageSnapshotList,
+  )
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  getPageSpy.mockRestore()
+  getPageSnapshotListSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageSnapshotListCommand", () => {
+  describe("正常系", () => {
+    it("--json フラグ付きでスナップショット一覧が JSON 出力される", async () => {
+      try {
+        await runSnapshotList(defaultArgs)
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+
+      // exit が呼ばれていない = エラーなし
+      expect(exitMock).not.toHaveBeenCalled()
+
+      // stdout に JSON が書き込まれた
+      expect(stdoutMock).toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const parsed = JSON.parse(output)
+      expect(parsed.data.pageId).toBe("page-id-hello")
+      expect(parsed.data.timestamps).toHaveLength(3)
+    })
+
+    it("getPage → getPageSnapshotList の順で pageId が渡ること", async () => {
+      try {
+        await runSnapshotList(defaultArgs)
+      } catch {
+        // 想定内
+      }
+
+      // getPage が title で呼ばれた
+      expect(getPageSpy).toHaveBeenCalledTimes(1)
+      const getPageOpts = getPageSpy.mock.calls[0]?.[1] as { project: string; title: string }
+      expect(getPageOpts.title).toBe("Hello World")
+
+      // getPageSnapshotList が pageId で呼ばれた
+      expect(getPageSnapshotListSpy).toHaveBeenCalledTimes(1)
+      const snapshotOpts = getPageSnapshotListSpy.mock.calls[0]?.[1] as {
+        project: string
+        pageId: string
+      }
+      expect(snapshotOpts.pageId).toBe(pageDetailFixture.id)
+    })
+
+    it("--plain で <timestampId>  <日時> 形式の行が 1 件ずつ出力される", async () => {
+      try {
+        await runSnapshotList({ ...defaultArgs, json: false, plain: true })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+
+      // stdout.write が各スナップショット分 (3件) 呼ばれた
+      const writtenLines = stdoutMock.mock.calls.map((c: unknown[]) => c[0] as string)
+      expect(writtenLines).toHaveLength(3)
+      // 1 件目は "1700000000-snap2  2023-11-14 ..." 形式
+      expect(writtenLines[0]).toMatch(/^1700000000-snap2\s+20\d{2}-/)
+    })
+  })
+
+  describe("バリデーションエラー", () => {
+    it("project 未指定は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotList({ ...defaultArgs, project: undefined })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("title が空文字は VALIDATION_ERROR (exit 5) になる", async () => {
+      try {
+        await runSnapshotList({ ...defaultArgs, title: "" })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("API エラー", () => {
+    it("AuthError は exit 2 になる", async () => {
+      getPageSpy.mockRejectedValue(new AuthError())
+      try {
+        await runSnapshotList(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+
+    it("NotFoundError は exit 4 になる", async () => {
+      getPageSpy.mockRejectedValue(new NotFoundError("テストページ"))
+      try {
+        await runSnapshotList(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("ForbiddenError は exit 3 になる", async () => {
+      getPageSpy.mockRejectedValue(new ForbiddenError())
+      try {
+        await runSnapshotList(defaultArgs)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(3)
+    })
+  })
+
+  describe("sandbox", () => {
+    it("--disable-commands page.snapshot.list は exit 7 になる", async () => {
+      try {
+        await runSnapshotList({
+          ...defaultArgs,
+          "enable-commands": undefined,
+          "disable-commands": "page.snapshot.list",
+        })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+})

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -14,6 +14,8 @@ import pageDetailFixture from "../../../fixtures/page-detail.json"
 import pageListFixture from "../../../fixtures/page-list.json"
 import searchTitlesPage2Fixture from "../../../fixtures/search-titles-page2.json"
 import searchTitlesFixture from "../../../fixtures/search-titles.json"
+import pageSnapshotResultFixture from "../../../fixtures/snapshots/page-snapshot-result.json"
+import pageSnapshotsListFixture from "../../../fixtures/snapshots/page-snapshots-list.json"
 
 const BASE_URL = "https://scrapbox.io"
 const TEST_PROJECT = "テストプロジェクト"
@@ -113,6 +115,35 @@ const server = setupServer(
     }
     return HttpResponse.json({ message: "Not found" }, { status: 404 })
   }),
+
+  http.get(`${BASE_URL}/api/page-snapshots/:project/:pageId`, ({ params, request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] === TEST_PROJECT && params["pageId"] === "page-id-hello") {
+      return HttpResponse.json(pageSnapshotsListFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  http.get(
+    `${BASE_URL}/api/page-snapshots/:project/:pageId/:timestampId`,
+    ({ params, request }) => {
+      const cookie = request.headers.get("Cookie")
+      if (!cookie?.includes("connect.sid")) {
+        return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+      }
+      if (
+        params["project"] === TEST_PROJECT &&
+        params["pageId"] === "page-id-hello" &&
+        params["timestampId"] === "1700000000-snap2"
+      ) {
+        return HttpResponse.json(pageSnapshotResultFixture)
+      }
+      return HttpResponse.json({ message: "Not found" }, { status: 404 })
+    },
+  ),
 
   http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ request, params }) => {
     const cookie = request.headers.get("Cookie")
@@ -326,6 +357,52 @@ describe("CosenseRestClient", () => {
     it("未認証の場合は AuthError をスローする", async () => {
       const client = new CosenseRestClient({ sid: "" })
       await expect(client.searchTitles(TEST_PROJECT)).rejects.toThrow()
+    })
+  })
+
+  describe("getSnapshotList", () => {
+    it("スナップショット一覧 (pageId + timestamps) を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.getSnapshotList(TEST_PROJECT, "page-id-hello")
+      expect(result.pageId).toBe("page-id-hello")
+      expect(result.timestamps).toHaveLength(3)
+      expect(result.timestamps[0]?.id).toBe("1700000000-snap2")
+      expect(result.timestamps[0]?.created).toBe(1700000000)
+    })
+
+    it("存在しない pageId は NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(client.getSnapshotList(TEST_PROJECT, "存在しないページID")).rejects.toThrow()
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.getSnapshotList(TEST_PROJECT, "page-id-hello")).rejects.toThrow()
+    })
+  })
+
+  describe("getSnapshot", () => {
+    it("指定 timestampId のスナップショット詳細を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.getSnapshot(TEST_PROJECT, "page-id-hello", "1700000000-snap2")
+      expect(result.page.title).toBe("Hello World")
+      expect(result.snapshot.title).toBe("Hello World")
+      expect(result.snapshot.lines).toHaveLength(3)
+      expect(result.snapshot.lines[1]?.text).toBe("最初の行のスナップショット内容")
+    })
+
+    it("存在しない timestampId は NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(
+        client.getSnapshot(TEST_PROJECT, "page-id-hello", "存在しないtimestampId"),
+      ).rejects.toThrow()
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(
+        client.getSnapshot(TEST_PROJECT, "page-id-hello", "1700000000-snap2"),
+      ).rejects.toThrow()
     })
   })
 })


### PR DESCRIPTION
## Summary

- `cos page snapshot list <title> [--project <name>]` — ページのスナップショット一覧を取得する
- `cos page snapshot get <title> <timestampId> [--project <name>]` — 特定スナップショットを取得する
  - `--json` (デフォルト): `{ page, snapshot }` の JSON envelope 出力
  - `--plain`: タイトル + 作成日時 + 本文テキスト
  - `--text`: `snapshot.lines[].text` のみを改行区切りで出力 (`--plain` と排他)

## 変更ファイル

**新規**
- `src/schemas/snapshot.ts` — zod スキーマ
- `src/commands/page/snapshot/list.ts` — list コマンド
- `src/commands/page/snapshot/get.ts` — get コマンド
- `tests/fixtures/snapshots/` — API レスポンスフィクスチャ
- `tests/unit/commands/page/snapshot/` — ユニットテスト

**変更**
- `src/core/api/rest.ts` — `getSnapshotList` / `getSnapshot` メソッド追加
- `src/core/pages.ts` — `getPageSnapshotList` / `getPageSnapshot` ユースケース関数追加
- `src/cli.ts` — `pageSnapshotCommand` グループを登録
- `src/core/command-classification.ts` — `READ_COMMANDS` に `page.snapshot.get` / `page.snapshot.list` を追加

## 実装メモ

- `cos page history` (PR #122) と同じパターンで実装 (title → pageId 解決 → REST → presenter)
- `@cosense/std` は使わず、自前 `CosenseRestClient` に直接 URL を叩く設計を踏襲
- sandbox: `page.snapshot.list` / `page.snapshot.get` は `READ_COMMANDS` に登録済み

## Test plan

- [ ] `bun test` — 1189 件パス、0 件失敗 ✓
- [ ] `bun run typecheck` — エラーなし ✓
- [ ] `bunx biome check src tests` — エラーなし ✓
- [ ] `bun run build` — 全プラットフォームビルド完了 ✓
- [ ] CodeRabbit — No findings ✓

Closes #123

🤖 Generated with [Claude Code](https://claude.ai/claude-code)