### PR TITLE
feat(project): cos project search コマンドを追加して参加プロジェクト横断検索を実装する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import { projectGraphCommand } from "@/commands/project/graph"
 import { projectInfoCommand } from "@/commands/project/info"
 // プロジェクトコマンド
 import { projectListCommand } from "@/commands/project/list"
+import { projectSearchCommand } from "@/commands/project/search"
 import { projectStreamCommand } from "@/commands/project/stream"
 
 // 検索コマンド
@@ -148,6 +149,7 @@ const projectCommand = defineCommand({
     info: projectInfoCommand,
     graph: projectGraphCommand,
     stream: projectStreamCommand,
+    search: projectSearchCommand,
   },
 })
 

--- a/src/commands/project/search.ts
+++ b/src/commands/project/search.ts
@@ -1,0 +1,55 @@
+/**
+ * project/search.ts — `cos project search <query>` コマンド。
+ *
+ * 参加プロジェクト全体を横断して query にマッチするプロジェクト一覧を返す。
+ * 内部で /api/projects/search/query を叩き、結果をそのまま出力する。
+ * --project は不要 (横断検索のため)。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
+import { writeJson } from "@/presenter/json"
+import { writeTsv } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+export const projectSearchCommand = defineCommand({
+  meta: {
+    name: "search",
+    description: "参加プロジェクト全体を横断してマッチするプロジェクトを検索する",
+  },
+  args: {
+    ...commonArgs,
+    query: {
+      type: "positional",
+      description: "検索キーワード",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { query: string }
+    checkSandbox("project.search", a)
+    const logger = buildLogger(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.query}" を参加プロジェクト全体から検索中...`)
+
+    const client = await buildRestClient(a)
+    const result = await client.searchJoinedProjects(a.query)
+
+    if (a.json) {
+      writeJson(result, { command: "project.search", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    writeTsv(
+      ["name", "displayName"],
+      result.projects.map((p) => [p.name, p.displayName]),
+    )
+  },
+})

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,9 @@
 /**
  * search.ts — `cos search <query>` コマンド。
  *
- * プロジェクト内のページをキーワード検索する。
+ * --joined なし: プロジェクト内のページをキーワード検索する。
+ * --joined あり: 参加プロジェクト全体を横断してマッチするプロジェクト一覧を返す。
+ *   --joined と --project / COS_PROJECT は排他 (同時指定は exit 5)。
  */
 
 import {
@@ -13,7 +15,7 @@ import {
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
-import { writeJson } from "@/presenter/json"
+import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writePlainList, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
@@ -28,16 +30,51 @@ export const searchCommand = defineCommand({
     },
     limit: {
       type: "string",
-      description: "最大件数",
+      description: "最大件数 (プロジェクト内検索時のみ有効)",
+    },
+    joined: {
+      type: "boolean",
+      description: "参加プロジェクト全体を横断してマッチするプロジェクトを検索する",
+      default: false,
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { query: string; limit?: string }
+    const a = args as CommonArgs & { query: string; limit?: string; joined: boolean }
     checkSandbox("search", a)
     const logger = buildLogger(a)
-    const project = requireProject(a)
     const startTime = Date.now()
 
+    if (a.joined) {
+      // --joined と --project / COS_PROJECT の同時指定は排他
+      const projectFromEnv = process.env["COS_PROJECT"]
+      if (a.project || projectFromEnv) {
+        writeErrorJson(
+          "PROJECT_AND_JOINED_EXCLUSIVE",
+          "--joined と --project は同時に指定できません",
+          "--joined 使用時は --project および COS_PROJECT 環境変数を外してください",
+        )
+        process.exit(5)
+        throw new Error("PROJECT_AND_JOINED_EXCLUSIVE")
+      }
+
+      logger.info(`"${a.query}" を参加プロジェクト全体から検索中...`)
+
+      const client = await buildRestClient(a)
+      const result = await client.searchJoinedProjects(a.query)
+
+      if (a.json) {
+        writeJson(result, { command: "search", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      writeTsv(
+        ["name", "displayName"],
+        result.projects.map((p) => [p.name, p.displayName]),
+      )
+      return
+    }
+
+    const project = requireProject(a)
     logger.info(`"${a.query}" を検索中...`)
 
     const client = await buildRestClient(a)

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,9 +1,7 @@
 /**
  * search.ts — `cos search <query>` コマンド。
  *
- * --joined なし: プロジェクト内のページをキーワード検索する。
- * --joined あり: 参加プロジェクト全体を横断してマッチするプロジェクト一覧を返す。
- *   --joined と --project / COS_PROJECT は排他 (同時指定は exit 5)。
+ * プロジェクト内のページをキーワード検索する。
  */
 
 import {
@@ -15,7 +13,7 @@ import {
   commonArgs,
   requireProject,
 } from "@/commands/_shared"
-import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeJson } from "@/presenter/json"
 import { writePlainList, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
@@ -30,51 +28,16 @@ export const searchCommand = defineCommand({
     },
     limit: {
       type: "string",
-      description: "最大件数 (プロジェクト内検索時のみ有効)",
-    },
-    joined: {
-      type: "boolean",
-      description: "参加プロジェクト全体を横断してマッチするプロジェクトを検索する",
-      default: false,
+      description: "最大件数",
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { query: string; limit?: string; joined: boolean }
+    const a = args as CommonArgs & { query: string; limit?: string }
     checkSandbox("search", a)
     const logger = buildLogger(a)
+    const project = requireProject(a)
     const startTime = Date.now()
 
-    if (a.joined) {
-      // --joined と --project / COS_PROJECT の同時指定は排他
-      const projectFromEnv = process.env["COS_PROJECT"]
-      if (a.project || projectFromEnv) {
-        writeErrorJson(
-          "PROJECT_AND_JOINED_EXCLUSIVE",
-          "--joined と --project は同時に指定できません",
-          "--joined 使用時は --project および COS_PROJECT 環境変数を外してください",
-        )
-        process.exit(5)
-        throw new Error("--joined と --project / COS_PROJECT は同時に指定できません")
-      }
-
-      logger.info(`"${a.query}" を参加プロジェクト全体から検索中...`)
-
-      const client = await buildRestClient(a)
-      const result = await client.searchJoinedProjects(a.query)
-
-      if (a.json) {
-        writeJson(result, { command: "search", startTime }, buildJsonOpts(a))
-        return
-      }
-
-      writeTsv(
-        ["name", "displayName"],
-        result.projects.map((p) => [p.name, p.displayName]),
-      )
-      return
-    }
-
-    const project = requireProject(a)
     logger.info(`"${a.query}" を検索中...`)
 
     const client = await buildRestClient(a)

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -54,7 +54,7 @@ export const searchCommand = defineCommand({
           "--joined 使用時は --project および COS_PROJECT 環境変数を外してください",
         )
         process.exit(5)
-        throw new Error("PROJECT_AND_JOINED_EXCLUSIVE")
+        throw new Error("--joined と --project / COS_PROJECT は同時に指定できません")
       }
 
       logger.info(`"${a.query}" を参加プロジェクト全体から検索中...`)

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -15,8 +15,12 @@ import {
   TitleSearchResultSchema,
 } from "@/schemas/page"
 import type { Page, PageListResponse, SearchResult, TitleSearchResult } from "@/schemas/page"
-import { ProjectListResponseSchema, ProjectSchema } from "@/schemas/project"
-import type { Project, ProjectListResponse } from "@/schemas/project"
+import {
+  ProjectListResponseSchema,
+  ProjectSchema,
+  ProjectSearchResultSchema,
+} from "@/schemas/project"
+import type { Project, ProjectListResponse, ProjectSearchResult } from "@/schemas/project"
 import { PageSnapshotListSchema, PageSnapshotResultSchema } from "@/schemas/snapshot"
 import type { PageSnapshotList, PageSnapshotResult } from "@/schemas/snapshot"
 import { StreamResponseSchema } from "@/schemas/stream"
@@ -168,6 +172,13 @@ export class CosenseRestClient {
       `${BASE_URL}/api/pages/${encodeURIComponent(project)}/search/query?${params.toString()}`,
     )
     return SearchResultSchema.parse(data)
+  }
+
+  /** searchJoinedProjects は /api/projects/search/query を叩いて参加プロジェクト横断検索を行い、マッチしたプロジェクト一覧を返す。 */
+  async searchJoinedProjects(query: string): Promise<ProjectSearchResult> {
+    const params = new URLSearchParams({ q: query })
+    const data = await this.fetchJson(`${BASE_URL}/api/projects/search/query?${params.toString()}`)
+    return ProjectSearchResultSchema.parse(data)
   }
 
   /**

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -34,6 +34,7 @@ export const READ_COMMANDS: readonly string[] = [
   "project.graph",
   "project.info",
   "project.list",
+  "project.search",
   "project.stream",
   "schema",
   "search",

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -36,3 +36,34 @@ export const ProjectListResponseSchema = z.object({
   projects: z.array(ProjectSchema),
 })
 export type ProjectListResponse = z.infer<typeof ProjectListResponseSchema>
+
+/**
+ * FoundProjectSchema は /api/projects/search/query と /api/projects/search/watch-list
+ * のレスポンス内の各プロジェクト要素。
+ * @cosense/types の FoundProject interface に対応する。
+ */
+export const FoundProjectSchema = z.object({
+  _id: z.string(),
+  name: z.string(),
+  displayName: z.string(),
+  image: z.string().nullable().optional(),
+})
+export type FoundProject = z.infer<typeof FoundProjectSchema>
+
+/**
+ * ProjectSearchResultSchema は /api/projects/search/query のレスポンス全体。
+ *
+ * 既知フィールドのみ受理し、未知キーはストリップする（passthrough を使用しない）。
+ */
+export const ProjectSearchResultSchema = z.object({
+  searchQuery: z.string(),
+  // 認証時は object 形式、未認証または旧バージョンでは string 形式が返る場合がある
+  query: z
+    .union([
+      z.string(),
+      z.object({ words: z.array(z.string()).optional(), excludes: z.array(z.string()).optional() }),
+    ])
+    .optional(),
+  projects: z.array(FoundProjectSchema),
+})
+export type ProjectSearchResult = z.infer<typeof ProjectSearchResultSchema>

--- a/tests/unit/commands/project/search.test.ts
+++ b/tests/unit/commands/project/search.test.ts
@@ -1,0 +1,100 @@
+/**
+ * project/search.test.ts — `cos project search` コマンドのテスト。
+ *
+ * 参加プロジェクト横断検索でマッチしたプロジェクト一覧を返す動作を検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { projectSearchCommand } from "@/commands/project/search"
+import { CosenseRestClient } from "@/core/api/rest"
+
+/** ProjectSearchResult の最小限フィクスチャ */
+const SEARCH_JOINED_FIXTURE = {
+  searchQuery: "hello",
+  query: { words: ["hello"], excludes: [] },
+  projects: [
+    { _id: "proj-id-my", name: "myproject", displayName: "マイプロジェクト" },
+    { _id: "proj-id-help", name: "helpproject", displayName: "ヘルプ" },
+  ],
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let searchJoinedProjectsSpy: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runProjectSearch(args: Record<string, unknown>) {
+  await (
+    projectSearchCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 共通の args ベース */
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    query: "hello",
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  // buildRestClient がキーチェーン呼び出しをスキップできるようダミー SID を設定する
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  searchJoinedProjectsSpy = spyOn(
+    CosenseRestClient.prototype,
+    "searchJoinedProjects",
+  ).mockResolvedValue(SEARCH_JOINED_FIXTURE as never)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  searchJoinedProjectsSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("projectSearchCommand", () => {
+  it("searchJoinedProjects が呼ばれ name と displayName をタブ区切りで出力する", async () => {
+    await runProjectSearch(baseArgs())
+    expect(searchJoinedProjectsSpy).toHaveBeenCalledTimes(1)
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("myproject")
+    expect(output).toContain("マイプロジェクト")
+    expect(output).toContain("helpproject")
+    expect(output).toContain("ヘルプ")
+  })
+
+  it("--json で projects 配列を含む JSON envelope を出力する", async () => {
+    await runProjectSearch(baseArgs({ json: true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    const parsed = JSON.parse(output)
+    expect(parsed.meta.command).toBe("project.search")
+    expect(parsed.data.projects).toHaveLength(2)
+    expect(parsed.data.projects[0].name).toBe("myproject")
+  })
+
+  it("クエリが API に正しく渡される", async () => {
+    await runProjectSearch(baseArgs({ query: "テスト検索ワード" }))
+    expect(searchJoinedProjectsSpy).toHaveBeenCalledWith("テスト検索ワード")
+  })
+})

--- a/tests/unit/commands/search.test.ts
+++ b/tests/unit/commands/search.test.ts
@@ -1,0 +1,171 @@
+/**
+ * search.test.ts — `cos search` コマンドのテスト。
+ *
+ * プロジェクト内検索 (既存) と --joined フラグによる参加プロジェクト横断検索の
+ * 動作を検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { searchCommand } from "@/commands/search"
+import { CosenseRestClient } from "@/core/api/rest"
+
+/** SearchResult の最小限フィクスチャ (プロジェクト内検索) */
+const SEARCH_PAGES_FIXTURE = {
+  projectName: "テストプロジェクト",
+  searchQuery: "hello",
+  pages: [
+    { id: "page-id-1", title: "Hello World" },
+    { id: "page-id-2", title: "Helloと挨拶" },
+  ],
+}
+
+/** ProjectSearchResult の最小限フィクスチャ (参加プロジェクト横断検索) */
+const SEARCH_JOINED_FIXTURE = {
+  searchQuery: "hello",
+  query: { words: ["hello"], excludes: [] },
+  projects: [
+    { _id: "proj-id-my", name: "myproject", displayName: "マイプロジェクト" },
+    { _id: "proj-id-help", name: "helpproject", displayName: "ヘルプ" },
+  ],
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let searchPagesSpy: ReturnType<typeof spyOn>
+let searchJoinedProjectsSpy: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runSearch(args: Record<string, unknown>) {
+  await (
+    searchCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 共通の args ベース (プロジェクト内検索用) */
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    query: "hello",
+    project: "テストプロジェクト",
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: true,
+    joined: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  // buildRestClient がキーチェーン呼び出しをスキップできるようダミー SID を設定する
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  // CosenseRestClient のメソッドをモック
+  searchPagesSpy = spyOn(CosenseRestClient.prototype, "searchPages").mockResolvedValue(
+    SEARCH_PAGES_FIXTURE as never,
+  )
+  searchJoinedProjectsSpy = spyOn(
+    CosenseRestClient.prototype,
+    "searchJoinedProjects",
+  ).mockResolvedValue(SEARCH_JOINED_FIXTURE as never)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  searchPagesSpy.mockRestore()
+  searchJoinedProjectsSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("searchCommand", () => {
+  describe("--joined なし (既存のプロジェクト内検索)", () => {
+    it("searchPages が呼ばれ title 一覧を改行区切りで出力する", async () => {
+      await runSearch(baseArgs())
+      // searchPages が呼ばれること
+      expect(searchPagesSpy).toHaveBeenCalledTimes(1)
+      // searchJoinedProjects は呼ばれないこと
+      expect(searchJoinedProjectsSpy).not.toHaveBeenCalled()
+      // 結果が標準出力に書き出されること
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      expect(output).toContain("Hello World")
+      expect(output).toContain("Helloと挨拶")
+    })
+
+    it("--project 未指定かつ COS_PROJECT 未設定は PROJECT_REQUIRED で exit 5 になる", async () => {
+      try {
+        await runSearch({ ...baseArgs(), project: undefined })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("PROJECT_REQUIRED"))
+    })
+  })
+
+  describe("--joined (参加プロジェクト横断検索)", () => {
+    it("searchJoinedProjects が呼ばれ name と displayName をタブ区切りで出力する", async () => {
+      await runSearch(baseArgs({ joined: true, project: undefined }))
+      // searchJoinedProjects が呼ばれること
+      expect(searchJoinedProjectsSpy).toHaveBeenCalledTimes(1)
+      // searchPages は呼ばれないこと
+      expect(searchPagesSpy).not.toHaveBeenCalled()
+      // 出力に name と displayName が含まれること
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      expect(output).toContain("myproject")
+      expect(output).toContain("マイプロジェクト")
+      expect(output).toContain("helpproject")
+      expect(output).toContain("ヘルプ")
+    })
+
+    it("--joined と --project を同時指定すると PROJECT_AND_JOINED_EXCLUSIVE で exit 5 になる", async () => {
+      try {
+        await runSearch(baseArgs({ joined: true, project: "テストプロジェクト" }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(
+        expect.stringContaining("PROJECT_AND_JOINED_EXCLUSIVE"),
+      )
+    })
+
+    it("--joined と COS_PROJECT を同時指定すると PROJECT_AND_JOINED_EXCLUSIVE で exit 5 になる", async () => {
+      process.env["COS_PROJECT"] = "環境変数プロジェクト"
+      try {
+        await runSearch(baseArgs({ joined: true, project: undefined }))
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(
+        expect.stringContaining("PROJECT_AND_JOINED_EXCLUSIVE"),
+      )
+    })
+
+    it("--joined --json で projects 配列を含む JSON envelope を出力する", async () => {
+      await runSearch(baseArgs({ joined: true, project: undefined, json: true }))
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      const parsed = JSON.parse(output)
+      // command フィールドが含まれること
+      expect(parsed.meta.command).toBe("search")
+      // projects 配列が含まれること
+      expect(parsed.data.projects).toHaveLength(2)
+      expect(parsed.data.projects[0].name).toBe("myproject")
+    })
+  })
+})

--- a/tests/unit/commands/search.test.ts
+++ b/tests/unit/commands/search.test.ts
@@ -1,15 +1,14 @@
 /**
  * search.test.ts — `cos search` コマンドのテスト。
  *
- * プロジェクト内検索 (既存) と --joined フラグによる参加プロジェクト横断検索の
- * 動作を検証する。
+ * プロジェクト内のページをキーワード検索する動作を検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { searchCommand } from "@/commands/search"
 import { CosenseRestClient } from "@/core/api/rest"
 
-/** SearchResult の最小限フィクスチャ (プロジェクト内検索) */
+/** SearchResult の最小限フィクスチャ */
 const SEARCH_PAGES_FIXTURE = {
   projectName: "テストプロジェクト",
   searchQuery: "hello",
@@ -19,21 +18,10 @@ const SEARCH_PAGES_FIXTURE = {
   ],
 }
 
-/** ProjectSearchResult の最小限フィクスチャ (参加プロジェクト横断検索) */
-const SEARCH_JOINED_FIXTURE = {
-  searchQuery: "hello",
-  query: { words: ["hello"], excludes: [] },
-  projects: [
-    { _id: "proj-id-my", name: "myproject", displayName: "マイプロジェクト" },
-    { _id: "proj-id-help", name: "helpproject", displayName: "ヘルプ" },
-  ],
-}
-
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
 let stderrMock: ReturnType<typeof spyOn>
 let searchPagesSpy: ReturnType<typeof spyOn>
-let searchJoinedProjectsSpy: ReturnType<typeof spyOn>
 
 /** コマンド run ヘルパー */
 async function runSearch(args: Record<string, unknown>) {
@@ -50,7 +38,7 @@ async function runSearch(args: Record<string, unknown>) {
   })
 }
 
-/** 共通の args ベース (プロジェクト内検索用) */
+/** 共通の args ベース */
 function baseArgs(overrides: Record<string, unknown> = {}) {
   return {
     query: "hello",
@@ -59,7 +47,6 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
     plain: false,
     "results-only": false,
     quiet: true,
-    joined: false,
     ...overrides,
   }
 }
@@ -73,14 +60,9 @@ beforeEach(() => {
   Reflect.deleteProperty(process.env, "COS_PROJECT")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
-  // CosenseRestClient のメソッドをモック
   searchPagesSpy = spyOn(CosenseRestClient.prototype, "searchPages").mockResolvedValue(
     SEARCH_PAGES_FIXTURE as never,
   )
-  searchJoinedProjectsSpy = spyOn(
-    CosenseRestClient.prototype,
-    "searchJoinedProjects",
-  ).mockResolvedValue(SEARCH_JOINED_FIXTURE as never)
 })
 
 afterEach(() => {
@@ -88,84 +70,25 @@ afterEach(() => {
   stdoutMock.mockRestore()
   stderrMock.mockRestore()
   searchPagesSpy.mockRestore()
-  searchJoinedProjectsSpy.mockRestore()
   Reflect.deleteProperty(process.env, "COS_SID")
 })
 
 describe("searchCommand", () => {
-  describe("--joined なし (既存のプロジェクト内検索)", () => {
-    it("searchPages が呼ばれ title 一覧を改行区切りで出力する", async () => {
-      await runSearch(baseArgs())
-      // searchPages が呼ばれること
-      expect(searchPagesSpy).toHaveBeenCalledTimes(1)
-      // searchJoinedProjects は呼ばれないこと
-      expect(searchJoinedProjectsSpy).not.toHaveBeenCalled()
-      // 結果が標準出力に書き出されること
-      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
-      expect(output).toContain("Hello World")
-      expect(output).toContain("Helloと挨拶")
-    })
-
-    it("--project 未指定かつ COS_PROJECT 未設定は PROJECT_REQUIRED で exit 5 になる", async () => {
-      try {
-        await runSearch({ ...baseArgs(), project: undefined })
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(5)
-      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("PROJECT_REQUIRED"))
-    })
+  it("searchPages が呼ばれ title 一覧を改行区切りで出力する", async () => {
+    await runSearch(baseArgs())
+    expect(searchPagesSpy).toHaveBeenCalledTimes(1)
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("Hello World")
+    expect(output).toContain("Helloと挨拶")
   })
 
-  describe("--joined (参加プロジェクト横断検索)", () => {
-    it("searchJoinedProjects が呼ばれ name と displayName をタブ区切りで出力する", async () => {
-      await runSearch(baseArgs({ joined: true, project: undefined }))
-      // searchJoinedProjects が呼ばれること
-      expect(searchJoinedProjectsSpy).toHaveBeenCalledTimes(1)
-      // searchPages は呼ばれないこと
-      expect(searchPagesSpy).not.toHaveBeenCalled()
-      // 出力に name と displayName が含まれること
-      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
-      expect(output).toContain("myproject")
-      expect(output).toContain("マイプロジェクト")
-      expect(output).toContain("helpproject")
-      expect(output).toContain("ヘルプ")
-    })
-
-    it("--joined と --project を同時指定すると PROJECT_AND_JOINED_EXCLUSIVE で exit 5 になる", async () => {
-      try {
-        await runSearch(baseArgs({ joined: true, project: "テストプロジェクト" }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(5)
-      expect(stdoutMock).toHaveBeenCalledWith(
-        expect.stringContaining("PROJECT_AND_JOINED_EXCLUSIVE"),
-      )
-    })
-
-    it("--joined と COS_PROJECT を同時指定すると PROJECT_AND_JOINED_EXCLUSIVE で exit 5 になる", async () => {
-      process.env["COS_PROJECT"] = "環境変数プロジェクト"
-      try {
-        await runSearch(baseArgs({ joined: true, project: undefined }))
-      } catch {
-        // process.exit モック後の継続による throw は想定内
-      }
-      expect(exitMock).toHaveBeenCalledWith(5)
-      expect(stdoutMock).toHaveBeenCalledWith(
-        expect.stringContaining("PROJECT_AND_JOINED_EXCLUSIVE"),
-      )
-    })
-
-    it("--joined --json で projects 配列を含む JSON envelope を出力する", async () => {
-      await runSearch(baseArgs({ joined: true, project: undefined, json: true }))
-      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
-      const parsed = JSON.parse(output)
-      // command フィールドが含まれること
-      expect(parsed.meta.command).toBe("search")
-      // projects 配列が含まれること
-      expect(parsed.data.projects).toHaveLength(2)
-      expect(parsed.data.projects[0].name).toBe("myproject")
-    })
+  it("--project 未指定かつ COS_PROJECT 未設定は PROJECT_REQUIRED で exit 5 になる", async () => {
+    try {
+      await runSearch({ ...baseArgs(), project: undefined })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("PROJECT_REQUIRED"))
   })
 })

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -145,6 +145,26 @@ const server = setupServer(
     },
   ),
 
+  http.get(`${BASE_URL}/api/projects/search/query`, ({ request }) => {
+    const cookie = request.headers.get("Cookie")
+    if (!cookie?.includes("connect.sid")) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    const url = new URL(request.url)
+    const query = url.searchParams.get("q")
+    return HttpResponse.json({
+      searchQuery: query ?? "",
+      query: { words: query ? [query] : [], excludes: [] },
+      projects:
+        query === "hello"
+          ? [
+              { _id: "project-id-my", name: "myproject", displayName: "マイプロジェクト" },
+              { _id: "project-id-help", name: "helpproject", displayName: "ヘルプ" },
+            ]
+          : [],
+    })
+  }),
+
   http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ request, params }) => {
     const cookie = request.headers.get("Cookie")
     if (!cookie?.includes("connect.sid")) {
@@ -357,6 +377,44 @@ describe("CosenseRestClient", () => {
     it("未認証の場合は AuthError をスローする", async () => {
       const client = new CosenseRestClient({ sid: "" })
       await expect(client.searchTitles(TEST_PROJECT)).rejects.toThrow()
+    })
+  })
+
+  describe("searchJoinedProjects", () => {
+    it("クエリにマッチするプロジェクト一覧を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchJoinedProjects("hello")
+      expect(result.projects).toHaveLength(2)
+      expect(result.projects[0]?.name).toBe("myproject")
+      expect(result.projects[0]?.displayName).toBe("マイプロジェクト")
+      expect(result.projects[1]?.name).toBe("helpproject")
+    })
+
+    it("マッチしないクエリは空の projects 配列を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.searchJoinedProjects("存在しないキーワード")
+      expect(result.projects).toHaveLength(0)
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.searchJoinedProjects("hello")).rejects.toThrow()
+    })
+
+    it("5xx エラーの CosenseApiError メッセージにクエリ文字列 (?q=...) が含まれない", async () => {
+      // 500 を返すハンドラーで一時上書き (afterEach で自動リセットされる)
+      server.use(
+        http.get(`${BASE_URL}/api/projects/search/query`, () => {
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const error = await client.searchJoinedProjects("検索キーワード").catch((e) => e)
+      expect(error).toBeInstanceOf(CosenseApiError)
+      // pathname は含まれること
+      expect(error.message).toContain("/api/projects/")
+      // クエリ文字列は含まれないこと
+      expect(error.message).not.toContain("?")
     })
   })
 


### PR DESCRIPTION
## Summary

- `cos project search <query>` を新規追加
- 内部で `GET /api/projects/search/query?q=...` を 1 回叩き、マッチしたプロジェクト一覧を返す
- plain 出力: `name\tdisplayName` の TSV 形式
- `--project` 不要 (横断検索のため)

## 設計の経緯

当初 `cos search <query> --joined` として実装したが、設計上の問題があった:

- `cos search <query>` → **ページ一覧**
- `cos search <query> --joined` → **プロジェクト一覧**

同じコマンドなのに返ってくる型が全く異なるのは直感に反する。

既存の noun-verb 規則 (`cos project list`, `cos project info` 等) に則り、**`cos project search <query>`** として分離することで対比が明確になる:

```
cos search hello           # "hello" を含むページを検索 (プロジェクト内)
cos project search hello   # "hello" を含むページがあるプロジェクトを検索 (横断)
```

## Test plan

- [ ] `bun test` 全件 pass を確認
- [ ] `bun run typecheck` エラーなしを確認
- [ ] `bunx biome check src tests` 警告ゼロを確認
- [ ] 手動確認: `COS_SID=... cos project search hello` でプロジェクト一覧が出力されること
- [ ] 手動確認: `cos search hello --project foo` (既存挙動) が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #125