### PR TITLE
refactor(cli): cli.ts を commands/index.ts・cli-context.ts・cli-runner.ts に分割する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,183 +6,15 @@
  * sandbox (--enable-commands/--disable-commands) を一元管理する。
  */
 
+import { rootSubCommands } from "@/commands/index"
 import { setRootCommand } from "@/core/cli-root"
-import { ROOT_STRING_FLAGS, normalizeRootStringFlags } from "@/infra/args"
-import {
-  extractErrorMessage,
-  extractStackTrace,
-  resolveErrorCode,
-  resolveExitCode,
-} from "@/infra/cli-error-handler"
-import { initColor } from "@/infra/color"
-import { createCustomShowUsage } from "@/infra/help"
-import { Logger } from "@/infra/logger"
-import { normalizeVersion } from "@/infra/version"
-import { writeErrorJson } from "@/presenter/json"
-import { defineCommand, runCommand } from "citty"
+import { applyRootContext } from "@/infra/cli-context"
+import type { RootArgs } from "@/infra/cli-context"
+import { runWithHelpAndErrors } from "@/infra/cli-runner"
+import { defineCommand } from "citty"
 
 // bun build --define 'VERSION="x.y.z"' でビルド時に注入される
 declare const VERSION: string
-
-import { pageAppendCommand } from "@/commands/page/append"
-import { pageCodeCommand } from "@/commands/page/code"
-import { pageContextCommand } from "@/commands/page/context"
-import { pageDeleteCommand } from "@/commands/page/delete"
-import { pageEditCommand } from "@/commands/page/edit"
-import { pageGetCommand } from "@/commands/page/get"
-import { pageHistoryCommand } from "@/commands/page/history"
-import { pageIconCommand } from "@/commands/page/icon"
-import { pageInsertCommand } from "@/commands/page/insert"
-import { pageLineDeleteCommand } from "@/commands/page/line/delete"
-import { pageLineGetCommand } from "@/commands/page/line/get"
-import { pageLineReplaceCommand } from "@/commands/page/line/replace"
-// ページコマンド
-import { pageListCommand } from "@/commands/page/list"
-import { pageNewCommand } from "@/commands/page/new"
-import { pagePinCommand } from "@/commands/page/pin"
-import { pagePrependCommand } from "@/commands/page/prepend"
-import { pageRenameCommand } from "@/commands/page/rename"
-import { pageSnapshotGetCommand } from "@/commands/page/snapshot/get"
-import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
-import { pageTableCommand } from "@/commands/page/table"
-import { pageTextCommand } from "@/commands/page/text"
-import { pageUnpinCommand } from "@/commands/page/unpin"
-import { pageUrlCommand } from "@/commands/page/url"
-import { pageWatchCommand } from "@/commands/page/watch"
-
-import { projectGraphCommand } from "@/commands/project/graph"
-import { projectInfoCommand } from "@/commands/project/info"
-// プロジェクトコマンド
-import { projectListCommand } from "@/commands/project/list"
-import { projectSearchCommand } from "@/commands/project/search"
-import { projectStreamCommand } from "@/commands/project/stream"
-
-// 検索コマンド
-import { searchCommand } from "@/commands/search"
-
-// 認証コマンド
-import { authLoginCommand } from "@/commands/auth/login"
-import { authLogoutCommand } from "@/commands/auth/logout"
-import { authWhoamiCommand } from "@/commands/auth/whoami"
-
-// 設定コマンド
-import { configGetCommand } from "@/commands/config/get"
-import { configPathCommand } from "@/commands/config/path"
-import { configSetCommand } from "@/commands/config/set"
-
-// 同期コマンド
-import { syncDiffCommand } from "@/commands/sync/diff"
-import { syncPullCommand } from "@/commands/sync/pull"
-import { syncPushCommand } from "@/commands/sync/push"
-
-// 変換コマンド
-import { convertCommand } from "@/commands/convert"
-
-// サーブコマンド
-import { serveCommand } from "@/commands/serve"
-
-// エージェント向け補助コマンド
-import { exitCodesCommand } from "@/commands/exit-codes"
-import { notationGuideCommand } from "@/commands/notation/guide"
-import { schemaCommand } from "@/commands/schema"
-
-/** page line サブコマンドグループ */
-const pageLineCommand = defineCommand({
-  meta: { name: "line", description: "行単位編集 (replace / delete / get)" },
-  subCommands: {
-    replace: pageLineReplaceCommand,
-    delete: pageLineDeleteCommand,
-    rm: pageLineDeleteCommand,
-    get: pageLineGetCommand,
-  },
-})
-
-/** page snapshot サブコマンドグループ */
-const pageSnapshotCommand = defineCommand({
-  meta: { name: "snapshot", description: "ページのスナップショット (list / get)" },
-  subCommands: {
-    list: pageSnapshotListCommand,
-    ls: pageSnapshotListCommand,
-    get: pageSnapshotGetCommand,
-  },
-})
-
-/** page サブコマンドグループ */
-const pageCommand = defineCommand({
-  meta: { name: "page", description: "ページ操作コマンド" },
-  subCommands: {
-    list: pageListCommand,
-    ls: pageListCommand,
-    get: pageGetCommand,
-    text: pageTextCommand,
-    code: pageCodeCommand,
-    table: pageTableCommand,
-    url: pageUrlCommand,
-    new: pageNewCommand,
-    create: pageNewCommand,
-    edit: pageEditCommand,
-    ed: pageEditCommand,
-    append: pageAppendCommand,
-    prepend: pagePrependCommand,
-    insert: pageInsertCommand,
-    rename: pageRenameCommand,
-    mv: pageRenameCommand,
-    pin: pagePinCommand,
-    unpin: pageUnpinCommand,
-    icon: pageIconCommand,
-    history: pageHistoryCommand,
-    snapshot: pageSnapshotCommand,
-    delete: pageDeleteCommand,
-    rm: pageDeleteCommand,
-    watch: pageWatchCommand,
-    context: pageContextCommand,
-    line: pageLineCommand,
-  },
-})
-
-/** project サブコマンドグループ */
-const projectCommand = defineCommand({
-  meta: { name: "project", description: "プロジェクト操作コマンド" },
-  subCommands: {
-    list: projectListCommand,
-    ls: projectListCommand,
-    info: projectInfoCommand,
-    graph: projectGraphCommand,
-    stream: projectStreamCommand,
-    search: projectSearchCommand,
-  },
-})
-
-/** auth サブコマンドグループ */
-const authCommand = defineCommand({
-  meta: { name: "auth", description: "認証コマンド" },
-  subCommands: {
-    login: authLoginCommand,
-    logout: authLogoutCommand,
-    whoami: authWhoamiCommand,
-    me: authWhoamiCommand,
-  },
-})
-
-/** config サブコマンドグループ */
-const configCommand = defineCommand({
-  meta: { name: "config", description: "設定コマンド" },
-  subCommands: {
-    get: configGetCommand,
-    set: configSetCommand,
-    path: configPathCommand,
-  },
-})
-
-/** sync サブコマンドグループ */
-const syncCommand = defineCommand({
-  meta: { name: "sync", description: "ローカルファイルと Cosense の同期コマンド" },
-  subCommands: {
-    pull: syncPullCommand,
-    push: syncPushCommand,
-    diff: syncDiffCommand,
-  },
-})
 
 /** ルートコマンド */
 const main = defineCommand({
@@ -229,94 +61,13 @@ const main = defineCommand({
     },
   },
   setup({ args }) {
-    // 色初期化
-    const colorMode = (args.color ?? "auto") as "auto" | "always" | "never"
-    initColor(colorMode)
-
-    // sandbox ポリシーのプリセット設定を環境変数に反映する
-    // 実際の判定は各コマンドの checkSandbox() で行う
-    if (args["enable-commands"]) {
-      process.env["COS_ENABLE_COMMANDS"] = args["enable-commands"]
-    }
-    if (args["disable-commands"]) {
-      process.env["COS_DISABLE_COMMANDS"] = args["disable-commands"]
-    }
-
-    // --json と --plain は相互排他なのでいずれも指定された場合はエラー
-    if (args.json === true && args.plain === true) {
-      process.stderr.write("error: --json と --plain は同時に指定できません\n")
-      process.exit(5)
-    }
-
-    // 出力制御フラグを環境変数経由でサブコマンドへ伝播する
-    // buildLogger / buildJsonOpts がこれらの環境変数を参照する
-    if (args.json === true) process.env["COS_JSON"] = "1"
-    if (args.plain === true) process.env["COS_PLAIN"] = "1"
-    if (args["results-only"] === true) process.env["COS_RESULTS_ONLY"] = "1"
-    if (args.select) process.env["COS_SELECT"] = args.select
+    applyRootContext(args as RootArgs, process.env)
   },
-  subCommands: {
-    page: pageCommand,
-    project: projectCommand,
-    search: searchCommand,
-    find: searchCommand,
-    auth: authCommand,
-    login: authLoginCommand,
-    me: authWhoamiCommand,
-    config: configCommand,
-    sync: syncCommand,
-    convert: convertCommand,
-    serve: serveCommand,
-    "exit-codes": exitCodesCommand,
-    schema: schemaCommand,
-    notation: notationGuideCommand,
-  },
+  subCommands: rootSubCommands,
 })
 
 // schema コマンドがルートを参照できるよう singleton に登録する
 // exactOptionalPropertyTypes のため具体的な args 型を CommandDef に広げてから渡す
 setRootCommand(main as unknown as import("citty").CommandDef)
 
