### PR TITLE
feat(auth): Service Account Access Key 認証に対応する

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -548,7 +548,9 @@ export async function showUsageIfNoSubCommand(ctx: {
   rawArgs: string[]
   cmd: CommandDef
 }): Promise<void> {
-  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
+  const subCommandNames = new Set(Object.keys(ctx.cmd.subCommands ?? {}))
+  const hasSubCommand = ctx.rawArgs.some((a) => subCommandNames.has(a))
+  if (!hasSubCommand) {
     await showUsage(ctx.cmd)
   }
 }

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -278,6 +278,26 @@ export function assertValidSid(sid: string): void {
   }
 }
 
+// Service Account Access Key は cs_ プレフィックスと 64桁小文字16進数から構成される
+const SA_KEY_PATTERN = /^cs_[0-9a-f]{64}$/
+
+/** ServiceAccountKeyValidationError は Service Account キーのフォーマット違反を表すエラー。 */
+export class ServiceAccountKeyValidationError extends Error {
+  constructor() {
+    super(
+      "Service Account キーのフォーマットが不正です。cs_ で始まる 67 文字 (cs_ + 64 桁小文字 16 進数) を指定してください",
+    )
+    this.name = "ServiceAccountKeyValidationError"
+  }
+}
+
+/** assertValidServiceAccountKey は Service Account キーのフォーマットを検証し、違反時は ServiceAccountKeyValidationError をスローする。 */
+export function assertValidServiceAccountKey(key: string): void {
+  if (!SA_KEY_PATTERN.test(key)) {
+    throw new ServiceAccountKeyValidationError()
+  }
+}
+
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
 export async function requireSid(profile?: string): Promise<string> {
   // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)
@@ -335,8 +355,42 @@ export function requireProject(args: CommonArgs): string {
   return project
 }
 
-/** buildRestClient は認証済み REST クライアントを生成する。 */
+/**
+ * buildRestClient は認証情報を解決して REST クライアントを生成する。
+ *
+ * 認証解決の優先順位:
+ * 1. COS_SERVICE_ACCOUNT_KEY 環境変数 (Service Account キー認証)
+ * 2. --project 指定時 + 設定ファイルの serviceAccounts に該当プロジェクトが存在 (Service Account キー認証)
+ * 3. SID 認証 (connect.sid Cookie)
+ */
 export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClient> {
+  // 1. 環境変数 COS_SERVICE_ACCOUNT_KEY を最優先チェック
+  const envKey = process.env["COS_SERVICE_ACCOUNT_KEY"]
+  if (envKey !== undefined) {
+    try {
+      assertValidServiceAccountKey(envKey)
+    } catch {
+      writeErrorJson(
+        "INVALID_SERVICE_ACCOUNT_KEY",
+        "COS_SERVICE_ACCOUNT_KEY のフォーマットが不正です",
+        "cs_ で始まる 67 文字のキーを指定してください",
+      )
+      exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
+    }
+    return new CosenseRestClient({ serviceAccountKey: envKey })
+  }
+
+  // 2. --project 指定時は設定ファイルから SA キーを検索
+  const project = args.project ?? process.env["COS_PROJECT"]
+  if (project) {
+    const config = loadConfig()
+    const saKey = config.serviceAccounts?.[project]
+    if (saKey !== undefined) {
+      return new CosenseRestClient({ serviceAccountKey: saKey })
+    }
+  }
+
+  // 3. SID 認証にフォールバック
   const sid = await requireSid(args.profile)
   return new CosenseRestClient({ sid })
 }

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -17,6 +17,8 @@ import { Logger } from "@/infra/logger"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
 import { writeErrorJson } from "@/presenter/json"
 import type { JsonOutputOptions } from "@/presenter/json"
+import type { CommandDef } from "citty"
+import { showUsage } from "citty"
 
 /**
  * exitWithError は指定コードでプロセスを終了する。
@@ -386,6 +388,16 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
     const config = loadConfig()
     const saKey = config.serviceAccounts?.[project]
     if (saKey !== undefined) {
+      try {
+        assertValidServiceAccountKey(saKey)
+      } catch {
+        writeErrorJson(
+          "INVALID_SERVICE_ACCOUNT_KEY",
+          `設定ファイルの ${project} の Service Account キーのフォーマットが不正です`,
+          "cs_ で始まる 67 文字のキーを指定してください",
+        )
+        exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
+      }
       return new CosenseRestClient({ serviceAccountKey: saKey })
     }
   }
@@ -528,6 +540,19 @@ export function runNotationLint(lines: string[], args: StrictNotationArg): strin
  * - NotFoundError → exit 4, code: NOT_FOUND
  * - その他 → 何もしない (呼び出し側で再スローする想定)
  */
+/**
+ * showUsageIfNoSubCommand はサブコマンドが指定されていない場合にのみ usage を表示する。
+ * citty はサブコマンド実行後も親コマンドの run を呼ぶため、rawArgs で判定する。
+ */
+export async function showUsageIfNoSubCommand(ctx: {
+  rawArgs: string[]
+  cmd: CommandDef
+}): Promise<void> {
+  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
+    await showUsage(ctx.cmd)
+  }
+}
+
 export function handleRestError(
   err: unknown,
   context: { resourceKind: "page" | "project" | "snapshot"; resourceName: string },

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -23,7 +23,15 @@ import { AuthError, CosenseRestClient, ForbiddenError } from "@/core/api/rest"
 import type { CoscliConfig } from "@/infra/config"
 import { defaultConfigPath, loadConfig, saveConfig } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
+import type { CommandDef } from "citty"
 import { defineCommand, showUsage } from "citty"
+
+/** showUsageIfNoSubCommand はサブコマンドが指定されていない場合にのみ usage を表示する。 */
+async function showUsageIfNoSubCommand(ctx: { rawArgs: string[]; cmd: CommandDef }) {
+  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
+    await showUsage(ctx.cmd)
+  }
+}
 
 /** AuthSaCommandDeps は createAuthSa* コマンドファクトリに注入できる依存。テスト専用。 */
 export interface AuthSaCommandDeps {
@@ -234,9 +242,7 @@ export function createAuthSaCommand(deps: AuthSaCommandDeps = {}) {
       list: createAuthSaListCommand(deps),
       ls: createAuthSaListCommand(deps),
     },
-    async run(ctx) {
-      await showUsage(ctx.cmd)
-    },
+    run: showUsageIfNoSubCommand,
   })
 }
 

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -23,7 +23,7 @@ import { AuthError, CosenseRestClient, ForbiddenError } from "@/core/api/rest"
 import type { CoscliConfig } from "@/infra/config"
 import { defaultConfigPath, loadConfig, saveConfig } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
