### PR TITLE
feat(page): LLM生成infoboxデータを取得する cos page infobox コマンドを追加する

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import { pageEditCommand } from "@/commands/page/edit"
 import { pageGetCommand } from "@/commands/page/get"
 import { pageHistoryCommand } from "@/commands/page/history"
 import { pageIconCommand } from "@/commands/page/icon"
+import { pageInfoboxCommand } from "@/commands/page/infobox"
 import { pageInsertCommand } from "@/commands/page/insert"
 import { pageLineDeleteCommand } from "@/commands/page/line/delete"
 import { pageLineGetCommand } from "@/commands/page/line/get"
@@ -124,6 +125,7 @@ export const pageCommand = defineCommand({
     rm: pageDeleteCommand,
     watch: pageWatchCommand,
     context: pageContextCommand,
+    infobox: pageInfoboxCommand,
     line: pageLineCommand,
   },
   run: showUsageIfNoSubCommand,

--- a/src/commands/page/infobox.ts
+++ b/src/commands/page/infobox.ts
@@ -1,0 +1,96 @@
+/**
+ * page/infobox.ts — `cos page infobox <title>` コマンド。
+ *
+ * 指定したページの LLM 生成 infobox データ (infoboxResult) を取得して出力する。
+ * --no-hallucination フラグで hallucination: true のアイテムを除外できる。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  requireProject,
+} from "@/commands/_shared"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import { getPage } from "@/core/pages"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import type { InfoboxResultItem } from "@/schemas/page"
+import { defineCommand } from "citty"
+
+export const pageInfoboxCommand = defineCommand({
+  meta: { name: "infobox", description: "LLM 生成 infobox データを取得する" },
+  args: {
+    ...commonArgs,
+    title: {
+      type: "positional",
+      description: "ページタイトル",
+      required: true,
+    },
+    "no-hallucination": {
+      type: "boolean",
+      description: "hallucination: true のアイテムを除外する",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { title: string; "no-hallucination": boolean }
+    checkSandbox("page.infobox", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    logger.info(`"${a.title}" の infobox を取得中...`)
+
+    try {
+      const client = await buildRestClient(a)
+      const page = await getPage(client, { project, title: a.title })
+
+      let items: InfoboxResultItem[] = page.infoboxResult ?? []
+      if (a["no-hallucination"]) {
+        items = items.filter((item) => !item.hallucination)
+      }
+
+      if (a.json || !a.plain) {
+        writeJson(
+          { infoboxResult: items },
+          { command: "page.infobox", startTime },
+          buildJsonOpts(a),
+        )
+        return
+      }
+
+      // プレーンテキスト: タイトル + Key-Value 形式で出力
+      for (const item of items) {
+        process.stdout.write(`=== ${item.title} ===\n`)
+        for (const [key, value] of Object.entries(item.infobox)) {
+          process.stdout.write(`  ${key}: ${value}\n`)
+        }
+        process.stdout.write("\n")
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        writeErrorJson("AUTH_ERROR", err.message, "`cos auth login` を実行してください")
+        process.exit(2)
+        throw err
+      }
+      if (err instanceof ForbiddenError) {
+        writeErrorJson("FORBIDDEN", err.message, "アクセス権限を確認してください")
+        process.exit(3)
+        throw err
+      }
+      if (err instanceof NotFoundError) {
+        writeErrorJson(
+          "NOT_FOUND",
+          err.message,
+          "ページが見つかりません。タイトルを確認してください",
+        )
+        process.exit(4)
+        throw err
+      }
+      throw err
+    }
+  },
+})

--- a/src/schemas/page.ts
+++ b/src/schemas/page.ts
@@ -6,6 +6,20 @@
 
 import { z } from "zod"
 
+/**
+ * InfoboxResultItem は LLM が生成した infobox の 1 件分のデータ。
+ *
+ * hallucination が true の場合、LLM が幻覚した可能性がある。
+ * truncated が true の場合、出力が切り捨てられている。
+ */
+export const InfoboxResultItemSchema = z.object({
+  title: z.string(),
+  infobox: z.record(z.string(), z.string()),
+  hallucination: z.boolean(),
+  truncated: z.boolean(),
+})
+export type InfoboxResultItem = z.infer<typeof InfoboxResultItemSchema>
+
 /** Line は Cosense ページの 1 行を表す。 */
 export const LineSchema = z.object({
   id: z.string(),
@@ -77,6 +91,12 @@ export const PageSchema = z.object({
       hasBackLinks: z.boolean().optional(),
     })
     .optional(),
+  /** table:infobox 記法の行データ */
+  infoboxDefinition: z.array(z.string()).optional(),
+  /** LLM が生成した infobox の結果一覧 */
+  infoboxResult: z.array(InfoboxResultItemSchema).optional(),
+  /** infobox でリンクを無効化するページタイトル一覧 */
+  infoboxDisableLinks: z.array(z.string()).optional(),
 })
 export type Page = z.infer<typeof PageSchema>
 

--- a/tests/unit/commands/page/infobox.test.ts
+++ b/tests/unit/commands/page/infobox.test.ts
@@ -1,0 +1,297 @@
+/**
+ * page/infobox.test.ts — `cos page infobox <title>` コマンドのテスト。
+ *
+ * infoboxResult の取得・表示、--json / --no-hallucination フラグ、
+ * エラー系・sandbox 違反を検証する。
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageInfoboxCommand } from "@/commands/page/infobox"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_TITLE = "製品仕様書"
+
+/** infoboxResult が含まれるページレスポンスのモック */
+const SAMPLE_PAGE = {
+  id: "page-id-sample",
+  title: TEST_TITLE,
+  image: null,
+  descriptions: ["製品の仕様を記述したページ"],
+  user: { id: "user-id-1" },
+  pin: 0,
+  views: 42,
+  linked: 5,
+  created: 1700000000,
+  updated: 1700100000,
+  persistent: true,
+  lines: [
+    {
+      id: "line-id-title",
+      text: TEST_TITLE,
+      userId: "user-id-1",
+      created: 1700000000,
+      updated: 1700000000,
+    },
+    {
+      id: "line-id-1",
+      text: "製品の仕様を記述したページ",
+      userId: "user-id-1",
+      created: 1700000001,
+      updated: 1700000001,
+    },
+  ],
+  links: [],
+  icons: [],
+  files: [],
+  infoboxDefinition: ["table:infobox", "\t名前\t値"],
+  infoboxResult: [
+    {
+      title: TEST_TITLE,
+      infobox: { 製品名: "コスマネージャー", バージョン: "2.0", 担当者: "田中太郎" },
+      hallucination: false,
+      truncated: false,
+    },
+    {
+      title: "関連ページA",
+      infobox: { 製品名: "コスビューア", バージョン: "1.5" },
+      hallucination: true,
+      truncated: false,
+    },
+  ],
+  infoboxDisableLinks: [],
+}
+
+/** infoboxResult が空のページレスポンス */
+const EMPTY_INFOBOX_PAGE = {
+  ...SAMPLE_PAGE,
+  title: "infoboxなしページ",
+  infoboxDefinition: [],
+  infoboxResult: [],
+}
+
+const server = setupServer(
+  // /api/pages/:project/:title モック
+  http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+    const project = decodeURIComponent(params["project"] as string)
+    const title = decodeURIComponent(params["title"] as string)
+    if (project === TEST_PROJECT && title === TEST_TITLE) {
+      return HttpResponse.json(SAMPLE_PAGE)
+    }
+    if (project === TEST_PROJECT && title === "infoboxなしページ") {
+      return HttpResponse.json(EMPTY_INFOBOX_PAGE)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+  // 認証確認用
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({ id: "テストユーザーID", name: "テストユーザー" })
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runInfobox(args: Record<string, unknown>) {
+  await (
+    pageInfoboxCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  server.resetHandlers()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageInfoboxCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("正常系 (plain): 各 infoboxResult がタイトルとKey-Value形式で stdout に出力される", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    expect(output).toContain(TEST_TITLE)
+    expect(output).toContain("製品名")
+    expect(output).toContain("コスマネージャー")
+    expect(output).toContain("担当者")
+    expect(output).toContain("田中太郎")
+    // hallucination: true の関連ページも表示される
+    expect(output).toContain("関連ページA")
+  })
+
+  it("--json 指定時: envelope の data.infoboxResult に配列が含まれる", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        json: true,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const rawOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    const parsed = JSON.parse(rawOutput) as {
+      data: { infoboxResult: Array<{ title: string; infobox: Record<string, string> }> }
+      meta: { command: string }
+    }
+    expect(parsed.meta.command).toBe("page.infobox")
+    expect(parsed.data.infoboxResult).toHaveLength(2)
+    expect(parsed.data.infoboxResult[0]?.title).toBe(TEST_TITLE)
+    expect(parsed.data.infoboxResult[0]?.infobox["製品名"]).toBe("コスマネージャー")
+  })
+
+  it("--no-hallucination 指定時: hallucination: true のアイテムが除外される", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": true,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    // hallucination: false のアイテムは含まれる
+    expect(output).toContain(TEST_TITLE)
+    expect(output).toContain("コスマネージャー")
+    // hallucination: true のアイテムは除外される
+    expect(output).not.toContain("関連ページA")
+  })
+
+  it("--no-hallucination --json 指定時: hallucination: true が除外された JSON が出力される", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        json: true,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": true,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const rawOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    const parsed = JSON.parse(rawOutput) as {
+      data: { infoboxResult: Array<{ hallucination: boolean }> }
+    }
+    // hallucination: false のアイテムのみ残る
+    expect(parsed.data.infoboxResult).toHaveLength(1)
+    expect(parsed.data.infoboxResult[0]?.hallucination).toBe(false)
+  })
+
+  it("infoboxResult が空のページでは空リストが返る (--json)", async () => {
+    try {
+      await runInfobox({
+        title: "infoboxなしページ",
+        project: TEST_PROJECT,
+        json: true,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+      })
+    } catch {
+      // REST クライアント初期化中の throw は想定内
+    }
+    const rawOutput = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+    const parsed = JSON.parse(rawOutput) as {
+      data: { infoboxResult: unknown[] }
+    }
+    expect(parsed.data.infoboxResult).toHaveLength(0)
+  })
+
+  it("存在しないページの場合は exit 4 で終了する", async () => {
+    try {
+      await runInfobox({
+        title: "存在しないページ",
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(4)
+  })
+
+  it("--disable-commands page.infobox 指定時は exit 7 で終了する", async () => {
+    try {
+      await runInfobox({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "no-hallucination": false,
+        quiet: false,
+        "disable-commands": "page.infobox",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})


### PR DESCRIPTION
## Summary

- Cosense APIに新たに追加された `infoboxDefinition` / `infoboxResult` フィールドを `PageSchema` に追加し、`cos page get --json` の出力でも参照できるようにした
- 新コマンド `cos page infobox <title>` を実装し、LLMが生成したinfoboxデータを取得・表示できるようにした
- `--no-hallucination` フラグで `hallucination: true` のアイテムを除外可能

## Background

takkerの調査 (2024/03/14) により、Cosenseの `/api/pages/:project/:title` に以下のフィールドが追加されたことが判明した:

- `infoboxDefinition: string[]` — ページ内の `table:infobox` 記法の行データ（質問テンプレート）
- `infoboxResult: InfoboxResultItem[]` — LLMがページ内容を解析して生成した構造化データ
- `InfoboxResultItem.hallucination: boolean` — LLMが幻覚した可能性を示すフラグ

これらは従来のcoscliスキーマに未定義だったため、zodのパース時にストリップされていた。

## Usage

```bash
# LLM生成infoboxデータをJSON出力（デフォルト）
cos page infobox "好きなハンバーガー" --project villagepump

# プレーンテキスト出力
cos page infobox "好きなハンバーガー" --project villagepump --plain

# hallucination: true のアイテムを除外
cos page infobox "好きなハンバーガー" --project villagepump --no-hallucination
```

## Test plan

- [x] `bun test tests/unit/commands/page/infobox.test.ts` — 8テストすべてGREEN
- [x] `bunx biome check src tests` — Lint警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ
- [x] `bun test` — 全1320テスト通過
- [x] `bun run build` — ビルド成功
- [x] CodeRabbit — 指摘なし
- [x] 実環境動作確認: `villagepump` プロジェクトの「好きなハンバーガー」ページでinfoboxデータを正常取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)