-// citty がスペース区切りの string フラグ値をサブコマンドと誤認識する問題を回避する
-const rawArgs = normalizeRootStringFlags(process.argv.slice(2), ROOT_STRING_FLAGS)
-const showUsageFn = createCustomShowUsage(main as unknown as import("citty").CommandDef, "cos")
-
-// --help / -h: citty の showUsage を呼んで exit 0
-if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
-  await showUsageFn(main as unknown as import("citty").CommandDef, null as never)
-  process.exit(0)
-}
-
-// --version (単独): バージョンを表示して exit 0
-if (rawArgs.length === 1 && rawArgs[0] === "--version") {
-  const meta =
-    typeof main.meta === "function" ? await main.meta() : await Promise.resolve(main.meta)
-  const version = normalizeVersion(meta?.version ?? "")
-  console.log(version)
-  process.exit(0)
-}
-
-// 通常コマンド実行: runCommand を直接呼び、エラーを自前で分類する
-const isJson = rawArgs.some((a) => a === "--json" || a === "-J")
-const isVerbose = rawArgs.some(
-  (a) => a === "-v" || a === "-vv" || a === "--verbose" || a.startsWith("--verbose="),
-)
-
-try {
-  await runCommand(main, { rawArgs })
-} catch (err) {
-  const exitCode = resolveExitCode(err)
-  const message = extractErrorMessage(err)
-  const stack = isVerbose ? extractStackTrace(err) : undefined
-
-  if (isJson) {
-    writeErrorJson(resolveErrorCode(err), message)
-  } else {
-    const logger = new Logger()
-    logger.error(message)
-    if (stack) {
-      process.stderr.write(`${stack}\n`)
-    }
-  }
-  process.exit(exitCode)
-}
+await runWithHelpAndErrors(main as unknown as import("citty").CommandDef, process.argv.slice(2))

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,188 @@
+/**
+ * commands/index.ts — トップレベルサブコマンドレジストリ。
+ *
+ * cli.ts から分離したサブコマンドツリー定義。
+ * 新しいコマンドを追加する際は rootSubCommands に追加し、
+ * alias がある場合はここに登録すること (CLAUDE.md の alias ルールを参照)。
+ */
+
+import { pageAppendCommand } from "@/commands/page/append"
+import { pageCodeCommand } from "@/commands/page/code"
+import { pageContextCommand } from "@/commands/page/context"
+import { pageDeleteCommand } from "@/commands/page/delete"
+import { pageEditCommand } from "@/commands/page/edit"
+import { pageGetCommand } from "@/commands/page/get"
+import { pageHistoryCommand } from "@/commands/page/history"
+import { pageIconCommand } from "@/commands/page/icon"
+import { pageInsertCommand } from "@/commands/page/insert"
+import { pageLineDeleteCommand } from "@/commands/page/line/delete"
+import { pageLineGetCommand } from "@/commands/page/line/get"
+import { pageLineReplaceCommand } from "@/commands/page/line/replace"
+// ページコマンド
+import { pageListCommand } from "@/commands/page/list"
+import { pageNewCommand } from "@/commands/page/new"
+import { pagePinCommand } from "@/commands/page/pin"
+import { pagePrependCommand } from "@/commands/page/prepend"
+import { pageRenameCommand } from "@/commands/page/rename"
+import { pageSnapshotGetCommand } from "@/commands/page/snapshot/get"
+import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
+import { pageTableCommand } from "@/commands/page/table"
+import { pageTextCommand } from "@/commands/page/text"
+import { pageUnpinCommand } from "@/commands/page/unpin"
+import { pageUrlCommand } from "@/commands/page/url"
+import { pageWatchCommand } from "@/commands/page/watch"
+
+import { projectGraphCommand } from "@/commands/project/graph"
+import { projectInfoCommand } from "@/commands/project/info"
+// プロジェクトコマンド
+import { projectListCommand } from "@/commands/project/list"
+import { projectSearchCommand } from "@/commands/project/search"
+import { projectStreamCommand } from "@/commands/project/stream"
+
+// 検索コマンド
+import { searchCommand } from "@/commands/search"
+
+// 認証コマンド
+import { authLoginCommand } from "@/commands/auth/login"
+import { authLogoutCommand } from "@/commands/auth/logout"
+import { authWhoamiCommand } from "@/commands/auth/whoami"
+
+// 設定コマンド
+import { configGetCommand } from "@/commands/config/get"
+import { configPathCommand } from "@/commands/config/path"
+import { configSetCommand } from "@/commands/config/set"
+
+// 同期コマンド
+import { syncDiffCommand } from "@/commands/sync/diff"
+import { syncPullCommand } from "@/commands/sync/pull"
+import { syncPushCommand } from "@/commands/sync/push"
+
+// 変換コマンド
+import { convertCommand } from "@/commands/convert"
+
+// サーブコマンド
+import { serveCommand } from "@/commands/serve"
+
+// エージェント向け補助コマンド
+import { exitCodesCommand } from "@/commands/exit-codes"
+import { notationGuideCommand } from "@/commands/notation/guide"
+import { schemaCommand } from "@/commands/schema"
+
+import { defineCommand } from "citty"
+
+/** page line サブコマンドグループ */
+export const pageLineCommand = defineCommand({
+  meta: { name: "line", description: "行単位編集 (replace / delete / get)" },
+  subCommands: {
+    replace: pageLineReplaceCommand,
+    delete: pageLineDeleteCommand,
+    rm: pageLineDeleteCommand,
+    get: pageLineGetCommand,
+  },
+})
+
+/** page snapshot サブコマンドグループ */
+export const pageSnapshotCommand = defineCommand({
+  meta: { name: "snapshot", description: "ページのスナップショット (list / get)" },
+  subCommands: {
+    list: pageSnapshotListCommand,
+    ls: pageSnapshotListCommand,
+    get: pageSnapshotGetCommand,
+  },
+})
+
+/** page サブコマンドグループ */
+export const pageCommand = defineCommand({
+  meta: { name: "page", description: "ページ操作コマンド" },
+  subCommands: {
+    list: pageListCommand,
+    ls: pageListCommand,
+    get: pageGetCommand,
+    text: pageTextCommand,
+    code: pageCodeCommand,
+    table: pageTableCommand,
+    url: pageUrlCommand,
+    new: pageNewCommand,
+    create: pageNewCommand,
+    edit: pageEditCommand,
+    ed: pageEditCommand,
+    append: pageAppendCommand,
+    prepend: pagePrependCommand,
+    insert: pageInsertCommand,
+    rename: pageRenameCommand,
+    mv: pageRenameCommand,
+    pin: pagePinCommand,
+    unpin: pageUnpinCommand,
+    icon: pageIconCommand,
+    history: pageHistoryCommand,
+    snapshot: pageSnapshotCommand,
+    delete: pageDeleteCommand,
+    rm: pageDeleteCommand,
+    watch: pageWatchCommand,
+    context: pageContextCommand,
+    line: pageLineCommand,
+  },
+})
+
+/** project サブコマンドグループ */
+export const projectCommand = defineCommand({
+  meta: { name: "project", description: "プロジェクト操作コマンド" },
+  subCommands: {
+    list: projectListCommand,
+    ls: projectListCommand,
+    info: projectInfoCommand,
+    graph: projectGraphCommand,
+    stream: projectStreamCommand,
+    search: projectSearchCommand,
+  },
+})
+
+/** auth サブコマンドグループ */
+export const authCommand = defineCommand({
+  meta: { name: "auth", description: "認証コマンド" },
+  subCommands: {
+    login: authLoginCommand,
+    logout: authLogoutCommand,
+    whoami: authWhoamiCommand,
+    me: authWhoamiCommand,
+  },
+})
+
+/** config サブコマンドグループ */
+export const configCommand = defineCommand({
+  meta: { name: "config", description: "設定コマンド" },
+  subCommands: {
+    get: configGetCommand,
+    set: configSetCommand,
+    path: configPathCommand,
+  },
+})
+
+/** sync サブコマンドグループ */
+export const syncCommand = defineCommand({
+  meta: { name: "sync", description: "ローカルファイルと Cosense の同期コマンド" },
+  subCommands: {
+    pull: syncPullCommand,
+    push: syncPushCommand,
+    diff: syncDiffCommand,
+  },
+})
+
+/** rootSubCommands はトップレベルサブコマンドのレジストリ。 */
+export const rootSubCommands = {
+  page: pageCommand,
+  project: projectCommand,
+  search: searchCommand,
+  find: searchCommand,
+  auth: authCommand,
+  // トップレベルエイリアス: alias ルール (CLAUDE.md) に従い cli.ts でも同時登録すること
+  login: authLoginCommand,
+  me: authWhoamiCommand,
+  config: configCommand,
+  sync: syncCommand,
+  convert: convertCommand,
+  serve: serveCommand,
+  "exit-codes": exitCodesCommand,
+  schema: schemaCommand,
+  notation: notationGuideCommand,
+} as const