-import { defineCommand } from "citty"
+import { defineCommand, showUsage } from "citty"
 
 /** AuthSaCommandDeps は createAuthSa* コマンドファクトリに注入できる依存。テスト専用。 */
 export interface AuthSaCommandDeps {
@@ -233,6 +233,9 @@ export function createAuthSaCommand(deps: AuthSaCommandDeps = {}) {
       rm: createAuthSaDeleteCommand(deps),
       list: createAuthSaListCommand(deps),
       ls: createAuthSaListCommand(deps),
+    },
+    async run(ctx) {
+      await showUsage(ctx.cmd)
     },
   })
 }

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -1,0 +1,241 @@
+/**
+ * auth/service-account.ts — `cos auth sa` サブコマンドグループ。
+ *
+ * Cosense Business Plan の Service Account Access Key を管理する。
+ * キーは設定ファイル (serviceAccounts フィールド) に保存する。
+ *
+ * サブコマンド:
+ *   add    --project <name> --key <key>  キーを登録して API 検証する
+ *   delete --project <name>              登録済みキーを削除する
+ *   list                                 登録済みプロジェクト一覧を表示する
+ */
+
+import {
+  type CommonArgs,
+  ServiceAccountKeyValidationError,
+  assertValidServiceAccountKey,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+} from "@/commands/_shared"
+import { AuthError, CosenseRestClient, ForbiddenError } from "@/core/api/rest"
+import type { CoscliConfig } from "@/infra/config"
+import { defaultConfigPath, loadConfig, saveConfig } from "@/infra/config"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** AuthSaCommandDeps は createAuthSa* コマンドファクトリに注入できる依存。テスト専用。 */
+export interface AuthSaCommandDeps {
+  /**
+   * configPath は設定ファイルパスの上書き。
+   * テスト時は一時ファイルパスを渡して実設定ファイルを汚染しないようにする。
+   */
+  configPath?: string
+}
+
+/**
+ * createAuthSaAddCommand は auth sa add コマンド定義を返すファクトリ。
+ * deps を省略した場合は本番実装を使用する。
+ */
+export function createAuthSaAddCommand(deps: AuthSaCommandDeps = {}) {
+  const getConfigPath = () => deps.configPath ?? defaultConfigPath()
+
+  return defineCommand({
+    meta: { name: "add", description: "Service Account キーを登録する" },
+    args: {
+      ...commonArgs,
+      key: {
+        type: "string",
+        description: "Service Account Access Key (cs_ で始まる 67 文字)",
+      },
+    },
+    async run({ args }) {
+      type SaAddArgs = CommonArgs & { key?: string }
+      const a = args as SaAddArgs
+      checkSandbox("auth.sa.add", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      const project = a.project ?? process.env["COS_PROJECT"]
+      if (!project) {
+        writeErrorJson(
+          "PROJECT_REQUIRED",
+          "プロジェクト名が指定されていません",
+          "--project (-p) フラグか COS_PROJECT 環境変数でプロジェクトを指定してください",
+        )
+        process.exit(5)
+        return
+      }
+
+      if (!a.key) {
+        writeErrorJson(
+          "KEY_REQUIRED",
+          "Service Account キーが指定されていません",
+          "--key フラグで cs_ で始まる 67 文字のキーを指定してください",
+        )
+        process.exit(5)
+        return
+      }
+
+      // キー形式を検証する
+      try {
+        assertValidServiceAccountKey(a.key)
+      } catch (err) {
+        if (err instanceof ServiceAccountKeyValidationError) {
+          writeErrorJson("INVALID_SERVICE_ACCOUNT_KEY", err.message)
+          process.exit(5)
+          return
+        }
+        throw err
+      }
+
+      // API を呼び出してキーの有効性を確認する (pages API で検証)
+      logger.info(`${project} の Service Account キーを確認中...`)
+      const client = new CosenseRestClient({ serviceAccountKey: a.key })
+      try {
+        await client.listPages(project, { limit: 1 })
+      } catch (err) {
+        if (err instanceof AuthError) {
+          writeErrorJson(
+            "AUTH_ERROR",
+            "Service Account キーが無効です。キーとプロジェクト名を確認してください",
+          )
+          process.exit(2)
+          return
+        }
+        if (err instanceof ForbiddenError) {
+          writeErrorJson(
+            "FORBIDDEN",
+            "このプロジェクトへのアクセス権限がありません",
+            "プロジェクト名と Service Account キーを確認してください",
+          )
+          process.exit(3)
+          return
+        }
+        throw err
+      }
+
+      // 設定ファイルに保存する
+      const configPath = getConfigPath()
+      const config = loadConfig(configPath)
+      const updated: CoscliConfig = {
+        ...config,
+        serviceAccounts: {
+          ...config.serviceAccounts,
+          [project]: a.key,
+        },
+      }
+      saveConfig(updated, configPath)
+
+      logger.success(`${project} の Service Account キーを登録しました`)
+
+      if (a.json) {
+        writeJson({ project }, { command: "auth.sa.add", startTime }, buildJsonOpts(a))
+      }
+    },
+  })
+}
+
+/**
+ * createAuthSaDeleteCommand は auth sa delete コマンド定義を返すファクトリ。
+ * deps を省略した場合は本番実装を使用する。
+ */
+export function createAuthSaDeleteCommand(deps: AuthSaCommandDeps = {}) {
+  const getConfigPath = () => deps.configPath ?? defaultConfigPath()
+
+  return defineCommand({
+    meta: { name: "delete", description: "登録済み Service Account キーを削除する" },
+    args: {
+      ...commonArgs,
+    },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.sa.delete", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      const project = a.project ?? process.env["COS_PROJECT"]
+      if (!project) {
+        writeErrorJson(
+          "PROJECT_REQUIRED",
+          "プロジェクト名が指定されていません",
+          "--project (-p) フラグか COS_PROJECT 環境変数でプロジェクトを指定してください",
+        )
+        process.exit(5)
+        return
+      }
+
+      const configPath = getConfigPath()
+      const config = loadConfig(configPath)
+      // 該当プロジェクトのキーを削除して保存する
+      const accounts = { ...config.serviceAccounts }
+      delete accounts[project]
+      const updated: CoscliConfig = { ...config, serviceAccounts: accounts }
+      saveConfig(updated, configPath)
+
+      logger.success(`${project} の Service Account キーを削除しました`)
+
+      if (a.json) {
+        writeJson({ project }, { command: "auth.sa.delete", startTime }, buildJsonOpts(a))
+      }
+    },
+  })
+}
+
+/**
+ * createAuthSaListCommand は auth sa list コマンド定義を返すファクトリ。
+ * deps を省略した場合は本番実装を使用する。
+ */
+export function createAuthSaListCommand(deps: AuthSaCommandDeps = {}) {
+  const getConfigPath = () => deps.configPath ?? defaultConfigPath()
+
+  return defineCommand({
+    meta: { name: "list", description: "登録済み Service Account プロジェクト一覧を表示する" },
+    args: {
+      ...commonArgs,
+    },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.sa.list", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      const configPath = getConfigPath()
+      const config = loadConfig(configPath)
+      const projects = Object.keys(config.serviceAccounts ?? {})
+
+      if (a.json) {
+        writeJson({ projects }, { command: "auth.sa.list", startTime }, buildJsonOpts(a))
+      } else {
+        if (projects.length === 0) {
+          logger.info("登録済みの Service Account キーはありません")
+        } else {
+          for (const project of projects) {
+            process.stdout.write(`${project}\n`)
+          }
+        }
+      }
+    },
+  })
+}
+
+/**
+ * createAuthSaCommand は auth sa コマンドグループ定義を返すファクトリ。
+ * deps を省略した場合は本番実装を使用する。
+ */
+export function createAuthSaCommand(deps: AuthSaCommandDeps = {}) {
+  return defineCommand({
+    meta: { name: "sa", description: "Service Account キー管理コマンド" },
+    subCommands: {
+      add: createAuthSaAddCommand(deps),
+      delete: createAuthSaDeleteCommand(deps),
+      rm: createAuthSaDeleteCommand(deps),
+      list: createAuthSaListCommand(deps),
+      ls: createAuthSaListCommand(deps),
+    },
+  })
+}
+
+/** authSaCommand はデフォルト実装を使った auth sa コマンド定義。 */
+export const authSaCommand = createAuthSaCommand()

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -35,10 +35,7 @@ export interface AuthSaCommandDeps {
   configPath?: string
 }
 
