### PR TITLE
chore(test): ScrapboxWriter モックと msw ボイラープレートを共通ヘルパーに集約する

### DIFF
--- a/tests/helpers/msw.test.ts
+++ b/tests/helpers/msw.test.ts
@@ -1,0 +1,52 @@
+/**
+ * msw.test.ts — useMswServer ヘルパーのテスト。
+ *
+ * msw モックサーバーのライフサイクル管理ヘルパーが正しく動作することを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { http, HttpResponse } from "msw"
+import { useMswServer } from "./msw"
+
+const server = useMswServer([
+  http.get("https://example.test/api/initial", () => {
+    return HttpResponse.json({ メッセージ: "初期ハンドラー応答" })
+  }),
+])
+
+describe("useMswServer", () => {
+  it("サーバーオブジェクトに use / resetHandlers / close メソッドが存在する", () => {
+    expect(typeof server.use).toBe("function")
+    expect(typeof server.resetHandlers).toBe("function")
+    expect(typeof server.close).toBe("function")
+  })
+
+  it("初期ハンドラーが登録済みで fetch でレスポンスを受け取れる", async () => {
+    const res = await fetch("https://example.test/api/initial")
+    const body = await res.json()
+    expect(body).toEqual({ メッセージ: "初期ハンドラー応答" })
+  })
+
+  it("use で動的にハンドラーを追加できる", async () => {
+    server.use(
+      http.get("https://example.test/api/dynamic", () => {
+        return HttpResponse.json({ 動的: true })
+      }),
+    )
+    const res = await fetch("https://example.test/api/dynamic")
+    const body = await res.json()
+    expect(body).toEqual({ 動的: true })
+  })
+
+  it("各テスト後にハンドラーがリセットされている (動的ハンドラーはクリアされている)", async () => {
+    // 前のテストで use した動的ハンドラーは afterEach でリセット済みのため、
+    // unhandled request となり接続拒否エラーがスローされる
+    let threw = false
+    try {
+      await fetch("https://example.test/api/dynamic")
+    } catch {
+      threw = true
+    }
+    expect(threw).toBe(true)
+  })
+})

--- a/tests/helpers/msw.ts
+++ b/tests/helpers/msw.ts
@@ -1,0 +1,26 @@
+/**
+ * msw.ts — msw モックサーバーのライフサイクル管理ヘルパー。
+ *
+ * bun:test のライフサイクルフックへの自動登録を提供する。
+ */
+
+import { afterAll, afterEach, beforeAll } from "bun:test"
+import type { RequestHandler } from "msw"
+import { setupServer } from "msw/node"
+
+/**
+ * useMswServer は msw のモックサーバーを生成し、テストのライフサイクルに自動登録する。
+ *
+ * - beforeAll でサーバーを起動する
+ * - afterEach でハンドラーをリセットする (server.use で追加した動的ハンドラーを破棄)
+ * - afterAll でサーバーを停止する
+ *
+ * テストファイルのトップレベルで呼び出すこと。
+ */
+export function useMswServer(handlers: RequestHandler[] = []): ReturnType<typeof setupServer> {
+  const server = setupServer(...handlers)
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+  return server
+}