--- a/src/infra/cli-context.ts
+++ b/src/infra/cli-context.ts
@@ -1,0 +1,52 @@
+/**
+ * cli-context.ts — ルートフラグ評価と環境変数注入。
+ *
+ * cli.ts の setup() ロジックを純粋関数として分離し、
+ * --json/--plain の排他チェックと環境変数への伝播を担当する。
+ */
+
+import { initColor } from "@/infra/color"
+
+/** RootArgs はルートコマンドが受け取るフラグの型。 */
+export interface RootArgs {
+  "enable-commands"?: string
+  "disable-commands"?: string
+  color?: string
+  json: boolean
+  plain: boolean
+  "results-only": boolean
+  select?: string
+}
+
+/**
+ * applyRootContext はルートフラグを評価して環境変数へ注入し、グローバル状態 (initColor) を初期化する。
+ * --json と --plain の同時指定は exit 5 で終了する。
+ */
+export function applyRootContext(args: RootArgs, env: NodeJS.ProcessEnv): void {
+  // 色初期化
+  const colorMode = (args.color ?? "auto") as "auto" | "always" | "never"
+  initColor(colorMode)
+
+  // --json と --plain は相互排他
+  if (args.json === true && args.plain === true) {
+    process.stderr.write("error: --json と --plain は同時に指定できません\n")
+    process.exit(5)
+    return
+  }
+
+  // sandbox ポリシーのプリセット設定を環境変数に反映する
+  // 実際の判定は各コマンドの checkSandbox() で行う
+  if (args["enable-commands"]) {
+    env["COS_ENABLE_COMMANDS"] = args["enable-commands"]
+  }
+  if (args["disable-commands"]) {
+    env["COS_DISABLE_COMMANDS"] = args["disable-commands"]
+  }
+
+  // 出力制御フラグを環境変数経由でサブコマンドへ伝播する
+  // buildLogger / buildJsonOpts がこれらの環境変数を参照する
+  if (args.json === true) env["COS_JSON"] = "1"
+  if (args.plain === true) env["COS_PLAIN"] = "1"
+  if (args["results-only"] === true) env["COS_RESULTS_ONLY"] = "1"
+  if (args.select) env["COS_SELECT"] = args.select
+}

