### PR TITLE
refactor(commands): 入力読み込み・lint・REST エラー処理をヘルパー関数に集約する

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -5,14 +5,16 @@
  * ルートフラグを統一して受け取れる。
  */
 
-import { CosenseRestClient } from "@/core/api/rest"
+import { AuthError, CosenseRestClient, ForbiddenError, NotFoundError } from "@/core/api/rest"
 import { createScrapboxWriter } from "@/core/api/ws"
 import { loadSession } from "@/core/auth/session"
 import { expandPermissionPreset } from "@/core/command-classification"
+import { lintNotation } from "@/core/notation/lint"
 import { PolicyError, createPolicy } from "@/core/sandbox"
 import { loadConfig } from "@/infra/config"
 import { createTokenStore } from "@/infra/keychain/index"
 import { Logger } from "@/infra/logger"
+import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson } from "@/presenter/json"
 import type { JsonOutputOptions } from "@/presenter/json"
 
@@ -395,4 +397,135 @@ export function notationFindingToWarning(
     finding.column !== undefined ? `行 ${finding.line} 列 ${finding.column}` : `行 ${finding.line}`
   const hint = finding.hint ? ` (修正案: ${finding.hint})` : ""
   return `[${loc}] ${finding.rule}: ${finding.message}${hint}`
+}
+
+/**
+ * ReadWriteInputArgs は --line/--text/--from-file/stdin の入力ソース引数の型。
+ *
+ * `line` は citty が複数回指定を受け付けると `string[]` になるため両方を許可する。
+ */
+export type ReadWriteInputArgs = {
+  line?: string | string[]
+  text?: string
+  "from-file"?: string
+  "allow-unsafe-read"?: boolean
+}
+
+/**
+ * readWriteInput は --line/--text/--from-file/stdin の入力ソースを統一的に解決する。
+ *
+ * 解決優先順位: line/text > stdin (-/"") > from-file (パス)
+ * stdin/ファイル読み込み時の UnsafePathError は exit 5 (UNSAFE_PATH) で終了する。
+ * すべて未指定または空の場合は requireContentErrorCode で exit 5 で終了する。
+ *
+ * `readStdin` / `readFile` は省略時に実実装 (readStdinBounded / readFromFile) を使用する。
+ * テストコードはこれらを差し替えることでファイル I/O を回避できる。
+ */
+export function readWriteInput(
+  args: ReadWriteInputArgs,
+  opts: {
+    requireContentErrorCode: string
+    requireContentMessage: string
+    requireContentHint?: string
+    readStdin?: () => string
+    readFile?: (path: string, opts: { allowUnsafe: boolean }) => string
+  },
+): string[] {
+  const readStdinFn = opts.readStdin ?? readStdinBounded
+  const readFileFn = opts.readFile ?? readFromFile
+  let lines: string[] = []
+
+  const lineValue = args.line ?? args.text
+  if (lineValue !== undefined) {
+    // citty が --line を複数回渡すと配列になるため string と string[] の両方に対応する
+    const values = Array.isArray(lineValue) ? lineValue : [lineValue]
+    lines = values.flatMap((l) => l.split(/\r?\n|\\n/))
+  } else if (isStdinPath(args["from-file"])) {
+    // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
+    try {
+      const content = readStdinFn()
+      lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    } catch (err) {
+      if (err instanceof UnsafePathError) {
+        // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
+        writeErrorJson("UNSAFE_PATH", err.message)
+        exitWithError(5, "UNSAFE_PATH")
+      }
+      throw err
+    }
+  } else if (args["from-file"]) {
+    // ファイルから読み込む
+    try {
+      const content = readFileFn(args["from-file"], {
+        allowUnsafe: args["allow-unsafe-read"] ?? false,
+      })
+      lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
+    } catch (err) {
+      if (err instanceof UnsafePathError) {
+        writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
+        exitWithError(5, "UNSAFE_PATH")
+      }
+      throw err
+    }
+  }
+
+  if (lines.length === 0) {
+    writeErrorJson(
+      opts.requireContentErrorCode,
+      opts.requireContentMessage,
+      opts.requireContentHint,
+    )
+    exitWithError(5, opts.requireContentErrorCode)
+  }
+
+  return lines
+}
+
+/**
+ * runNotationLint は Cosense 記法の lint 検査を実行し、警告文字列配列を返す。
+ *
+ * --strict-notation が true の場合は lint 指摘があると exit 5 (NOTATION_LINT) で終了する。
+ * false の場合は warnings 文字列配列を返す (空配列 = 警告なし)。
+ */
+export function runNotationLint(lines: string[], args: StrictNotationArg): string[] {
+  const findings = lintNotation(lines)
+  const warnings = findings.map(notationFindingToWarning)
+
+  if (args["strict-notation"] && findings.length > 0) {
+    writeErrorJson(
+      "NOTATION_LINT",
+      `Cosense 記法の問題が ${findings.length} 件あります`,
+      "--strict-notation を外すと警告のみで実行できます",
+      { findings },
+    )
+    exitWithError(5, "NOTATION_LINT")
+  }
+
+  return warnings
+}
+
+/**
+ * handleRestError は REST 例外を判定して該当 exit コードでプロセスを終了する。
+ *
+ * - AuthError → exit 2, code: AUTH_ERROR
+ * - ForbiddenError → exit 3, code: FORBIDDEN
+ * - NotFoundError → exit 4, code: NOT_FOUND
+ * - その他 → 何もしない (呼び出し側で再スローする想定)
+ */
+export function handleRestError(
+  err: unknown,
+  context: { resourceKind: "page" | "project" | "snapshot"; resourceName: string },
+): void {
+  if (err instanceof AuthError) {
+    writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+    exitWithError(2, "AUTH_ERROR")
+  }
+  if (err instanceof ForbiddenError) {
+    writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+    exitWithError(3, "FORBIDDEN")
+  }
+  if (err instanceof NotFoundError) {
+    writeErrorJson("NOT_FOUND", err.message, `${context.resourceKind}名を確認してください`)
+    exitWithError(4, "NOT_FOUND")
+  }
 }

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -14,16 +14,14 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
-  isStdinPath,
-  notationFindingToWarning,
+  readWriteInput,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
-import { lintNotation } from "@/core/notation/lint"
 import { appendToPage } from "@/core/pages"
