### PR TITLE
feat(page/table): cos page table コマンドを追加する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import { pagePrependCommand } from "@/commands/page/prepend"
 import { pageRenameCommand } from "@/commands/page/rename"
 import { pageSnapshotGetCommand } from "@/commands/page/snapshot/get"
 import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
+import { pageTableCommand } from "@/commands/page/table"
 import { pageTextCommand } from "@/commands/page/text"
 import { pageUnpinCommand } from "@/commands/page/unpin"
 import { pageUrlCommand } from "@/commands/page/url"
@@ -114,6 +115,7 @@ const pageCommand = defineCommand({
     get: pageGetCommand,
     text: pageTextCommand,
     code: pageCodeCommand,
+    table: pageTableCommand,
     url: pageUrlCommand,
     new: pageNewCommand,
     create: pageNewCommand,

--- a/src/commands/page/table.ts
+++ b/src/commands/page/table.ts
@@ -1,0 +1,78 @@
+/**
+ * page/table.ts — `cos page table <title> <filename>` コマンド。
+ *
+ * ページ内の [table:filename] ブロックを CSV テキストで取得して stdout に出力する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { getTable } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageTableCommand = defineCommand({
+  meta: { name: "table", description: "ページ内のテーブルを CSV で取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    filename: {
+      type: "positional",
+      description: "テーブルのファイル名",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; filename: string }
+    checkSandbox("page.table", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" の ${a.filename} のテーブルを取得中...`)
+
+    try {
+      const client = await buildRestClient(a)
+      const csv = await getTable(client, { project, title: a.title, filename: a.filename })
+
+      if (a.json) {
+        writeJson({ csv }, { command: "page.table", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      process.stdout.write(`${csv}\n`)
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+        process.exit(2)
+        throw err
+      }
+      if (err instanceof ForbiddenError) {
+        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+        process.exit(3)
+        throw err
+      }
+      if (err instanceof NotFoundError) {
+        writeErrorJson(
+          "NOT_FOUND",
+          err.message,
+          "テーブルが見つかりません。タイトルとファイル名を確認してください",
+        )
+        process.exit(4)
+        throw err
+      }
+      throw err
+    }
+  },
+})

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -149,6 +149,13 @@ export class CosenseRestClient {
     )
   }
 
+  /** getTable は /api/table/:project/:title/:filename.csv を叩いてテーブルを CSV テキストで返す。 */
+  async getTable(project: string, title: string, filename: string): Promise<string> {
+    return this.fetchText(
+      `${BASE_URL}/api/table/${encodeURIComponent(project)}/${encodePageTitle(title)}/${encodeURIComponent(filename)}.csv`,
+    )
+  }
+
   /** searchPages は /api/pages/:project/search/query を叩いて全文検索する。 */
   async searchPages(
     project: string,

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -27,6 +27,7 @@ export const READ_COMMANDS: readonly string[] = [
   "page.list",
   "page.snapshot.get",
   "page.snapshot.list",
+  "page.table",
   "page.text",
   "page.url",
   "page.watch",

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -47,7 +47,7 @@ export async function getCodeBlock(
   return client.getCodeBlock(opts.project, opts.title, opts.filename)
 }
 
-/** getTable はページ内のテーブルを CSV テキストで取得する。 */
+/** getTable はページ内のテーブルを CSV テキストで返す。 */
 export async function getTable(
   client: CosenseRestClient,
   opts: { project: string; title: string; filename: string },

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -47,6 +47,14 @@ export async function getCodeBlock(
   return client.getCodeBlock(opts.project, opts.title, opts.filename)
 }
 
+/** getTable はページ内のテーブルを CSV テキストで取得する。 */
+export async function getTable(
+  client: CosenseRestClient,
+  opts: { project: string; title: string; filename: string },
+) {
+  return client.getTable(opts.project, opts.title, opts.filename)
+}
+
 /** getPageCommits はページのコミット履歴を返す。 */
 export async function getPageCommits(
   client: CosenseRestClient,

--- a/tests/unit/commands/page/table.test.ts
+++ b/tests/unit/commands/page/table.test.ts
@@ -1,0 +1,162 @@
+/**
+ * page/table.test.ts — `cos page table <title> <filename>` コマンドのテスト。
+ *
+ * テーブル CSV 取得の正常系・--json 出力・404 エラー・sandbox 違反を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageTableCommand } from "@/commands/page/table"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_TITLE = "テストページ"
+const TEST_FILENAME = "サンプルテーブル"
+// Cosense テーブル API が返す CSV テキスト
+const SAMPLE_CSV = "名前,年齢\n田中太郎,30\n鈴木花子,25"
+
+const server = setupServer(
+  // /api/table/:project/:title/:filename.csv モック
+  http.get(`${BASE_URL}/api/table/:project/:title/:filename`, ({ params }) => {
+    if (
+      decodeURIComponent(params["project"] as string) === TEST_PROJECT &&
+      decodeURIComponent(params["title"] as string) === TEST_TITLE &&
+      decodeURIComponent(params["filename"] as string) === `${TEST_FILENAME}.csv`
+    ) {
+      return HttpResponse.text(SAMPLE_CSV)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+  // 認証確認用
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({ id: "テストユーザーID", name: "テストユーザー" })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runTable(args: Record<string, unknown>) {
+  await (
+    pageTableCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // SID を設定 (ASCII のみ有効)
+  process.env["COS_SID"] = "s%3Atest-session-id"
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  server.resetHandlers()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageTableCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("正常系: CSV テキストが stdout に出力される", async () => {
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(output).toContain("名前,年齢")
+    expect(output).toContain("田中太郎,30")
+  })
+
+  it("--json 指定時: envelope の data.csv に CSV テキストが含まれる", async () => {
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: TEST_PROJECT,
+        json: true,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const rawOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    const parsed = JSON.parse(rawOutput) as { data: { csv: string }; meta: { command: string } }
+    expect(parsed.meta.command).toBe("page.table")
+    expect(parsed.data.csv).toContain("名前,年齢")
+    expect(parsed.data.csv).toContain("田中太郎,30")
+  })
+
+  it("存在しないテーブルの場合は exit 4 で終了する", async () => {
+    try {
+      await runTable({
+        title: "存在しないページ",
+        filename: "存在しないテーブル",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(4)
+  })
+
+  it("--disable-commands page.table 指定時は exit 7 で終了する", async () => {
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+        "disable-commands": "page.table",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/commands/page/table.test.ts
+++ b/tests/unit/commands/page/table.test.ts
@@ -142,6 +142,50 @@ describe("pageTableCommand", () => {
     expect(exitMock).toHaveBeenCalledWith(4)
   })
 
+  it("未認証 (401) の場合は exit 2 で終了する", async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/table/:project/:title/:filename`, () => {
+        return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+      }),
+    )
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(2)
+  })
+
+  it("権限なし (403) の場合は exit 3 で終了する", async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/table/:project/:title/:filename`, () => {
+        return HttpResponse.json({ message: "Forbidden" }, { status: 403 })
+      }),
+    )
+    try {
+      await runTable({
+        title: TEST_TITLE,
+        filename: TEST_FILENAME,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(3)
+  })
+
   it("--disable-commands page.table 指定時は exit 7 で終了する", async () => {
     try {
       await runTable({

--- a/tests/unit/core/command-classification.test.ts
+++ b/tests/unit/core/command-classification.test.ts
@@ -17,6 +17,7 @@ describe("READ_COMMANDS", () => {
     expect(READ_COMMANDS).toContain("page.text")
     expect(READ_COMMANDS).toContain("page.code")
     expect(READ_COMMANDS).toContain("page.context")
+    expect(READ_COMMANDS).toContain("page.table")
     expect(READ_COMMANDS).toContain("page.url")
     expect(READ_COMMANDS).toContain("page.watch")
     expect(READ_COMMANDS).toContain("page.line.get")

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -18,6 +18,7 @@ import {
   getCodeBlock,
   getPage,
   getPageText,
+  getTable,
   insertIntoPage,
   listPages,
   pinPage,
@@ -74,6 +75,7 @@ function createMockRestClient(overrides: Partial<CosenseRestClient> = {}): Cosen
     })),
     getPageText: mock(async () => "テストページ\n本文テキスト"),
     getCodeBlock: mock(async () => 'console.log("hello")'),
+    getTable: mock(async () => "名前,年齢\n田中太郎,30"),
     searchPages: mock(async () => ({
       projectName: "テストプロジェクト",
       query: "テスト",
@@ -197,6 +199,19 @@ describe("getCodeBlock", () => {
     })
     expect(client.getCodeBlock).toHaveBeenCalledWith("proj", "テストページ", "main.ts")
     expect(result).toContain("hello")
+  })
+})
+
+describe("getTable", () => {
+  it("テーブルを CSV テキストで取得する", async () => {
+    const client = createMockRestClient()
+    const result = await getTable(client, {
+      project: "proj",
+      title: "テストページ",
+      filename: "サンプルテーブル",
+    })
+    expect(client.getTable).toHaveBeenCalledWith("proj", "テストページ", "サンプルテーブル")
+    expect(result).toContain("田中太郎")
   })
 })
 


### PR DESCRIPTION
## Summary

- `GET /api/table/:project/:title/:filename.csv` をラップした `cos page table <title> <filename>` コマンドを実装
- `cos page code` と同型の設計で、CSV テキストをそのまま stdout に出力
- `--json` 指定時は `{ csv: "..." }` 形式の envelope で出力
- 404 / 401 / 403 は適切な exit code (4 / 2 / 3) で終了
- `page.table` を `READ_COMMANDS` に追加し、sandbox の permission 制御に対応

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/core/api/rest.ts` | `getTable()` メソッド追加 |
| `src/core/pages.ts` | `getTable()` ユースケース関数追加 |
| `src/commands/page/table.ts` | コマンド実装 (新規) |
| `src/cli.ts` | import と subCommands 登録 |
| `src/core/command-classification.ts` | `READ_COMMANDS` に `"page.table"` 追加 |
| `tests/unit/commands/page/table.test.ts` | コマンドテスト (新規) |
| `tests/unit/core/pages.test.ts` | `getTable` のユースケーステスト追加 |
| `tests/unit/core/command-classification.test.ts` | `page.table` の toContain アサーション追加 |

## Test plan

- [x] `bun test` 全件 pass (1195 pass, 0 fail)
- [x] `bunx biome check src tests` エラーなし
- [x] `bun run typecheck` エラーなし
- [x] 正常系・--json 出力・404 エラー・sandbox 違反の各ケースを検証

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ページ内のテーブルを取得できる `cos page table` コマンドを追加しました。指定したページタイトルとテーブルファイル名から該当テーブルを取得し、CSV形式またはJSON形式で出力できます。

* **Tests**
  * 新機能と関連する単体テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->