--- a/tests/helpers/scrapbox-writer.test.ts
+++ b/tests/helpers/scrapbox-writer.test.ts
@@ -1,0 +1,64 @@
+/**
+ * scrapbox-writer.test.ts — createTestWriter ヘルパーのテスト。
+ *
+ * ScrapboxWriter モック生成ヘルパーが正しく動作することを検証する。
+ */
+
+import { describe, expect, it, mock } from "bun:test"
+import type { ScrapboxWriter } from "@/core/api/ws"
+import { createTestWriter } from "./scrapbox-writer"
+
+describe("createTestWriter", () => {
+  it("ScrapboxWriter インターフェースの全メソッドを持つオブジェクトを返す", () => {
+    const writer = createTestWriter()
+    expect(typeof writer.patch).toBe("function")
+    expect(typeof writer.insertLines).toBe("function")
+    expect(typeof writer.deletePage).toBe("function")
+    expect(typeof writer.pinPage).toBe("function")
+    expect(typeof writer.unpinPage).toBe("function")
+  })
+
+  it("patch のデフォルト戻り値は commitId と pageId を持つ", async () => {
+    const writer = createTestWriter()
+    const result = await writer.patch({
+      project: "テストプロジェクト",
+      title: "テストページ",
+      update: async (lines) => lines.map((l) => l.text),
+    })
+    expect(result).toHaveProperty("commitId")
+    expect(result).toHaveProperty("pageId")
+  })
+
+  it("overrides で特定メソッドの戻り値を差し替えられる", async () => {
+    const dryRunResult = {
+      dryRun: true as const,
+      project: "上書きプロジェクト",
+      title: "上書きページ",
+    }
+    const writer = createTestWriter({
+      patch: mock(async () => dryRunResult),
+    })
+    const result = await writer.patch({
+      project: "上書きプロジェクト",
+      title: "上書きページ",
+      update: async (lines) => lines.map((l) => l.text),
+    })
+    expect(result).toEqual(dryRunResult)
+  })
+
+  it("各メソッドはスパイとして呼び出し回数と引数を記録できる", async () => {
+    const writer = createTestWriter()
+    await writer.deletePage({ project: "テストプロジェクト", title: "削除対象ページ" })
+    expect(writer.deletePage).toHaveBeenCalledTimes(1)
+    expect(writer.deletePage).toHaveBeenCalledWith({
+      project: "テストプロジェクト",
+      title: "削除対象ページ",
+    })
+  })
+
+  it("overrides で ScrapboxWriter を受け取る関数に渡せる型互換性がある", () => {
+    // 型レベルのチェック: createTestWriter の戻り値が ScrapboxWriter に代入できる
+    const writer: ScrapboxWriter = createTestWriter()
+    expect(writer).toBeDefined()
+  })
+})

--- a/tests/helpers/scrapbox-writer.ts
+++ b/tests/helpers/scrapbox-writer.ts
@@ -1,0 +1,24 @@
+/**
+ * scrapbox-writer.ts — ScrapboxWriter テストモック生成ヘルパー。
+ *
+ * 全メソッドが bun:test の mock() でラップされており、呼び出し引数と回数を検証できる。
+ */
+
+import { mock } from "bun:test"
+import type { ScrapboxWriter } from "@/core/api/ws"
+
+/**
+ * createTestWriter は ScrapboxWriter のモック実装を生成する。
+ *
+ * overrides で個別メソッドを差し替えられる。差し替えたメソッド以外はデフォルト実装が使われる。
+ */
+export function createTestWriter(overrides?: Partial<ScrapboxWriter>): ScrapboxWriter {
+  return {
+    patch: mock(async () => ({ commitId: "commitId1", pageId: "pageId1" })),
+    insertLines: mock(async () => ({ commitId: "commitId1" })),
+    deletePage: mock(async () => ({ title: "テストページ" })),
+    pinPage: mock(async () => ({ title: "テストページ" })),
+    unpinPage: mock(async () => ({ title: "テストページ" })),
+    ...overrides,
+  } as unknown as ScrapboxWriter
+}

--- a/tests/integration/serve.smoke.test.ts
+++ b/tests/integration/serve.smoke.test.ts
@@ -8,19 +8,13 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test"
 import { CosenseRestClient } from "@/core/api/rest"
-import type { ScrapboxWriter } from "@/core/api/ws"
 import { createPolicy } from "@/core/sandbox"
 import { createFetchHandler } from "@/core/server/rest"
 import type { ServerContext } from "@/core/server/types"
+import { createTestWriter } from "../helpers/scrapbox-writer"
 
 /** スモークテスト用のダミー ScrapboxWriter。実際の WS 接続は行わない。 */
-const dummyWriter: ScrapboxWriter = {
-  patch: async () => ({ commitId: "dummy", pageId: "dummy" }),
-  insertLines: async () => ({ commitId: "dummy" }),
-  deletePage: async () => ({ title: "dummy" }),
-  pinPage: async () => ({ title: "dummy" }),
-  unpinPage: async () => ({ title: "dummy" }),
-}
+const dummyWriter = createTestWriter()
 
 let server: ReturnType<typeof Bun.serve>
 let assignedPort = 0

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -6,13 +6,13 @@
  * 認証 API は msw でモックする。
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { createAuthLoginCommand } from "@/commands/auth/login"
 import type { BrowserLoginDeps } from "@/core/auth/browser-login"
 import { InMemoryTokenStore } from "@/core/auth/store"
 import { runCommand } from "citty"
 import { http, HttpResponse } from "msw"