-import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
-import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageAppendCommand = defineCommand({
@@ -60,56 +58,12 @@ export const pageAppendCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    let lines: string[] = []
-    if (a.line !== undefined) {
-      lines = a.line.split(/\r?\n|\\n/)
-    } else if (isStdinPath(a["from-file"])) {
-      try {
-        const content = readStdinBounded()
-        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message)
-          process.exit(5)
-        }
-        throw err
-      }
-    } else if (a["from-file"]) {
-      try {
-        const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-        lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-          process.exit(5)
-        }
-        throw err
-      }
-    }
-
-    if (lines.length === 0) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "追加する行が指定されていません",
-        "--line または --from-file でコンテンツを指定してください",
-      )
-      process.exit(5)
-    }
-
-    // Cosense 記法の lint 検査
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    const lines = readWriteInput(a, {
+      requireContentErrorCode: "CONTENT_REQUIRED",
+      requireContentMessage: "追加する行が指定されていません",
+      requireContentHint: "--line または --from-file でコンテンツを指定してください",
+    })
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" に行を追加中...`)
 

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -20,14 +20,13 @@ import {
   commonArgs,
   dryRunArg,
   isStdinPath,
-  notationFindingToWarning,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
 import { CommitConflictError } from "@/core/errors"
 import { convert } from "@/core/format/index"
-import { lintNotation } from "@/core/notation/lint"
 import { editPage } from "@/core/pages"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
@@ -134,20 +133,7 @@ export const pageEditCommand = defineCommand({
       return
     }
 
-    // Cosense 記法の lint 検査: findings を warnings に変換する
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" を編集中...`)
 

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -16,15 +16,13 @@ import {
   commonArgs,
   dryRunArg,
   getRawFlagValue,
-  isStdinPath,
-  notationFindingToWarning,
+  readWriteInput,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
-import { lintNotation } from "@/core/notation/lint"
 import { insertIntoPage } from "@/core/pages"
-import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -83,69 +81,12 @@ export const pageInsertCommand = defineCommand({
     }
     const afterN = Number.parseInt(rawAfter, 10)
 
-    let lines: string[] = []
-    if (a.line !== undefined) {
-      lines = a.line.split(/\r?\n|\\n/)
-    } else if (a["from-file"] !== undefined) {
-      // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
-      if (isStdinPath(a["from-file"])) {
-        try {
-          const content = readStdinBounded()
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
-            writeErrorJson("UNSAFE_PATH", err.message)
-            process.exit(5)
-            return
-          }
-          throw err
-        }
-      } else {
-        try {
-          const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-            process.exit(5)
-            return
-          }
-          writeErrorJson(
-            "VALIDATION_ERROR",
-            `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
-            "ファイルパスが正しいか確認してください",
-          )
-          process.exit(5)
-          return
-        }
-      }
-    }
-
-    if (lines.length === 0) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "挿入する行が指定されていません",
-        "--line または --from-file でコンテンツを指定してください",
-      )
-      process.exit(5)
-      return
-    }
-
-    // Cosense 記法の lint 検査
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    const lines = readWriteInput(a, {
+      requireContentErrorCode: "CONTENT_REQUIRED",
+      requireContentMessage: "挿入する行が指定されていません",
+      requireContentHint: "--line または --from-file でコンテンツを指定してください",
+    })
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" の ${afterN} 行目の後ろに挿入中...`)
 

--- a/src/commands/page/line/replace.ts
+++ b/src/commands/page/line/replace.ts
@@ -15,17 +15,15 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
-  isStdinPath,
-  notationFindingToWarning,
+  readWriteInput,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
 import { PageLineError } from "@/core/errors"
-import { lintNotation } from "@/core/notation/lint"
 import { replaceLinesInPage } from "@/core/pages"
 import { RangeSpecError, parseLineSpec } from "@/core/range"
-import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -93,88 +91,26 @@ export const pageLineReplaceCommand = defineCommand({
     }
 
     // --text / --from-file 排他チェック
-    const hasText = a.text !== undefined
-    const hasFile = a["from-file"] !== undefined
-
-    if (hasText && hasFile) {
+    if (a.text !== undefined && a["from-file"] !== undefined) {
       writeErrorJson("VALIDATION_ERROR", "--text と --from-file を同時に指定することはできません")
       process.exit(5)
       return
     }
 
-    if (!hasText && !hasFile) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "置換内容が指定されていません",
-        "--text または --from-file でコンテンツを指定してください",
-      )
-      process.exit(5)
-      return
-    }
-
-    // 行内容の読み込み
-    let lines: string[] = []
-    if (hasText) {
-      lines = (a.text as string).split(/\r?\n|\\n/)
-    } else {
-      const filePath = a["from-file"] as string
-      if (isStdinPath(filePath)) {
-        try {
-          const content = readStdinBounded()
-          lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            writeErrorJson("UNSAFE_PATH", err.message)
-            process.exit(5)
-            return
-          }
-          throw err
-        }
-      } else {
-        try {
-          const content = readFromFile(filePath, { allowUnsafe: a["allow-unsafe-read"] })
-          lines = content.split(/\r?\n/).filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-            process.exit(5)
-            return
-          }
-          writeErrorJson(
-            "VALIDATION_ERROR",
-            `ファイルの読み込みに失敗しました: "${filePath}"`,
-            "ファイルパスが正しいか確認してください",
-          )
-          process.exit(5)
-          return
-        }
-      }
-    }
-
-    if (lines.length === 0) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "置換内容が空です",
-        "--text または --from-file でコンテンツを指定してください",
-      )
-      process.exit(5)
-      return
-    }
-
-    // Cosense 記法の lint 検査
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    // 行内容の読み込み (line は行番号のため text/from-file のみ渡す)
+    const lines = readWriteInput(
+      {
+        ...(a.text !== undefined && { text: a.text }),
+        ...(a["from-file"] !== undefined && { "from-file": a["from-file"] }),
+        "allow-unsafe-read": a["allow-unsafe-read"],
+      },
+      {
+        requireContentErrorCode: "CONTENT_REQUIRED",
+        requireContentMessage: "置換内容が指定されていません",
+        requireContentHint: "--text または --from-file でコンテンツを指定してください",
+      },
+    )
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" の ${start}〜${end} 行目を置換中...`)
 

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -14,16 +14,14 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
-  isStdinPath,
-  notationFindingToWarning,
+  readWriteInput,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
-import { lintNotation } from "@/core/notation/lint"
 import { createPage } from "@/core/pages"
-import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
-import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pageNewCommand = defineCommand({
@@ -62,60 +60,12 @@ export const pageNewCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    let lines: string[] = []
-    if (isStdinPath(a["from-file"])) {
-      // stdin から読み込む (citty が "-" を "" に変換するバグにも対応)
-      try {
-        const content = readStdinBounded()
-        lines = content.split("\n").filter((l) => l.length > 0 || content.endsWith("\n"))
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message)
-          process.exit(5)
-        }
-        throw err
-      }
-    } else if (a["from-file"]) {
-      try {
-        const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-        lines = content.split("\n")
-      } catch (err) {
-        if (err instanceof UnsafePathError) {
-          writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-          process.exit(5)
-        }
-        throw err
-      }
-    } else if (a.line !== undefined) {
-      // citty は --line を複数回渡すと配列になるため、string と string[] の両方に対応する
-      // 実改行（\n, \r\n）とエスケープシーケンス（\\n）の両方を展開する
-      const lineValues = Array.isArray(a.line) ? a.line : [a.line]
-      lines = lineValues.flatMap((l) => l.split(/\r?\n|\\n/))
-    }
-
-    if (lines.length === 0) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "ページ本文が指定されていません",
-        "--from-file または --line でコンテンツを指定してください",
-      )
-      process.exit(5)
-    }
-
-    // Cosense 記法の lint 検査
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    const lines = readWriteInput(a, {
+      requireContentErrorCode: "CONTENT_REQUIRED",
+      requireContentMessage: "ページ本文が指定されていません",
+      requireContentHint: "--from-file または --line でコンテンツを指定してください",
+    })
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" を作成中...`)
 

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -14,16 +14,14 @@ import {
   checkSandbox,
   commonArgs,
   dryRunArg,
-  isStdinPath,
-  notationFindingToWarning,
+  readWriteInput,
   requireProject,
+  runNotationLint,
   strictNotationArg,
   unsafeReadArg,
 } from "@/commands/_shared"