-/**
- * createAuthSaAddCommand は auth sa add コマンド定義を返すファクトリ。
- * deps を省略した場合は本番実装を使用する。
- */
+/** createAuthSaAddCommand は auth sa add コマンド定義を返すファクトリ。deps を省略した場合は本番実装を使用する。 */
 export function createAuthSaAddCommand(deps: AuthSaCommandDeps = {}) {
   const getConfigPath = () => deps.configPath ?? defaultConfigPath()
 
@@ -138,10 +135,7 @@ export function createAuthSaAddCommand(deps: AuthSaCommandDeps = {}) {
   })
 }
 
-/**
- * createAuthSaDeleteCommand は auth sa delete コマンド定義を返すファクトリ。
- * deps を省略した場合は本番実装を使用する。
- */
+/** createAuthSaDeleteCommand は auth sa delete コマンド定義を返すファクトリ。deps を省略した場合は本番実装を使用する。 */
 export function createAuthSaDeleteCommand(deps: AuthSaCommandDeps = {}) {
   const getConfigPath = () => deps.configPath ?? defaultConfigPath()
 
@@ -184,10 +178,7 @@ export function createAuthSaDeleteCommand(deps: AuthSaCommandDeps = {}) {
   })
 }
 
-/**
- * createAuthSaListCommand は auth sa list コマンド定義を返すファクトリ。
- * deps を省略した場合は本番実装を使用する。
- */
+/** createAuthSaListCommand は auth sa list コマンド定義を返すファクトリ。deps を省略した場合は本番実装を使用する。 */
 export function createAuthSaListCommand(deps: AuthSaCommandDeps = {}) {
   const getConfigPath = () => deps.configPath ?? defaultConfigPath()
 
@@ -221,10 +212,7 @@ export function createAuthSaListCommand(deps: AuthSaCommandDeps = {}) {
   })
 }
 
