### PR TITLE
fix(schemas): 実 API の null/省略フィールドに対応したスキーマ修正

### DIFF
--- a/src/schemas/commit.ts
+++ b/src/schemas/commit.ts
@@ -15,7 +15,7 @@ import { z } from "zod"
  */
 export const commitSchema = z.object({
   id: z.string(),
-  parentId: z.string().optional(),
+  parentId: z.string().nullish(),
   pageId: z.string(),
   userId: z.string(),
   created: z.number(),

--- a/src/schemas/stream.ts
+++ b/src/schemas/stream.ts
@@ -10,6 +10,17 @@ import { PageSummarySchema } from "@/schemas/page"
 import { z } from "zod"
 
 /**
+ * StreamPageSummarySchema は stream API の pages[] 要素を表す。
+ *
+ * /api/stream/:project/ は /api/pages/:project/ と異なり、
+ * created / updated を省略することがあるため optional に緩和する。
+ */
+const StreamPageSummarySchema = PageSummarySchema.extend({
+  created: z.number().optional(),
+  updated: z.number().optional(),
+})
+
+/**
  * ProjectEventBaseSchema はすべてのプロジェクトイベントに共通するフィールド定義。
  *
  * @cosense/types の ProjectEvent interface に対応する。
@@ -61,7 +72,7 @@ export type ProjectUpdatesStreamEvent = z.infer<typeof ProjectUpdatesStreamEvent
 export const StreamResponseSchema = z.object({
   projectName: z.string(),
   end: z.number(),
-  pages: z.array(PageSummarySchema),
+  pages: z.array(StreamPageSummarySchema),
   events: z.array(ProjectUpdatesStreamEventSchema),
 })
 export type StreamResponse = z.infer<typeof StreamResponseSchema>

--- a/tests/unit/schemas/commit.test.ts
+++ b/tests/unit/schemas/commit.test.ts
@@ -1,0 +1,97 @@
+/**
+ * commit.test.ts — commit スキーマの検証テスト。
+ *
+ * GET /api/commits/:project/:pageid レスポンスの zod スキーマを検証する。
+ * - 最初のコミットは parentId が null で返ってくる実 API の挙動に対応する
+ * - 通常コミットは parentId が string
+ * - parentId を省略したケース (undefined) も有効
+ */
+
+import { describe, expect, it } from "bun:test"
+import { commitSchema, commitsResponseSchema } from "@/schemas/commit"
+
+describe("commitSchema", () => {
+  it("parentId が null のコミットを解析できる (最初のコミット)", () => {
+    // 実 API は最初のコミットで parentId: null を返す
+    const result = commitSchema.safeParse({
+      id: "commit-id-0",
+      parentId: null,
+      pageId: "page-id-1",
+      userId: "user-id-1",
+      created: 1700000000,
+      kind: "page",
+      changes: [],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.parentId).toBeNull()
+    }
+  })
+
+  it("parentId が string のコミットを解析できる", () => {
+    const result = commitSchema.safeParse({
+      id: "commit-id-1",
+      parentId: "commit-id-0",
+      pageId: "page-id-1",
+      userId: "user-id-1",
+      created: 1700100000,
+      kind: "page",
+      changes: [],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.parentId).toBe("commit-id-0")
+    }
+  })
+
+  it("parentId を省略したコミットを解析できる (undefined 扱い)", () => {
+    const result = commitSchema.safeParse({
+      id: "commit-id-0",
+      pageId: "page-id-1",
+      userId: "user-id-1",
+      created: 1700000000,
+      kind: "page",
+      changes: [],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.parentId).toBeUndefined()
+    }
+  })
+})
+
+describe("commitsResponseSchema", () => {
+  it("parentId が null のコミットを含むレスポンスを解析できる", () => {
+    const result = commitsResponseSchema.safeParse({
+      commits: [
+        {
+          id: "commit-id-1",
+          parentId: "commit-id-0",
+          pageId: "page-id-1",
+          userId: "user-id-1",
+          created: 1700100000,
+          kind: "page",
+          changes: [],
+        },
+        {
+          id: "commit-id-0",
+          parentId: null,
+          pageId: "page-id-1",
+          userId: "user-id-1",
+          created: 1700000000,
+          kind: "page",
+          changes: [],
+        },
+      ],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.commits).toHaveLength(2)
+      expect(result.data.commits[1]?.parentId).toBeNull()
+    }
+  })
+})

--- a/tests/unit/schemas/stream.test.ts
+++ b/tests/unit/schemas/stream.test.ts
@@ -113,6 +113,22 @@ describe("StreamResponseSchema", () => {
     expect(types).toContain("owner.set")
   })
 
+  it("pages の created/updated が省略されたペイロードをパースできる (stream API の実挙動)", () => {
+    // 実 API は stream レスポンスの pages[] で created/updated を省略する場合がある
+    const result = StreamResponseSchema.safeParse({
+      projectName: "テストプロジェクト",
+      end: 1700000000,
+      pages: [{ id: "ページID-001", title: "テストページ" }],
+      events: [],
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.pages[0]?.created).toBeUndefined()
+      expect(result.data.pages[0]?.updated).toBeUndefined()
+    }
+  })
+
   it("end が文字列の場合はパースエラーになる", () => {
     expect(() =>
       StreamResponseSchema.parse({


### PR DESCRIPTION
## Summary

- `commitSchema.parentId` を `z.string().optional()` → `z.string().nullish()` に変更
  - `/api/commits/:project/:pageid` は最初のコミットで `parentId: null` を返す実 API の挙動に対応
- `StreamPageSummarySchema` を新設し `pages[].created/updated` を optional に緩和
  - `/api/stream/:project/` の pages[] は `created`/`updated` を省略する場合がある
- `tests/unit/schemas/commit.test.ts` を新規追加
- `tests/unit/schemas/stream.test.ts` に null/省略ケースのテストを追加

## 背景

`mtane0412-sandbox` を使った動作確認で `page history` と `project stream` コマンドが `VALIDATION_ERROR` で失敗していた。実 API のレスポンスが zod スキーマの期待値と一致していないことが原因。

## Test plan

- [ ] `bun test tests/unit/schemas/commit.test.ts` — 4件すべて pass
- [ ] `bun test tests/unit/schemas/stream.test.ts` — 8件すべて pass
- [ ] `bun test --silent` — 1270 pass / 0 fail
- [ ] `bunx biome check src tests` — エラーなし
- [ ] `bun run typecheck` — エラーなし
- [ ] `./dist/cos-darwin-arm64 page history -p mtane0412-sandbox <title>` — 正常に JSON 出力
- [ ] `./dist/cos-darwin-arm64 project stream -p mtane0412-sandbox` — 正常に JSON 出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)