-import { lintNotation } from "@/core/notation/lint"
 import { prependToPage } from "@/core/pages"
-import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
-import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const pagePrependCommand = defineCommand({
@@ -60,69 +58,12 @@ export const pagePrependCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    let lines: string[] = []
-    if (a.line !== undefined) {
-      lines = a.line.split(/\r?\n|\\n/)
-    } else if (a["from-file"] !== undefined) {
-      // citty が "-" を "" に変換するバグにも対応するため isStdinPath で判定する
-      if (isStdinPath(a["from-file"])) {
-        try {
-          const content = readStdinBounded()
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            // stdin には --allow-unsafe-read は適用されないためヒントを表示しない
-            writeErrorJson("UNSAFE_PATH", err.message)
-            process.exit(5)
-            return
-          }
-          throw err
-        }
-      } else {
-        try {
-          const content = readFromFile(a["from-file"], { allowUnsafe: a["allow-unsafe-read"] })
-          lines = content.split("\n").filter((l, i, arr) => l !== "" || i < arr.length - 1)
-        } catch (err) {
-          if (err instanceof UnsafePathError) {
-            writeErrorJson("UNSAFE_PATH", err.message, "--allow-unsafe-read フラグで許可できます")
-            process.exit(5)
-            return
-          }
-          writeErrorJson(
-            "VALIDATION_ERROR",
-            `ファイルの読み込みに失敗しました: "${a["from-file"]}"`,
-            "ファイルパスが正しいか確認してください",
-          )
-          process.exit(5)
-          return
-        }
-      }
-    }
-
-    if (lines.length === 0) {
-      writeErrorJson(
-        "CONTENT_REQUIRED",
-        "挿入する行が指定されていません",
-        "--line または --from-file でコンテンツを指定してください",
-      )
-      process.exit(5)
-      return
-    }
-
-    // Cosense 記法の lint 検査
-    const findings = lintNotation(lines)
-    const warnings = findings.map(notationFindingToWarning)
-
-    if (a["strict-notation"] && findings.length > 0) {
-      writeErrorJson(
-        "NOTATION_LINT",
-        `Cosense 記法の問題が ${findings.length} 件あります`,
-        "--strict-notation を外すと警告のみで実行できます",
-        { findings },
-      )
-      process.exit(5)
-      return
-    }
+    const lines = readWriteInput(a, {
+      requireContentErrorCode: "CONTENT_REQUIRED",
+      requireContentMessage: "挿入する行が指定されていません",
+      requireContentHint: "--line または --from-file でコンテンツを指定してください",
+    })
+    const warnings = runNotationLint(lines, a)
 
     logger.info(`"${a.title}" の先頭に行を挿入中...`)
 

--- a/src/commands/page/snapshot/get.ts
+++ b/src/commands/page/snapshot/get.ts
@@ -18,9 +18,9 @@ import {
   buildRestClient,
   checkSandbox,
   commonArgs,
+  handleRestError,
   requireProject,
 } from "@/commands/_shared"
-import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
 import { getPage, getPageSnapshot } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
@@ -131,25 +131,7 @@ export const pageSnapshotGetCommand = defineCommand({
         buildJsonOpts(a),
       )
     } catch (err) {
-      if (err instanceof AuthError) {
-        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
-        process.exit(2)
-        throw err
-      }
-      if (err instanceof ForbiddenError) {
-        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
-        process.exit(3)
-        throw err
-      }
-      if (err instanceof NotFoundError) {
-        writeErrorJson(
-          "NOT_FOUND",
-          err.message,
-          "ページタイトルとプロジェクト名、もしくは timestampId を確認してください",
-        )
-        process.exit(4)
-        throw err
-      }
+      handleRestError(err, { resourceKind: "snapshot", resourceName: a.title })
       throw err
     }
   },