-import { setupServer } from "msw/node"
+import { useMswServer } from "../../../helpers/msw"
 
 // ---------------------------------------------------------------------------
 // MSW サーバーセットアップ
@@ -23,7 +23,7 @@ const testUserDisplayName = "田中花子"
 // SID はHTTPヘッダーに設定されるため ASCII のみ使用する
 const testSid = "s%3Atest-browser-sid-xyz987"
 
-const server = setupServer(
+useMswServer([
   http.get(`${BASE_URL}/api/users/me`, () => {
     return HttpResponse.json({
       id: "tanaka-hanako-id",
@@ -32,10 +32,7 @@ const server = setupServer(
       csrfToken: "test-csrf-token",
     })
   }),
-)
-
-beforeAll(() => server.listen())
-afterAll(() => server.close())
+])
 
 // ---------------------------------------------------------------------------
 // テストヘルパー
@@ -95,7 +92,6 @@ afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
   stderrMock.mockRestore()
-  server.resetHandlers()
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/commands/page/text.test.ts
+++ b/tests/unit/commands/page/text.test.ts
@@ -5,10 +5,10 @@
  * --format=md による変換動作を検証する。
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { pageTextCommand } from "@/commands/page/text"
 import { http, HttpResponse } from "msw"
-import { setupServer } from "msw/node"
+import { useMswServer } from "../../../helpers/msw"
 
 const BASE_URL = "https://scrapbox.io"
 const TEST_PROJECT = "テストプロジェクト"
@@ -16,7 +16,7 @@ const TEST_TITLE = "テストページ"
 // テキストエンドポイントが返す Scrapbox 本文 (タイトル行含む)
 const SCRAPBOX_TEXT = `${TEST_TITLE}\n[*** 大見出し]\n本文テキスト`
 
-const server = setupServer(
+useMswServer([
   // /api/pages/:project/:title/text モック
   http.get(`${BASE_URL}/api/pages/:project/:title/text`, ({ params }) => {
     if (
@@ -31,10 +31,7 @@ const server = setupServer(
   http.get(`${BASE_URL}/api/users/me`, () => {
     return HttpResponse.json({ id: "テストユーザーID", name: "テストユーザー" })
   }),
-)
-
-beforeAll(() => server.listen())
-afterAll(() => server.close())
+])
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
@@ -62,7 +59,6 @@ beforeEach(() => {
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
-  server.resetHandlers()
   Reflect.deleteProperty(process.env, "COS_SID")
 })
 

--- a/tests/unit/commands/serve.test.ts
+++ b/tests/unit/commands/serve.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { type ServeDeps, makeServeCommand } from "@/commands/serve"
+import { createTestWriter } from "../../helpers/scrapbox-writer"
 
 // ----- デフォルト引数 -----
 
@@ -78,13 +79,7 @@ const immediateStartServer: ServeDeps["startServer"] = async () => {}
 const mockGetSid: ServeDeps["getSid"] = async () => "テストSID"
 
 /** ScrapboxWriter のスタブ実装。 */
-const stubWriter: import("@/core/api/ws").ScrapboxWriter = {
-  patch: async () => ({ commitId: "test", pageId: "test" }),
-  insertLines: async () => ({ commitId: "test" }),
-  deletePage: async () => ({ title: "test" }),
-  pinPage: async () => ({ title: "test" }),
-  unpinPage: async () => ({ title: "test" }),
-}
+const stubWriter = createTestWriter()
 
 /** 即座に stubWriter を返す createWriter モック。 */
 const mockCreateWriter: ServeDeps["createWriter"] = async () => stubWriter

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -4,10 +4,10 @@
  * msw でモックサーバーを立て、REST クライアントの動作を検証する。
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { describe, expect, it } from "bun:test"
 import { CosenseApiError, CosenseRestClient, NotFoundError } from "@/core/api/rest"
 import { http, HttpResponse } from "msw"
-import { setupServer } from "msw/node"
+import { useMswServer } from "../../../helpers/msw"
 
 import meFixture from "../../../fixtures/me.json"
 import pageDetailFixture from "../../../fixtures/page-detail.json"
@@ -21,7 +21,7 @@ const BASE_URL = "https://scrapbox.io"
 const TEST_PROJECT = "テストプロジェクト"
 const TEST_SID = "s%3Atest-connect-sid"
 
-const server = setupServer(
+const server = useMswServer([
   http.get(`${BASE_URL}/api/users/me`, ({ request }) => {
     const cookie = request.headers.get("Cookie")
     if (!cookie?.includes("connect.sid")) {
@@ -187,11 +187,7 @@ const server = setupServer(
     }
     return HttpResponse.json([], { status: 200 })
   }),
-)
-
-beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
+])
 
 describe("CosenseRestClient", () => {
   describe("getMe", () => {

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, mock } from "bun:test"
 import type { CosenseRestClient } from "@/core/api/rest"
-import type { PatchMetadata, ScrapboxWriter } from "@/core/api/ws"
+import type { PatchMetadata } from "@/core/api/ws"
 import { CommitConflictError } from "@/core/errors"
 import {
   appendToPage,
@@ -27,6 +27,7 @@ import {
   replaceLinesInPage,
   unpinPage,
 } from "@/core/pages"
+import { createTestWriter } from "../../helpers/scrapbox-writer"
 
 /** REST クライアントのモック */
 function createMockRestClient(overrides: Partial<CosenseRestClient> = {}): CosenseRestClient {
@@ -103,18 +104,6 @@ function createMockRestClient(overrides: Partial<CosenseRestClient> = {}): Cosen
   } as unknown as CosenseRestClient
 }
 
-/** Writer のモック */
-function createMockWriter(overrides: Partial<ScrapboxWriter> = {}): ScrapboxWriter {
-  return {
-    patch: mock(async () => ({ commitId: "commit1", pageId: "page1" })),
-    insertLines: mock(async () => ({ commitId: "commit1" })),
-    deletePage: mock(async () => ({ title: "テストページ" })),
-    pinPage: mock(async () => ({ title: "ピン留めページ" })),
-    unpinPage: mock(async () => ({ title: "ピン解除ページ" })),
-    ...overrides,
-  } as unknown as ScrapboxWriter
-}
-
 describe("listPages", () => {
   it("REST クライアントから pages リストを取得して返す", async () => {
     const client = createMockRestClient()
@@ -141,19 +130,19 @@ describe("getPage", () => {
 
 describe("createPage", () => {
   it("Writer の patch を呼んでページを作成する", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     const result = await createPage(writer, {
       project: "proj",
       title: "新しいページ",
       lines: ["行1", "行2"],
     })
     expect(writer.patch).toHaveBeenCalledTimes(1)
-    expect(result).toMatchObject({ commitId: "commit1" })
+    expect(result).toMatchObject({ commitId: "commitId1" })
   })
 
   it("patch に previewLines としてコンテンツ行を渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "create-commit", pageId: "page1" }
@@ -166,7 +155,7 @@ describe("createPage", () => {
 
 describe("appendToPage", () => {
   it("Writer の insertLines を呼んで行を追加する", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     await appendToPage(writer, {
       project: "proj",
       title: "既存ページ",
@@ -217,7 +206,7 @@ describe("getTable", () => {
 
 /** update クロージャを実際に呼び出すモックライター生成ヘルパー */
 function createMetadataInvokingWriter(metadata: PatchMetadata) {
-  const writer = createMockWriter({
+  const writer = createTestWriter({
     patch: mock(async (opts) => {
       // @cosense/std の retry 動作をシミュレートするため update を metadata 付きで呼び出す
       await opts.update([], metadata)
@@ -229,14 +218,14 @@ function createMetadataInvokingWriter(metadata: PatchMetadata) {
 
 describe("editPage", () => {
   it("Writer の patch を呼んでページを全置換する", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     await editPage(writer, { project: "proj", title: "既存ページ", lines: ["新しい内容"] })
     expect(writer.patch).toHaveBeenCalledTimes(1)
   })
 
   it("patch に previewLines として新しいコンテンツ行を渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "edit-commit", pageId: "page1" }
@@ -300,7 +289,7 @@ describe("editPage", () => {
 
 describe("deletePage", () => {
   it("Writer の deletePage を呼んでページを削除する", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     await deletePage(writer, { project: "proj", title: "削除ページ" })
     expect(writer.deletePage).toHaveBeenCalledWith({ project: "proj", title: "削除ページ" })
   })
@@ -309,7 +298,7 @@ describe("deletePage", () => {
 describe("renamePage", () => {
   it("patch に previewLines として新タイトルを渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "rename-commit", pageId: "page1" }
@@ -327,7 +316,7 @@ describe("renamePage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "rename-commit", pageId: "page1" }
@@ -350,7 +339,7 @@ describe("renamePage", () => {
 describe("prependToPage", () => {
   it("patch に previewLines として挿入行を渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "prepend-commit", pageId: "page1" }
@@ -370,7 +359,7 @@ describe("prependToPage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "prepend-commit", pageId: "page1" }
@@ -397,7 +386,7 @@ describe("prependToPage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "prepend-commit", pageId: "page1" }
@@ -415,7 +404,7 @@ describe("prependToPage", () => {
 describe("insertIntoPage", () => {
   it("patch に previewLines として挿入行を渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "insert-commit", pageId: "page1" }
@@ -436,7 +425,7 @@ describe("insertIntoPage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "insert-commit", pageId: "page1" }
@@ -465,7 +454,7 @@ describe("insertIntoPage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "insert-commit", pageId: "page1" }
@@ -483,7 +472,7 @@ describe("insertIntoPage", () => {
           lines: { id: string; text: string; userId: string; created: number; updated: number }[],
         ) => string[] | Promise<string[]>)
       | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedUpdate = opts.update
         return { commitId: "insert-commit", pageId: "page1" }
@@ -506,7 +495,7 @@ function createUpdateCapturingWriter() {
         lines: { id: string; text: string; userId: string; created: number; updated: number }[],
       ) => string[] | Promise<string[]>)
     | undefined
-  const writer = createMockWriter({
+  const writer = createTestWriter({
     patch: mock(async (opts) => {
       capturedUpdate = opts.update
       return { commitId: "ダミーコミットID", pageId: "ダミーページID" }
@@ -611,7 +600,7 @@ describe("replaceLinesInPage", () => {
 
   it("previewLines として新しい行を渡す", async () => {
     let capturedPreviewLines: string[] | undefined
-    const writer = createMockWriter({
+    const writer = createTestWriter({
       patch: mock(async (opts) => {
         capturedPreviewLines = opts.previewLines
         return { commitId: "replace-commit", pageId: "page1" }
@@ -680,7 +669,7 @@ describe("deleteLinesFromPage", () => {
 
 describe("pinPage", () => {
   it("Writer の pinPage を正しい引数で呼ぶ", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     await pinPage(writer, { project: "proj", title: "ピンページ", create: true })
     expect(writer.pinPage).toHaveBeenCalledWith({
       project: "proj",
@@ -692,7 +681,7 @@ describe("pinPage", () => {
 
 describe("unpinPage", () => {
   it("Writer の unpinPage を正しい引数で呼ぶ", async () => {
-    const writer = createMockWriter()
+    const writer = createTestWriter()
     await unpinPage(writer, { project: "proj", title: "ピン解除ページ" })
     expect(writer.unpinPage).toHaveBeenCalledWith({
       project: "proj",

--- a/tests/unit/core/server/rest.test.ts
+++ b/tests/unit/core/server/rest.test.ts
@@ -5,14 +5,14 @@
  * 上流 Cosense REST は msw でモックし、ScrapboxWriter はインメモリモックを注入する。
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test"
+import { describe, expect, it, mock } from "bun:test"
 import { CosenseRestClient } from "@/core/api/rest"
-import type { ScrapboxWriter } from "@/core/api/ws"
 import { createPolicy } from "@/core/sandbox"
 import { createFetchHandler } from "@/core/server/rest"
 import type { ServerContext } from "@/core/server/types"
 import { http, HttpResponse } from "msw"
-import { setupServer } from "msw/node"
+import { useMswServer } from "../../../helpers/msw"
+import { createTestWriter } from "../../../helpers/scrapbox-writer"
 
 // bun --coverage モードでは複数テストファイルが同一プロセスで動作するため、
 // commands/page/*.test.ts の mock.module("@/core/pages", ...) が残留する場合がある。
@@ -30,16 +30,16 @@ const TEST_SID = "s%3Atest-connect-sid"
 const TEST_TITLE_RAW = "Hello World"
 const TEST_TITLE_ENCODED = "Hello%20World"
 
-// msw でモック ScrapboxWriter（WS 層のスタブ）
-const mockWriter: ScrapboxWriter = {
-  patch: async () => ({ commitId: "commit-abc", pageId: "page-id-abc" }),
-  insertLines: async () => ({ commitId: "commit-insert" }),
-  deletePage: async () => ({ title: TEST_TITLE_RAW }),
-  pinPage: async () => ({ title: TEST_TITLE_RAW }),
-  unpinPage: async () => ({ title: TEST_TITLE_RAW }),
-}
+// WS 層のスタブ (patch/insertLines/deletePage/pinPage/unpinPage の各メソッドをモック)
+// 各テストが期待する戻り値を override で明示する
+const mockWriter = createTestWriter({
+  patch: mock(async () => ({ commitId: "commit-abc", pageId: "page-id-abc" })),
+  deletePage: mock(async () => ({ title: TEST_TITLE_RAW })),
+  pinPage: mock(async () => ({ title: TEST_TITLE_RAW })),
+  unpinPage: mock(async () => ({ title: TEST_TITLE_RAW })),
+})
 
-const server = setupServer(
+useMswServer([
   // msw は :project をデコードして params に渡すため、TEST_PROJECT（日本語）とそのまま比較する
   http.get(`${BASE_URL}/api/pages/:project`, ({ params }) => {
     if (params["project"] === TEST_PROJECT) {
@@ -66,11 +66,7 @@ const server = setupServer(
     }
     return new HttpResponse("Not found", { status: 404 })
   }),
-)
-
-beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
+])
 
 /** テスト用のデフォルト ServerContext を生成する。 */
 function makeContext(overrides?: Partial<ServerContext>): ServerContext {

--- a/tests/unit/core/sync/engine.test.ts
+++ b/tests/unit/core/sync/engine.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path"
 import type { CosenseRestClient } from "@/core/api/rest"
 import type { ScrapboxWriter } from "@/core/api/ws"
 import { syncDiff, syncPull, syncPush } from "@/core/sync/engine"
+import { createTestWriter } from "../../../helpers/scrapbox-writer"
 
 // bun --coverage モードでは複数テストファイルが同一プロセスで動作するため、
 // commands/sync/push.test.ts の mock.module("@/core/sync/engine", ...) が残留する場合がある。
@@ -67,13 +68,10 @@ function makeRestClient(page: Page): CosenseRestClient {
 
 /** モック ScrapboxWriter を生成する */
 function makeWriter(commitId = "新コミットXYZ"): ScrapboxWriter {
-  return {
+  return createTestWriter({
     patch: mock(() => Promise.resolve({ commitId, pageId: "ページID" })),
     insertLines: mock(() => Promise.resolve({ commitId })),
-    deletePage: mock(() => Promise.resolve({ title: "テストページ" })),
-    pinPage: mock(() => Promise.resolve({ title: "テストページ" })),
-    unpinPage: mock(() => Promise.resolve({ title: "テストページ" })),
-  } as unknown as ScrapboxWriter
+  })
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

- `tests/helpers/scrapbox-writer.ts` を新設し `createTestWriter()` ヘルパーを提供
  - 散在していた 5 実装 (createMockWriter / makeWriter / mockWriter / stubWriter / dummyWriter) を統一
  - bun:test の `mock()` でラップ済みなので spy として呼び出し検証が可能
  - `overrides` で個別メソッドを差し替え可能
- `tests/helpers/msw.ts` を新設し `useMswServer()` ヘルパーを提供
  - `beforeAll/afterEach/afterAll` の 3 行ボイラープレートを 4 ファイルから排除
  - テストファイルのトップレベルで呼ぶだけでサーバーを起動・ライフサイクル管理

## Test plan

- [x] `bun test` 全 1215 件 pass (skip 16 件は既存)
- [x] `bunx biome check src tests` エラーゼロ
- [x] `bun run typecheck` エラーゼロ
- [x] 各ヘルパーのテスト (`tests/helpers/*.test.ts`) も実装済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)