-/**
- * createAuthSaCommand は auth sa コマンドグループ定義を返すファクトリ。
- * deps を省略した場合は本番実装を使用する。
- */
+/** createAuthSaCommand は auth sa コマンドグループ定義を返すファクトリ。deps を省略した場合は本番実装を使用する。 */
 export function createAuthSaCommand(deps: AuthSaCommandDeps = {}) {
   return defineCommand({
     meta: { name: "sa", description: "Service Account キー管理コマンド" },

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -18,20 +18,13 @@ import {
   buildLogger,
   checkSandbox,
   commonArgs,
+  showUsageIfNoSubCommand,
 } from "@/commands/_shared"
 import { AuthError, CosenseRestClient, ForbiddenError } from "@/core/api/rest"
 import type { CoscliConfig } from "@/infra/config"
 import { defaultConfigPath, loadConfig, saveConfig } from "@/infra/config"
 import { writeErrorJson, writeJson } from "@/presenter/json"
-import type { CommandDef } from "citty"
-import { defineCommand, showUsage } from "citty"
-
-/** showUsageIfNoSubCommand はサブコマンドが指定されていない場合にのみ usage を表示する。 */
-async function showUsageIfNoSubCommand(ctx: { rawArgs: string[]; cmd: CommandDef }) {
-  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
-    await showUsage(ctx.cmd)
-  }
-}
+import { defineCommand } from "citty"
 
 /** AuthSaCommandDeps は createAuthSa* コマンドファクトリに注入できる依存。テスト専用。 */
 export interface AuthSaCommandDeps {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -45,6 +45,7 @@ import { searchCommand } from "@/commands/search"
 // 認証コマンド
 import { authLoginCommand } from "@/commands/auth/login"
 import { authLogoutCommand } from "@/commands/auth/logout"
+import { authSaCommand } from "@/commands/auth/service-account"
 import { authWhoamiCommand } from "@/commands/auth/whoami"
 
 // 設定コマンド
@@ -145,6 +146,8 @@ export const authCommand = defineCommand({
     logout: authLogoutCommand,
     whoami: authWhoamiCommand,
     me: authWhoamiCommand,
+    sa: authSaCommand,
+    "service-account": authSaCommand,
   },
 })
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -69,15 +69,8 @@ import { exitCodesCommand } from "@/commands/exit-codes"
 import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
-import type { CommandDef } from "citty"
-import { defineCommand, showUsage } from "citty"
-
-/** showUsageIfNoSubCommand はサブコマンドが指定されていない場合にのみ usage を表示する。 */
-async function showUsageIfNoSubCommand(ctx: { rawArgs: string[]; cmd: CommandDef }) {
-  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
-    await showUsage(ctx.cmd)
-  }
-}
+import { showUsageIfNoSubCommand } from "@/commands/_shared"
+import { defineCommand } from "citty"
 
 /** page line サブコマンドグループ */
 export const pageLineCommand = defineCommand({

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -69,7 +69,15 @@ import { exitCodesCommand } from "@/commands/exit-codes"
 import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
+import type { CommandDef } from "citty"
 import { defineCommand, showUsage } from "citty"
+
+/** showUsageIfNoSubCommand はサブコマンドが指定されていない場合にのみ usage を表示する。 */
+async function showUsageIfNoSubCommand(ctx: { rawArgs: string[]; cmd: CommandDef }) {
+  if (!ctx.rawArgs.some((a) => !a.startsWith("-"))) {
+    await showUsage(ctx.cmd)
+  }
+}
 
 /** page line サブコマンドグループ */
 export const pageLineCommand = defineCommand({
@@ -80,9 +88,7 @@ export const pageLineCommand = defineCommand({
     rm: pageLineDeleteCommand,
     get: pageLineGetCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** page snapshot サブコマンドグループ */
@@ -93,9 +99,7 @@ export const pageSnapshotCommand = defineCommand({
     ls: pageSnapshotListCommand,
     get: pageSnapshotGetCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** page サブコマンドグループ */
@@ -129,9 +133,7 @@ export const pageCommand = defineCommand({
     context: pageContextCommand,
     line: pageLineCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** project サブコマンドグループ */
@@ -145,9 +147,7 @@ export const projectCommand = defineCommand({
     stream: projectStreamCommand,
     search: projectSearchCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** auth サブコマンドグループ */
@@ -161,9 +161,7 @@ export const authCommand = defineCommand({
     sa: authSaCommand,
     "service-account": authSaCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** config サブコマンドグループ */
@@ -174,9 +172,7 @@ export const configCommand = defineCommand({
     set: configSetCommand,
     path: configPathCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** sync サブコマンドグループ */
@@ -187,9 +183,7 @@ export const syncCommand = defineCommand({
     push: syncPushCommand,
     diff: syncDiffCommand,
   },
-  async run(ctx) {
-    await showUsage(ctx.cmd)
-  },
+  run: showUsageIfNoSubCommand,
 })
 
 /** rootSubCommands はトップレベルサブコマンドのレジストリ。 */

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -69,7 +69,7 @@ import { exitCodesCommand } from "@/commands/exit-codes"
 import { notationGuideCommand } from "@/commands/notation/guide"
 import { schemaCommand } from "@/commands/schema"
 
-import { defineCommand } from "citty"
+import { defineCommand, showUsage } from "citty"
 
 /** page line サブコマンドグループ */
 export const pageLineCommand = defineCommand({
@@ -80,6 +80,9 @@ export const pageLineCommand = defineCommand({
     rm: pageLineDeleteCommand,
     get: pageLineGetCommand,
   },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
+  },
 })
 
 /** page snapshot サブコマンドグループ */
@@ -89,6 +92,9 @@ export const pageSnapshotCommand = defineCommand({
     list: pageSnapshotListCommand,
     ls: pageSnapshotListCommand,
     get: pageSnapshotGetCommand,
+  },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
   },
 })
 
@@ -123,6 +129,9 @@ export const pageCommand = defineCommand({
     context: pageContextCommand,
     line: pageLineCommand,
   },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
+  },
 })
 
 /** project サブコマンドグループ */
@@ -135,6 +144,9 @@ export const projectCommand = defineCommand({
     graph: projectGraphCommand,
     stream: projectStreamCommand,
     search: projectSearchCommand,
+  },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
   },
 })
 
@@ -149,6 +161,9 @@ export const authCommand = defineCommand({
     sa: authSaCommand,
     "service-account": authSaCommand,
   },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
+  },
 })
 
 /** config サブコマンドグループ */
@@ -159,6 +174,9 @@ export const configCommand = defineCommand({
     set: configSetCommand,
     path: configPathCommand,
   },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
+  },
 })
 
 /** sync サブコマンドグループ */
@@ -168,6 +186,9 @@ export const syncCommand = defineCommand({
     pull: syncPullCommand,
     push: syncPushCommand,
     diff: syncDiffCommand,
+  },
+  async run(ctx) {
+    await showUsage(ctx.cmd)
   },
 })
 

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -95,6 +95,9 @@ export class CosenseRestClient {
     if (opts.sid === undefined && opts.serviceAccountKey === undefined) {
       throw new Error("sid または serviceAccountKey のいずれかが必要です")
     }
+    if (opts.sid !== undefined && opts.serviceAccountKey !== undefined) {
+      throw new Error("sid と serviceAccountKey は同時に指定できません")
+    }
     this.sid = opts.sid
     this.serviceAccountKey = opts.serviceAccountKey
     this.timeout = opts.timeout ?? 30_000

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -75,21 +75,28 @@ export class RateLimitError extends CosenseApiError {
   }
 }
 
-/** CosenseRestClientOptions は REST クライアントの設定オプション。 */
+/** CosenseRestClientOptions は REST クライアントの設定オプション。sid と serviceAccountKey は排他。 */
 export interface CosenseRestClientOptions {
-  /** connect.sid 値 (URLエンコード済みまたは生の値) */
-  sid: string
+  /** connect.sid 値 (Cookie ヘッダ認証)。serviceAccountKey と排他。 */
+  sid?: string
+  /** Service Account Access Key (x-service-account-access-key ヘッダ認証)。sid と排他。 */
+  serviceAccountKey?: string
   /** リクエストタイムアウト (ミリ秒、デフォルト 30000) */
   timeout?: number
 }
 
 /** CosenseRestClient は Cosense REST API を叩くクライアント。 */
 export class CosenseRestClient {
-  private readonly sid: string
+  private readonly sid: string | undefined
+  private readonly serviceAccountKey: string | undefined
   private readonly timeout: number
 
   constructor(opts: CosenseRestClientOptions) {
+    if (opts.sid === undefined && opts.serviceAccountKey === undefined) {
+      throw new Error("sid または serviceAccountKey のいずれかが必要です")
+    }
     this.sid = opts.sid
+    this.serviceAccountKey = opts.serviceAccountKey
     this.timeout = opts.timeout ?? 30_000
   }
 
@@ -270,7 +277,9 @@ export class CosenseRestClient {
     const headers: Record<string, string> = {
       Accept: "application/json",
     }
-    if (this.sid) {
+    if (this.serviceAccountKey) {
+      headers["x-service-account-access-key"] = this.serviceAccountKey
+    } else if (this.sid) {
       headers["Cookie"] = `connect.sid=${this.sid}`
     }
     return headers

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -55,6 +55,11 @@ export const CoscliConfigSchema = z.object({
   defaultProject: z.string().optional(),
   defaultProfile: z.string().optional(),
   /**
+   * プロジェクト名をキー、Service Account Access Key を値とするマップ。
+   * `cos auth sa add` で登録し `buildRestClient` が自動参照する。
+   */
+  serviceAccounts: z.record(z.string(), z.string()).optional(),
+  /**
    * projects に未列挙のプロジェクトへの既定権限プリセット。
    * プロジェクト指定時のみ適用される (プロジェクト未指定コマンドには無効)。
    * 未設定: 全コマンド許可 (後方互換)。

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -8,7 +8,9 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test"
 import {
   type CommonArgs,
+  ServiceAccountKeyValidationError,
   SidValidationError,
+  assertValidServiceAccountKey,
   assertValidSid,
   buildJsonOpts,
   buildLogger,
@@ -221,6 +223,56 @@ describe("assertValidSid / SidValidationError", () => {
     expect(err).toBeInstanceOf(Error)
     expect(err.name).toBe("SidValidationError")
     expect(err.message).toContain("SID")
+  })
+})
+
+describe("assertValidServiceAccountKey / ServiceAccountKeyValidationError", () => {
+  // cs_ + 64桁16進数の有効なキー
+  const VALID_SA_KEY = "cs_0000000000000000000000000000000000000000000000000000000000000001"
+
+  it("正常な Service Account キーは検証を通過する", () => {
+    expect(() => assertValidServiceAccountKey(VALID_SA_KEY)).not.toThrow()
+  })
+
+  it("実際の形式 (cs_ + 64桁小文字16進数) のキーは検証を通過する", () => {
+    const key = "cs_8487a04cdd0be210bb369e76dc8ccfdba0c994c17ad37dd39a7bf3d05cd6046e"
+    expect(() => assertValidServiceAccountKey(key)).not.toThrow()
+  })
+
+  it("空文字列は ServiceAccountKeyValidationError をスローする", () => {
+    expect(() => assertValidServiceAccountKey("")).toThrow(ServiceAccountKeyValidationError)
+  })
+
+  it("cs_ プレフィックスがない場合は ServiceAccountKeyValidationError をスローする", () => {
+    const keyWithoutPrefix = "0000000000000000000000000000000000000000000000000000000000000001"
+    expect(() => assertValidServiceAccountKey(keyWithoutPrefix)).toThrow(
+      ServiceAccountKeyValidationError,
+    )
+  })
+
+  it("64桁より短い16進数は ServiceAccountKeyValidationError をスローする", () => {
+    const shortKey = "cs_000000000000000000000000000000000000000000000000000000000000001"
+    expect(() => assertValidServiceAccountKey(shortKey)).toThrow(ServiceAccountKeyValidationError)
+  })
+
+  it("64桁より長い16進数は ServiceAccountKeyValidationError をスローする", () => {
+    const longKey = "cs_00000000000000000000000000000000000000000000000000000000000000001"
+    expect(() => assertValidServiceAccountKey(longKey)).toThrow(ServiceAccountKeyValidationError)
+  })
+
+  it("大文字16進数を含む場合は ServiceAccountKeyValidationError をスローする", () => {
+    const upperKey = "cs_0000000000000000000000000000000000000000000000000000000000000001".replace(
+      "0001",
+      "000A",
+    )
+    expect(() => assertValidServiceAccountKey(upperKey)).toThrow(ServiceAccountKeyValidationError)
+  })
+
+  it("ServiceAccountKeyValidationError は Error を継承し分かりやすいメッセージを持つ", () => {
+    const err = new ServiceAccountKeyValidationError()
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe("ServiceAccountKeyValidationError")
+    expect(err.message).toContain("cs_")
   })
 })
 

--- a/tests/unit/commands/auth/service-account.test.ts
+++ b/tests/unit/commands/auth/service-account.test.ts
@@ -1,0 +1,312 @@
+/**
+ * service-account.test.ts — `cos auth sa` コマンドのユニットテスト。
+ *
+ * 設定ファイル操作は一時ディレクトリの config.json5 で代替し、
+ * API は msw でモックする。add / delete / list サブコマンドの動作を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  createAuthSaAddCommand,
+  createAuthSaDeleteCommand,
+  createAuthSaListCommand,
+} from "@/commands/auth/service-account"
+import { loadConfig } from "@/infra/config"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+// ---------------------------------------------------------------------------
+// MSW サーバーセットアップ
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://scrapbox.io"
+// テスト用 Service Account キー (cs_ + 64桁16進数)
+const TEST_SA_KEY = "cs_0000000000000000000000000000000000000000000000000000000000000001"
+const TEST_PROJECT = "テスト事業プロジェクト"
+
+const server = setupServer(
+  http.get(`${BASE_URL}/api/pages/${encodeURIComponent(TEST_PROJECT)}`, ({ request }) => {
+    const saKey = request.headers.get("x-service-account-access-key")
+    if (saKey === TEST_SA_KEY) {
+      return HttpResponse.json({
+        projectName: TEST_PROJECT,
+        skip: 0,
+        limit: 1,
+        count: 10,
+        pages: [],
+      })
+    }
+    return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+afterEach(() => server.resetHandlers())
+
+// ---------------------------------------------------------------------------
+// 一時設定ファイル管理
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+let configPath: string
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `coscli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(tmpDir, { recursive: true })
+  configPath = join(tmpDir, "config.json5")
+  // 空の設定ファイルを作成する
+  writeFileSync(configPath, "{}")
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+type RunFn = (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+
+/** auth sa add を実行するヘルパー。 */
+async function runSaAdd(args: Record<string, unknown>) {
+  const cmd = createAuthSaAddCommand({ configPath })
+  if (typeof cmd.run !== "function") throw new Error("auth sa add コマンドが見つかりません")
+  await (cmd.run as RunFn)({ args, cmd: {} as never, rawArgs: [] })
+}
+
+/** auth sa delete を実行するヘルパー。 */
+async function runSaDelete(args: Record<string, unknown>) {
+  const cmd = createAuthSaDeleteCommand({ configPath })
+  if (typeof cmd.run !== "function") throw new Error("auth sa delete コマンドが見つかりません")
+  await (cmd.run as RunFn)({ args, cmd: {} as never, rawArgs: [] })
+}
+
+/** auth sa list を実行するヘルパー。 */
+async function runSaList(args: Record<string, unknown>) {
+  const cmd = createAuthSaListCommand({ configPath })
+  if (typeof cmd.run !== "function") throw new Error("auth sa list コマンドが見つかりません")
+  await (cmd.run as RunFn)({ args, cmd: {} as never, rawArgs: [] })
+}
+
+/** 一時設定ファイルからロードした serviceAccounts を返すヘルパー。 */
+function getStoredAccounts(): Record<string, string> {
+  return loadConfig(configPath).serviceAccounts ?? {}
+}
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** stdout への書き込みをキャプチャして JSON として返すヘルパー。 */
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => {
+    const raw = chunks.join("")
+    if (!raw.trim()) return {}
+    return JSON.parse(raw)
+  }
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock?.mockRestore()
+})
+
+// ---------------------------------------------------------------------------
+// auth sa add テスト
+// ---------------------------------------------------------------------------
+
+describe("auth sa add", () => {
+  it("有効なキーとプロジェクトを指定すると設定ファイルに保存される", async () => {
+    await runSaAdd({
+      project: TEST_PROJECT,
+      key: TEST_SA_KEY,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(getStoredAccounts()[TEST_PROJECT]).toBe(TEST_SA_KEY)
+  })
+
+  it("保存後に --json を指定すると project が JSON 出力に含まれる", async () => {
+    const getJson = captureJsonOutput()
+
+    await runSaAdd({
+      project: TEST_PROJECT,
+      key: TEST_SA_KEY,
+      json: true,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    const output = getJson() as { data?: { project: string } }
+    expect(output.data?.project).toBe(TEST_PROJECT)
+  })
+
+  it("不正なキー形式 (cs_ プレフィックスなし) は exit 5 で終了する", async () => {
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    const invalidKey = "invalid_key_without_cs_prefix"
+
+    await runSaAdd({
+      project: TEST_PROJECT,
+      key: invalidKey,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(exitMock).toHaveBeenCalledWith(5)
+    // 不正なキーは設定ファイルに保存されないこと
+    expect(getStoredAccounts()[TEST_PROJECT]).toBeUndefined()
+  })
+
+  it("プロジェクト名未指定は exit 5 で終了する", async () => {
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+
+    await runSaAdd({
+      key: TEST_SA_KEY,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("キー未指定は exit 5 で終了する", async () => {
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+
+    await runSaAdd({
+      project: TEST_PROJECT,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("API 認証が失敗した場合 (401) は保存せずに exit 2 で終了する", async () => {
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    const wrongKey = "cs_ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+    await runSaAdd({
+      project: TEST_PROJECT,
+      key: wrongKey,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    // 不正なキーは保存されないこと
+    expect(getStoredAccounts()[TEST_PROJECT]).toBeUndefined()
+    expect(exitMock).toHaveBeenCalledWith(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth sa delete テスト
+// ---------------------------------------------------------------------------
+
+describe("auth sa delete", () => {
+  it("保存済みキーを削除できる", async () => {
+    // 事前に保存しておく
+    writeFileSync(configPath, JSON.stringify({ serviceAccounts: { [TEST_PROJECT]: TEST_SA_KEY } }))
+
+    await runSaDelete({
+      project: TEST_PROJECT,
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(getStoredAccounts()[TEST_PROJECT]).toBeUndefined()
+  })
+
+  it("存在しないプロジェクトを削除しようとしても正常終了する", async () => {
+    await runSaDelete({
+      project: "存在しないプロジェクト",
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(exitMock).not.toHaveBeenCalledWith(1)
+  })
+
+  it("プロジェクト名未指定は exit 5 で終了する", async () => {
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+
+    await runSaDelete({
+      json: false,
+      quiet: false,
+      plain: false,
+      "results-only": false,
+    })
+
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth sa list テスト
+// ---------------------------------------------------------------------------
+
+describe("auth sa list", () => {
+  it("保存済みの SA プロジェクト一覧を返す", async () => {
+    const getJson = captureJsonOutput()
+    // 複数プロジェクトを事前に設定する
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        serviceAccounts: {
+          プロジェクトA: TEST_SA_KEY,
+          プロジェクトB: TEST_SA_KEY,
+        },
+      }),
+    )
+
+    await runSaList({ json: true, quiet: false, plain: false, "results-only": false })
+
+    const output = getJson() as { data?: { projects: string[] } }
+    expect(output.data?.projects).toContain("プロジェクトA")
+    expect(output.data?.projects).toContain("プロジェクトB")
+  })
+
+  it("SA キーが 1 件も登録されていない場合は空配列を返す", async () => {
+    const getJson = captureJsonOutput()
+
+    await runSaList({ json: true, quiet: false, plain: false, "results-only": false })
+
+    const output = getJson() as { data?: { projects: string[] } }
+    expect(output.data?.projects).toEqual([])
+  })
+})

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -4,7 +4,7 @@
  * msw でモックサーバーを立て、REST クライアントの動作を検証する。
  */
 
-import { describe, expect, it } from "bun:test"
+import { beforeEach, describe, expect, it } from "bun:test"
 import { CosenseApiError, CosenseRestClient, NotFoundError } from "@/core/api/rest"
 import { http, HttpResponse } from "msw"
 import { useMswServer } from "../../../helpers/msw"
@@ -457,6 +457,56 @@ describe("CosenseRestClient", () => {
       await expect(
         client.getSnapshot(TEST_PROJECT, "page-id-hello", "1700000000-snap2"),
       ).rejects.toThrow()
+    })
+  })
+
+  describe("Service Account 認証", () => {
+    // テスト用 SA キー (cs_ + 64桁16進数)
+    const TEST_SA_KEY = "cs_0000000000000000000000000000000000000000000000000000000000000001"
+    const SA_PROJECT = "sa-test-project"
+
+    beforeEach(() => {
+      // SA キー認証専用ハンドラーを追加する (afterEach でリセットされるため毎回登録する)
+      server.use(
+        http.get(`${BASE_URL}/api/pages/${encodeURIComponent(SA_PROJECT)}`, ({ request }) => {
+          const saKey = request.headers.get("x-service-account-access-key")
+          if (saKey !== TEST_SA_KEY) {
+            return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+          }
+          return HttpResponse.json({ ...pageListFixture, projectName: SA_PROJECT })
+        }),
+      )
+    })
+
+    it("serviceAccountKey を指定すると x-service-account-access-key ヘッダが送信され Cookie は送信されない", async () => {
+      // ハンドラー内でヘッダー内容を検証し、正しければ saKeyCorrect / noCookie を true にする
+      let saKeyCorrect = false
+      let noCookie = false
+
+      server.use(
+        http.get(`${BASE_URL}/api/pages/sa-header-check`, ({ request }) => {
+          saKeyCorrect = request.headers.get("x-service-account-access-key") === TEST_SA_KEY
+          noCookie = request.headers.get("Cookie") === null
+          return HttpResponse.json({ ...pageListFixture, projectName: "sa-header-check" })
+        }),
+      )
+
+      const client = new CosenseRestClient({ serviceAccountKey: TEST_SA_KEY })
+      await client.listPages("sa-header-check")
+
+      expect(saKeyCorrect).toBe(true)
+      // SA キー認証時は Cookie ヘッダを送信しないこと
+      expect(noCookie).toBe(true)
+    })
+
+    it("serviceAccountKey で認証するとページ一覧を取得できる", async () => {
+      const client = new CosenseRestClient({ serviceAccountKey: TEST_SA_KEY })
+      const result = await client.listPages(SA_PROJECT)
+      expect(result.pages).toHaveLength(2)
+    })
+
+    it("sid と serviceAccountKey の両方を省略するとエラーをスローする", () => {
+      expect(() => new CosenseRestClient({})).toThrow()
     })
   })
 })


### PR DESCRIPTION
## Summary

- `CosenseRestClient` に `serviceAccountKey` オプションを追加し、`x-service-account-access-key` ヘッダによる API 認証に対応する
- `buildRestClient()` の認証解決順序を **COS_SERVICE_ACCOUNT_KEY 環境変数 → config の serviceAccounts → SID Cookie** に変更する
- `cos auth sa add/delete/list` コマンドで SA キーを `~/.config/coscli/config.json5` の `serviceAccounts` フィールドに管理できるようにする
- `assertValidServiceAccountKey()` / `ServiceAccountKeyValidationError` で `cs_` + 64桁16進数のキー形式を検証する
- サブコマンド未指定時にヘルプを表示するよう全コマンドグループを修正する（`showUsageIfNoSubCommand` を `_shared.ts` に集約）

## 変更ファイル

| ファイル | 変更種別 |
|---------|---------|
| `src/core/api/rest.ts` | `serviceAccountKey` オプション追加、`buildHeaders()` 更新 |
| `src/commands/_shared.ts` | SA キー検証関数追加、`buildRestClient()` 認証フロー更新、`showUsageIfNoSubCommand` 追加 |
| `src/commands/auth/service-account.ts` | 新規: `cos auth sa` コマンドグループ |
| `src/commands/index.ts` | `authSaCommand` 登録、全コマンドグループに `showUsageIfNoSubCommand` 適用 |
| `src/infra/config.ts` | `serviceAccounts: Record<string, string>` フィールド追加 |

## Test plan

- [x] `bun test` — 1292 テスト全件パス
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — lint 警告なし
- [x] 手動検証: `cos auth sa add/list` → SA キー登録・一覧確認
- [x] 手動検証: `cos page list -p mtane0412-test-business` → SA キーで API アクセス成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Service Account キー認証を追加（Service Account キー優先で認証を選択）
  * Service Account キーの登録/削除/一覧表示コマンドを追加
  * 設定ファイルにプロジェクト別の Service Account キー保存を追加
  * サブコマンド未指定時のみ使用法を表示する共通動作を追加

* **改善**
  * Service Account キー形式の検証と関連エラーを追加

* **テスト**
  * 追加機能に対する単体テスト群を追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->