--- a/src/commands/project/stream.ts
+++ b/src/commands/project/stream.ts
@@ -21,9 +21,10 @@ import {
   buildRestClient,
   checkSandbox,
   commonArgs,
+  handleRestError,
   requireProject,
 } from "@/commands/_shared"
-import { AuthError, ForbiddenError, NotFoundError, RateLimitError } from "@/core/api/rest"
+import { RateLimitError } from "@/core/api/rest"
 import { writeErrorJson, writeJson, writeJsonLine } from "@/presenter/json"
 import { writePlainTable, writeTsv } from "@/presenter/plain"
 import type { StreamResponse } from "@/schemas/stream"
@@ -180,25 +181,7 @@ export function makeProjectStreamCommand(deps: ProjectStreamDeps = {}) {
         try {
           result = await client.getProjectStream(project, limitOpts)
         } catch (err) {
-          if (err instanceof NotFoundError) {
-            writeErrorJson(
-              "NOT_FOUND",
-              `プロジェクト "${project}" が見つかりません`,
-              "プロジェクト名を確認してください",
-            )
-            process.exit(4)
-            throw new Error("NOT_FOUND")
-          }
-          if (err instanceof AuthError) {
-            writeErrorJson("AUTH_ERROR", "認証が必要です", "`cos auth login` を実行してください")
-            process.exit(2)
-            throw new Error("AUTH_ERROR")
-          }
-          if (err instanceof ForbiddenError) {
-            writeErrorJson("FORBIDDEN", "このプロジェクトへのアクセス権限がありません")
-            process.exit(3)
-            throw new Error("FORBIDDEN")
-          }
+          handleRestError(err, { resourceKind: "project", resourceName: project })
           throw err
         }
 
@@ -268,21 +251,7 @@ export function makeProjectStreamCommand(deps: ProjectStreamDeps = {}) {
               await sleepFn(intervalMs, ac.signal)
               continue
             }
-            if (err instanceof AuthError) {
-              writeErrorJson("AUTH_ERROR", "認証が必要です")
-              process.exit(2)
-              throw new Error("AUTH_ERROR")
-            }
-            if (err instanceof ForbiddenError) {
-              writeErrorJson("FORBIDDEN", "このプロジェクトへのアクセス権限がありません")
-              process.exit(3)
-              throw new Error("FORBIDDEN")
-            }
-            if (err instanceof NotFoundError) {
-              writeErrorJson("NOT_FOUND", `プロジェクト "${project}" が見つかりません`)
-              process.exit(4)
-              throw new Error("NOT_FOUND")
-            }
+            handleRestError(err, { resourceKind: "project", resourceName: project })
             throw err
           }
 