--- a/src/infra/cli-runner.ts
+++ b/src/infra/cli-runner.ts
@@ -1,0 +1,72 @@
+/**
+ * cli-runner.ts — citty コマンド実行ラッパー。
+ *
+ * --help / --version の手書き経路と、エラーキャッチ → exit コードマッピングを内包する。
+ * cli.ts のエントリポイントから top-level await を分離し、テスト可能にする。
+ */
+
+import { ROOT_STRING_FLAGS, normalizeRootStringFlags } from "@/infra/args"
+import {
+  extractErrorMessage,
+  extractStackTrace,
+  resolveErrorCode,
+  resolveExitCode,
+} from "@/infra/cli-error-handler"
+import { createCustomShowUsage } from "@/infra/help"
+import { normalizeVersion } from "@/infra/version"
+import { writeErrorJson } from "@/presenter/json"
+import type { CommandDef } from "citty"
+import { runCommand } from "citty"
+
+/**
+ * runWithHelpAndErrors は citty メインコマンドを実行する。
+ * --help / --version の手書き経路と、エラーキャッチ → exit コードマッピングを内包する。
+ */
+export async function runWithHelpAndErrors(main: CommandDef, argv: string[]): Promise<void> {
+  // citty がスペース区切りの string フラグ値をサブコマンドと誤認識する問題を回避する
+  const rawArgs = normalizeRootStringFlags(argv, ROOT_STRING_FLAGS)
+  const showUsageFn = createCustomShowUsage(main, "cos")
+
+  // --help / -h: citty の showUsage を呼んで exit 0
+  if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+    await showUsageFn(main, null as never)
+    process.exit(0)
+    return
+  }
+
+  // --version (単独): バージョンを表示して exit 0
+  if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+    const meta =
+      typeof main.meta === "function" ? await main.meta() : await Promise.resolve(main.meta)
+    const version = normalizeVersion(meta?.version ?? "")
+    process.stdout.write(`${version}\n`)
+    process.exit(0)
+    return
+  }
+
+  // 通常コマンド実行: runCommand を直接呼び、エラーを自前で分類する
+  const isJson = rawArgs.some((a) => a === "--json" || a === "-J")
+  const isVerbose = rawArgs.some(
+    (a) => a === "-v" || a === "-vv" || a === "--verbose" || a.startsWith("--verbose="),
+  )
+
+  try {
+    await runCommand(main, { rawArgs })
+  } catch (err) {
+    const exitCode = resolveExitCode(err)
+    const message = extractErrorMessage(err)
+    const stack = isVerbose ? extractStackTrace(err) : undefined
+
+    if (isJson) {
+      writeErrorJson(resolveErrorCode(err), message)
+    } else {
+      const { Logger } = await import("@/infra/logger")
+      const logger = new Logger()
+      logger.error(message)
+      if (stack) {
+        process.stderr.write(`${stack}\n`)
+      }
+    }
+    process.exit(exitCode)
+  }
+}