--- a/tests/unit/commands/_shared.helpers.test.ts
+++ b/tests/unit/commands/_shared.helpers.test.ts
@@ -1,0 +1,243 @@
+/**
+ * _shared.helpers.test.ts — _shared.ts の readWriteInput / runNotationLint / handleRestError のテスト。
+ *
+ * readWriteInput のファイル I/O は opts.readStdin / opts.readFile による依存注入でモックし、
+ * mock.module を使用しないことで bun:test カバレッジモードの共有プロセス汚染を回避する。
+ * runNotationLint は実 lintNotation を使用し、既知の記法違反入力で findings を生成する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { handleRestError, readWriteInput, runNotationLint } from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { UnsafePathError } from "@/infra/safe-read"
+
+// ----- セットアップ -----
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+/** stdout への JSON 出力を収集してパースするヘルパー */
+function captureJsonOutput(): { error?: { code: string; hint?: string } } {
+  const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+  if (!output.trim()) return {}
+  return JSON.parse(output) as { error?: { code: string; hint?: string } }
+}
+
+// ----- readWriteInput テスト -----
+
+describe("readWriteInput", () => {
+  const defaultOpts = {
+    requireContentErrorCode: "CONTENT_REQUIRED",
+    requireContentMessage: "コンテンツが必要です",
+    requireContentHint: "--line または --from-file で指定してください",
+  }
+
+  describe("--line フラグ (string)", () => {
+    it("実改行 (\\n) で区切られた文字列を行配列に分割する", () => {
+      const result = readWriteInput({ line: "行1\n行2\n行3" }, defaultOpts)
+      expect(result).toEqual(["行1", "行2", "行3"])
+    })
+
+    it("エスケープシーケンス \\\\n で改行を表現できる", () => {
+      const result = readWriteInput({ line: "行1\\n行2" }, defaultOpts)
+      expect(result).toEqual(["行1", "行2"])
+    })
+
+    it("CRLF 改行 (\\r\\n) を正規化して行配列に分割する", () => {
+      const result = readWriteInput({ line: "行1\r\n行2\r\n行3" }, defaultOpts)
+      expect(result).toEqual(["行1", "行2", "行3"])
+    })
+  })
+
+  describe("--line フラグ (string[])", () => {
+    it("line が配列のとき各要素を展開してフラットな行配列を返す", () => {
+      const result = readWriteInput({ line: ["行1\n行2", "行3"] }, defaultOpts)
+      expect(result).toEqual(["行1", "行2", "行3"])
+    })
+  })
+
+  describe("--text フラグ", () => {
+    it("text フラグも line 同様に改行分割される", () => {
+      const result = readWriteInput({ text: "テキスト行1\nテキスト行2" }, defaultOpts)
+      expect(result).toEqual(["テキスト行1", "テキスト行2"])
+    })
+  })
+
+  describe("stdin 読み込み (opts.readStdin による依存注入)", () => {
+    it('--from-file "-" のとき readStdin を呼び出す', () => {
+      // 注入した readStdin が実際に呼ばれることを検証する
+      const readStdin = mock(() => "stdin行1\nstdin行2")
+      const result = readWriteInput({ "from-file": "-" }, { ...defaultOpts, readStdin })
+      expect(readStdin).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(["stdin行1", "stdin行2"])
+    })
+
+    it('--from-file "" (citty バグ対応) のとき readStdin を呼び出す', () => {
+      const readStdin = mock(() => "stdin行1\nstdin行2")
+      const result = readWriteInput({ "from-file": "" }, { ...defaultOpts, readStdin })
+      expect(readStdin).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(["stdin行1", "stdin行2"])
+    })
+
+    it("末尾改行を含む stdin 内容の最後の空行を除去する", () => {
+      // "行1\n行2\n" を split すると ["行1", "行2", ""] になり、最後の空文字を除去する
+      const readStdin = mock(() => "行1\n行2\n")
+      const result = readWriteInput({ "from-file": "-" }, { ...defaultOpts, readStdin })
+      expect(result).toEqual(["行1", "行2"])
+    })
+
+    it("stdin からの UnsafePathError は exit 5 / UNSAFE_PATH / hint なし で終了する", () => {
+      const readStdin = () => {
+        throw new UnsafePathError("/dev/stdin", "stdin からの読み込みはサポートされていません")
+      }
+      try {
+        readWriteInput({ "from-file": "-" }, { ...defaultOpts, readStdin })
+      } catch {
+        // process.exit モック後の throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const parsed = captureJsonOutput()
+      expect(parsed.error?.code).toBe("UNSAFE_PATH")
+      // stdin には --allow-unsafe-read のヒントは表示しない
+      expect(parsed.error?.hint).toBeUndefined()
+    })
+  })
+
+  describe("ファイル読み込み (opts.readFile による依存注入)", () => {
+    it("--from-file でファイルパスを指定すると readFile を呼び出す", () => {
+      const readFile = mock(
+        (_path: string, _opts: { allowUnsafe: boolean }) => "ファイル行1\nファイル行2",
+      )
+      const result = readWriteInput(
+        { "from-file": "/tmp/テスト.txt" },
+        { ...defaultOpts, readFile },
+      )
+      expect(readFile).toHaveBeenCalledWith("/tmp/テスト.txt", { allowUnsafe: false })
+      expect(result).toEqual(["ファイル行1", "ファイル行2"])
+    })
+
+    it("--allow-unsafe-read フラグが readFile に伝達される", () => {
+      const readFile = mock((_path: string, _opts: { allowUnsafe: boolean }) => "内容")
+      readWriteInput(
+        { "from-file": "/etc/passwd", "allow-unsafe-read": true },
+        { ...defaultOpts, readFile },
+      )
+      expect(readFile).toHaveBeenCalledWith("/etc/passwd", { allowUnsafe: true })
+    })
+
+    it("ファイルからの UnsafePathError は exit 5 / UNSAFE_PATH / --allow-unsafe-read ヒント付きで終了する", () => {
+      const readFile = (_path: string, _opts: { allowUnsafe: boolean }): string => {
+        throw new UnsafePathError("/etc/passwd", "システムファイルへのアクセスは禁止されています")
+      }
+      try {
+        readWriteInput({ "from-file": "/etc/passwd" }, { ...defaultOpts, readFile })
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const parsed = captureJsonOutput()
+      expect(parsed.error?.code).toBe("UNSAFE_PATH")
+      // ファイルには --allow-unsafe-read のヒントを表示する
+      expect(parsed.error?.hint).toContain("allow-unsafe-read")
+    })
+  })
+
+  describe("コンテンツ未指定 / 空", () => {
+    it("line も from-file も未指定の場合は exit 5 / requireContentErrorCode で終了する", () => {
+      try {
+        readWriteInput({}, defaultOpts)
+      } catch {
+        // 想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const parsed = captureJsonOutput()
+      expect(parsed.error?.code).toBe("CONTENT_REQUIRED")
+    })
+  })
+})
+
+// ----- runNotationLint テスト -----
+// 実 lintNotation を使用し、既知の記法違反入力で findings を生成する
+
+describe("runNotationLint", () => {
+  const nonStrictArgs = { "strict-notation": false }
+  const strictArgs = { "strict-notation": true }
+
+  it("lint 指摘がない場合は空配列を返す", () => {
+    // 有効な Cosense 記法のみを含む入力は findings を生成しない
+    const result = runNotationLint(["有効な行1", "有効な行2"], nonStrictArgs)
+    expect(result).toEqual([])
+  })
+
+  it("lint 指摘がある場合は警告文字列配列を返す (non-strict)", () => {
+    // [*テキスト] は no-space-in-emphasis ルール違反 (* 直後のスペースなし)
+    const result = runNotationLint(["[*テキスト]"], nonStrictArgs)
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0]).toContain("no-space-in-emphasis")
+  })
+
+  it("lint 指摘がある場合に --strict-notation=true なら exit 5 / NOTATION_LINT で終了する", () => {
+    try {
+      runNotationLint(["[*テキスト]"], strictArgs)
+    } catch {
+      // 想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const parsed = captureJsonOutput()
+    expect(parsed.error?.code).toBe("NOTATION_LINT")
+  })
+})
+
+// ----- handleRestError テスト -----
+
+describe("handleRestError", () => {
+  const context = { resourceKind: "page" as const, resourceName: "テストページ" }
+
+  it("AuthError の場合は exit 2 で終了する", () => {
+    try {
+      handleRestError(new AuthError(), context)
+    } catch {
+      // 想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(2)
+  })
+
+  it("ForbiddenError の場合は exit 3 で終了する", () => {
+    try {
+      handleRestError(new ForbiddenError(), context)
+    } catch {
+      // 想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(3)
+  })
+
+  it("NotFoundError の場合は exit 4 で終了する", () => {
+    try {
+      handleRestError(new NotFoundError("テストページ"), context)
+    } catch {
+      // 想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(4)
+  })
+
+  it("未知のエラーは何もしない (呼び出し側への再スローに委ねる)", () => {
+    // handleRestError 自体は process.exit を呼ばず、ただ return する
+    handleRestError(new Error("一般エラー"), context)
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("null は何もしない", () => {
+    handleRestError(null, context)
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- `src/commands/_shared.ts` に `readWriteInput` / `runNotationLint` / `handleRestError` の 3 ヘルパーを追加
- `page/append`, `prepend`, `insert`, `edit`, `new`, `line/replace`, `project/stream`, `page/snapshot/get` の 8 コマンドで重複していた約 300 行を置換
- `tests/unit/commands/_shared.helpers.test.ts` に 21 テストを先行作成 (TDD: RED → GREEN → REFACTOR)
- 機能挙動は一切変更なし (既存テストが全 pass することで振る舞い不変を保証)

## 変更の詳細

### 追加ヘルパー

| 関数 | 役割 | 置換前の重複数 |
|------|------|--------------|
| `readWriteInput` | `--line`/`--text`/`--from-file`/stdin の統一読み込み | 5〜6 箇所 |
| `runNotationLint` | Cosense 記法 lint + `--strict-notation` での終了 | 6 箇所 |
| `handleRestError` | AuthError/ForbiddenError/NotFoundError → exit コードマッピング | 3〜4 箇所 |

### 設計上の注意点

- `readWriteInput` は `opts.readStdin` / `opts.readFile` で依存注入可能にし、`mock.module` を使わずテスト可能にする (coverage モードでの共有プロセス汚染を回避)
- `runNotationLint` は実 `lintNotation` を使用。テストは既知の記法違反入力 `["[*テキスト]"]` で検証
- `line/replace.ts` は `--line` が行番号を指すため、`readWriteInput` には `text`/`from-file` のみを渡すよう制御

## Test plan

- [x] `bun test` 全件 pass (1227 pass, 16 skip, 0 fail)
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * コマンド実行時のエラーハンドリングを改善し、認証エラー・権限エラー・リソース未検出エラーに対応するようになりました。
  * 記法チェック機能を統合し、検証結果をより一貫して処理できるようになりました。

* **Refactor**
  * 複数コマンドの入力処理を共通ユーティリティに統一し、コード保守性を向上させました。

* **Tests**
  * 新しいユーティリティ関数の動作を検証するユニットテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->