--- a/tests/unit/cli/cli-context.test.ts
+++ b/tests/unit/cli/cli-context.test.ts
@@ -1,0 +1,103 @@
+/**
+ * cli-context.test.ts — applyRootContext() のテスト。
+ *
+ * ルートフラグ (--json / --plain / --results-only / --select /
+ * --enable-commands / --disable-commands / --color) を評価して
+ * 環境変数へ注入し、色設定を初期化する関数。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { applyRootContext } from "@/infra/cli-context"
+import * as color from "@/infra/color"
+
+let exitMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let initColorSpy: ReturnType<typeof spyOn>
+
+/** テスト前に環境変数をクリアし、モックを設定する */
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  initColorSpy = spyOn(color, "initColor").mockImplementation(() => {})
+
+  // テスト間の環境変数汚染を防ぐ
+  for (const key of [
+    "COS_JSON",
+    "COS_PLAIN",
+    "COS_RESULTS_ONLY",
+    "COS_SELECT",
+    "COS_ENABLE_COMMANDS",
+    "COS_DISABLE_COMMANDS",
+  ]) {
+    Reflect.deleteProperty(process.env, key)
+  }
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stderrMock.mockRestore()
+  initColorSpy.mockRestore()
+})
+
+describe("applyRootContext", () => {
+  it("--json=true のとき COS_JSON='1' を環境変数にセットする", () => {
+    applyRootContext({ json: true, plain: false, "results-only": false }, process.env)
+    expect(process.env["COS_JSON"]).toBe("1")
+  })
+
+  it("--plain=true のとき COS_PLAIN='1' を環境変数にセットする", () => {
+    applyRootContext({ json: false, plain: true, "results-only": false }, process.env)
+    expect(process.env["COS_PLAIN"]).toBe("1")
+  })
+
+  it("--results-only=true のとき COS_RESULTS_ONLY='1' を環境変数にセットする", () => {
+    applyRootContext({ json: false, plain: false, "results-only": true }, process.env)
+    expect(process.env["COS_RESULTS_ONLY"]).toBe("1")
+  })
+
+  it("--select が指定されたとき COS_SELECT を環境変数にセットする", () => {
+    applyRootContext(
+      { json: false, plain: false, "results-only": false, select: "pages[].title" },
+      process.env,
+    )
+    expect(process.env["COS_SELECT"]).toBe("pages[].title")
+  })
+
+  it("--enable-commands が指定されたとき COS_ENABLE_COMMANDS を環境変数にセットする", () => {
+    applyRootContext(
+      { json: false, plain: false, "results-only": false, "enable-commands": "page.get,page.list" },
+      process.env,
+    )
+    expect(process.env["COS_ENABLE_COMMANDS"]).toBe("page.get,page.list")
+  })
+
+  it("--disable-commands が指定されたとき COS_DISABLE_COMMANDS を環境変数にセットする", () => {
+    applyRootContext(
+      { json: false, plain: false, "results-only": false, "disable-commands": "page.delete" },
+      process.env,
+    )
+    expect(process.env["COS_DISABLE_COMMANDS"]).toBe("page.delete")
+  })
+
+  it("--json と --plain を同時に指定した場合は exit 5 で終了する", () => {
+    try {
+      applyRootContext({ json: true, plain: true, "results-only": false }, process.env)
+    } catch {
+      // process.exit モック後の throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("initColor が color フラグで呼ばれる", () => {
+    applyRootContext(
+      { json: false, plain: false, "results-only": false, color: "always" },
+      process.env,
+    )
+    expect(initColorSpy).toHaveBeenCalledWith("always")
+  })
+
+  it("color フラグ未指定のときは 'auto' で initColor を呼ぶ", () => {
+    applyRootContext({ json: false, plain: false, "results-only": false }, process.env)
+    expect(initColorSpy).toHaveBeenCalledWith("auto")
+  })
+})

--- a/tests/unit/cli/cli-runner.test.ts
+++ b/tests/unit/cli/cli-runner.test.ts
@@ -1,0 +1,103 @@
+/**
+ * cli-runner.test.ts — runWithHelpAndErrors() のテスト。
+ *
+ * --help / --version 経路と、エラーキャッチ → exit コードマッピングを内包する関数。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { runWithHelpAndErrors } from "@/infra/cli-runner"
+import { defineCommand } from "citty"
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+})
+
+/** テスト用の最小コマンドを生成するヘルパー */
+function makeTestCommand(version = "1.0.0") {
+  return defineCommand({
+    meta: { name: "テスト", version, description: "テスト用コマンド" },
+    args: {},
+    run() {},
+  })
+}
+
+describe("runWithHelpAndErrors", () => {
+  it("--help フラグで exit 0 で終了する", async () => {
+    const main = makeTestCommand()
+    try {
+      await runWithHelpAndErrors(main, ["--help"])
+    } catch {
+      // process.exit モック後の throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(0)
+  })
+
+  it("-h フラグで exit 0 で終了する", async () => {
+    const main = makeTestCommand()
+    try {
+      await runWithHelpAndErrors(main, ["-h"])
+    } catch {
+      // process.exit モック後の throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(0)
+  })
+
+  it("--version フラグ単独で exit 0 で終了する", async () => {
+    const main = makeTestCommand("2.3.4")
+    try {
+      await runWithHelpAndErrors(main, ["--version"])
+    } catch {
+      // process.exit モック後の throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(0)
+  })
+
+  it("--version でバージョン文字列を出力する", async () => {
+    const main = makeTestCommand("1.2.3")
+    try {
+      await runWithHelpAndErrors(main, ["--version"])
+    } catch {
+      // 想定内
+    }
+    const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(output).toContain("1.2.3")
+  })
+
+  it("コマンド実行が成功した場合は process.exit を呼ばない", async () => {
+    const main = defineCommand({
+      meta: { name: "テスト" },
+      args: {},
+      run() {},
+    })
+    await runWithHelpAndErrors(main, [])
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("コマンド実行でエラーが発生した場合は exit 1 で終了する", async () => {
+    const main = defineCommand({
+      meta: { name: "テスト" },
+      args: {},
+      run() {
+        throw new Error("一般エラー")
+      },
+    })
+    try {
+      await runWithHelpAndErrors(main, [])
+    } catch {
+      // 想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
## Summary

- `src/cli.ts` (323 行) を 3 ファイルに分割し 73 行に圧縮
- `src/commands/index.ts` — サブコマンドツリーとトップレベルエイリアステーブル
- `src/infra/cli-context.ts` — `applyRootContext()` ルートフラグ評価と環境変数注入
- `src/infra/cli-runner.ts` — `runWithHelpAndErrors()` help/version/エラー経路

## 変更の詳細

### 新規ファイル

| ファイル | 責務 | 行数 |
|---------|------|------|
| `src/commands/index.ts` | サブコマンドグループ定義 + `rootSubCommands` export | ~160 行 |
| `src/infra/cli-context.ts` | `applyRootContext()` — env 注入・排他チェック・initColor | ~55 行 |
| `src/infra/cli-runner.ts` | `runWithHelpAndErrors()` — --help/--version/エラーキャッチ | ~70 行 |

### TDD

- `tests/unit/cli/cli-context.test.ts` (9 テスト) を先行作成
- `tests/unit/cli/cli-runner.test.ts` (6 テスト) を先行作成

### alias ルール (CLAUDE.md) の遵守

トップレベルエイリアス (`login`, `me`, `find` 等) は `rootSubCommands` 内に明記し、
コメントで両登録箇所を更新する際の注意を記載

## Test plan

- [x] `bun test` 全件 pass (1221 pass, 16 skip, 0 fail)
- [x] `bunx biome check src tests` 警告ゼロ
- [x] `bun run typecheck` エラーゼロ
- [x] 既存 `tests/unit/cli/` 全テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)