### PR TITLE
refactor: 中間進捗メッセージを削除し UNIX 哲学（沈黙の原則）に準拠する

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -254,8 +254,6 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
         throw err
       }
 
-      logger.info("認証情報を確認中...")
-
       const client = new CosenseRestClient({ sid })
       const me = await client.getMe()
 

--- a/src/commands/auth/service-account.ts
+++ b/src/commands/auth/service-account.ts
@@ -89,7 +89,6 @@ export function createAuthSaAddCommand(deps: AuthSaCommandDeps = {}) {
       }
 
       // API を呼び出してキーの有効性を確認する (pages API で検証)
-      logger.info(`${project} の Service Account キーを確認中...`)
       const client = new CosenseRestClient({ serviceAccountKey: a.key })
       try {
         await client.listPages(project, { limit: 1 })

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -7,13 +7,7 @@
  * セキュリティ: csrfToken は --json 出力から除外する。(issue #89)
  */
 
-import {
-  type CommonArgs,
-  buildJsonOpts,
-  buildLogger,
-  checkSandbox,
-  commonArgs,
-} from "@/commands/_shared"
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
 import { loadSession } from "@/core/auth/session"
 import type { TokenStore } from "@/core/auth/store"
@@ -38,7 +32,6 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
     async run({ args }) {
       const a = args as CommonArgs
       checkSandbox("auth.whoami", a)
-      const logger = buildLogger(a)
       const startTime = Date.now()
 
       const store = createStore()
@@ -51,8 +44,6 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
         )
         process.exit(2)
       }
-
-      logger.info("ユーザー情報を取得中...")
 
       const client = new CosenseRestClient({ sid })
       const me = await client.getMe()

--- a/src/commands/page/append.ts
+++ b/src/commands/page/append.ts
@@ -65,8 +65,6 @@ export const pageAppendCommand = defineCommand({
     })
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" に行を追加中...`)
-
     const writer = await buildWriter(a)
     const result = await appendToPage(writer, { project, title: a.title, lines })
 

--- a/src/commands/page/code.ts
+++ b/src/commands/page/code.ts
@@ -7,7 +7,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -35,11 +34,8 @@ export const pageCodeCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; filename: string }
     checkSandbox("page.code", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
-
-    logger.info(`"${a.title}" の ${a.filename} を取得中...`)
 
     const client = await buildRestClient(a)
     const code = await getCodeBlock(client, { project, title: a.title, filename: a.filename })

--- a/src/commands/page/context.ts
+++ b/src/commands/page/context.ts
@@ -9,7 +9,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -41,7 +40,6 @@ export const pageContextCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; hops: string }
     checkSandbox("page.context", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -58,8 +56,6 @@ export const pageContextCommand = defineCommand({
       throw new Error("VALIDATION_ERROR")
     }
     const hops = hopsNum as Hops
-
-    logger.info(`"${a.title}" の Smart Context (${hops}hop) を取得中...`)
 
     const client = await buildRestClient(a)
     const text = await getSmartContext(client, { project, title: a.title, hops })

--- a/src/commands/page/delete.ts
+++ b/src/commands/page/delete.ts
@@ -82,8 +82,6 @@ export const pageDeleteCommand = defineCommand({
       }
     }
 
-    logger.info(`"${a.title}" を削除中...`)
-
     const writer = await buildWriter(a)
     const result = await deletePage(writer, { project, title: a.title })
 

--- a/src/commands/page/edit.ts
+++ b/src/commands/page/edit.ts
@@ -135,8 +135,6 @@ export const pageEditCommand = defineCommand({
 
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" を編集中...`)
-
     const writer = await buildWriter(a)
     let result: Awaited<ReturnType<typeof editPage>>
     try {

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -7,7 +7,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -30,11 +29,8 @@ export const pageGetCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string }
     checkSandbox("page.get", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
-
-    logger.info(`"${a.title}" を取得中...`)
 
     const client = await buildRestClient(a)
     const page = await getPage(client, { project, title: a.title })

--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -42,7 +41,6 @@ export const pageHistoryCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; limit?: string; head?: string }
     checkSandbox("page.history", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -72,8 +70,6 @@ export const pageHistoryCommand = defineCommand({
       }
       limit = parsed
     }
-
-    logger.info(`"${a.title}" のコミット履歴を取得中...`)
 
     try {
       const client = await buildRestClient(a)

--- a/src/commands/page/infobox.ts
+++ b/src/commands/page/infobox.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -38,11 +37,8 @@ export const pageInfoboxCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; "no-hallucination": boolean }
     checkSandbox("page.infobox", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
-
-    logger.info(`"${a.title}" の infobox を取得中...`)
 
     try {
       const client = await buildRestClient(a)

--- a/src/commands/page/insert.ts
+++ b/src/commands/page/insert.ts
@@ -88,8 +88,6 @@ export const pageInsertCommand = defineCommand({
     })
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" の ${afterN} 行目の後ろに挿入中...`)
-
     const writer = await buildWriter(a)
     let result: Awaited<ReturnType<typeof insertIntoPage>> | undefined
     try {

--- a/src/commands/page/line/delete.ts
+++ b/src/commands/page/line/delete.ts
@@ -70,8 +70,6 @@ export const pageLineDeleteCommand = defineCommand({
       throw err
     }
 
-    logger.info(`"${a.title}" の ${start}〜${end} 行目を削除中...`)
-
     const writer = await buildWriter(a)
     let result: Awaited<ReturnType<typeof deleteLinesFromPage>> | undefined
     try {

--- a/src/commands/page/line/get.ts
+++ b/src/commands/page/line/get.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -44,7 +43,6 @@ export const pageLineGetCommand = defineCommand({
       range?: string
     }
     checkSandbox("page.line.get", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -66,8 +64,6 @@ export const pageLineGetCommand = defineCommand({
       }
       throw err
     }
-
-    logger.info(`"${a.title}" の ${start}〜${end} 行目を取得中...`)
 
     const client = await buildRestClient(a)
     const result = await getLineRange(client, {

--- a/src/commands/page/line/replace.ts
+++ b/src/commands/page/line/replace.ts
@@ -112,8 +112,6 @@ export const pageLineReplaceCommand = defineCommand({
     )
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" の ${start}〜${end} 行目を置換中...`)
-
     const writer = await buildWriter(a)
     let result: Awaited<ReturnType<typeof replaceLinesInPage>> | undefined
     try {

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -39,11 +38,8 @@ export const pageListCommand = defineCommand({
   async run({ args }) {
     const commonArgs = args as CommonArgs & { limit?: string; skip?: string; sort?: string }
     checkSandbox("page.list", commonArgs)
-    const logger = buildLogger(commonArgs)
     const project = requireProject(commonArgs)
     const startTime = Date.now()
-
-    logger.info(`${project} のページ一覧を取得中...`)
 
     const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
 

--- a/src/commands/page/new.ts
+++ b/src/commands/page/new.ts
@@ -67,8 +67,6 @@ export const pageNewCommand = defineCommand({
     })
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" を作成中...`)
-
     const writer = await buildWriter(a)
     const result = await createPage(writer, { project, title: a.title, lines })
 

--- a/src/commands/page/pin.ts
+++ b/src/commands/page/pin.ts
@@ -62,8 +62,6 @@ export const pagePinCommand = defineCommand({
       }
     }
 
-    logger.info(`"${a.title}" をピン留め中...`)
-
     const writer = await buildWriter(a)
     const result = await pinPage(writer, { project, title: a.title, create: a.create })
 

--- a/src/commands/page/prepend.ts
+++ b/src/commands/page/prepend.ts
@@ -65,8 +65,6 @@ export const pagePrependCommand = defineCommand({
     })
     const warnings = runNotationLint(lines, a)
 
-    logger.info(`"${a.title}" の先頭に行を挿入中...`)
-
     const writer = await buildWriter(a)
     const result = await prependToPage(writer, { project, title: a.title, lines })
 

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -114,8 +114,6 @@ export const pageRenameCommand = defineCommand({
       }
     }
 
-    logger.info(`"${a.title}" を "${a["new-title"]}" に変更中...`)
-
     const writer = await buildWriter(a)
     const result = await renamePage(writer, {
       project,

--- a/src/commands/page/snapshot/get.ts
+++ b/src/commands/page/snapshot/get.ts
@@ -14,7 +14,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -49,7 +48,6 @@ export const pageSnapshotGetCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; timestampId: string; text: boolean }
     checkSandbox("page.snapshot.get", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -85,8 +83,6 @@ export const pageSnapshotGetCommand = defineCommand({
       process.exit(5)
       throw new Error("VALIDATION_ERROR")
     }
-
-    logger.info(`"${a.title}" のスナップショット (${a.timestampId}) を取得中...`)
 
     try {
       const client = await buildRestClient(a)

--- a/src/commands/page/snapshot/list.ts
+++ b/src/commands/page/snapshot/list.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -33,7 +32,6 @@ export const pageSnapshotListCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string }
     checkSandbox("page.snapshot.list", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -47,8 +45,6 @@ export const pageSnapshotListCommand = defineCommand({
       process.exit(5)
       throw new Error("VALIDATION_ERROR")
     }
-
-    logger.info(`"${a.title}" のスナップショット一覧を取得中...`)
 
     try {
       const client = await buildRestClient(a)

--- a/src/commands/page/table.ts
+++ b/src/commands/page/table.ts
@@ -7,7 +7,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -36,11 +35,8 @@ export const pageTableCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { title: string; filename: string }
     checkSandbox("page.table", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
-
-    logger.info(`"${a.title}" の ${a.filename} のテーブルを取得中...`)
 
     try {
       const client = await buildRestClient(a)

--- a/src/commands/page/text.ts
+++ b/src/commands/page/text.ts
@@ -11,7 +11,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -65,7 +64,6 @@ export const pageTextCommand = defineCommand({
       "body-only": boolean
     }
     checkSandbox("page.text", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -91,8 +89,6 @@ export const pageTextCommand = defineCommand({
       )
       process.exit(5)
     }
-
-    logger.info(`"${a.title}" のテキストを取得中...`)
 
     const client = await buildRestClient(a)
     const rawText = await getPageText(client, { project, title: a.title })

--- a/src/commands/page/unpin.ts
+++ b/src/commands/page/unpin.ts
@@ -36,8 +36,6 @@ export const pageUnpinCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    logger.info(`"${a.title}" のピン留めを解除中...`)
-
     const writer = await buildWriter(a)
     const result = await unpinPage(writer, { project, title: a.title })
 

--- a/src/commands/project/graph.ts
+++ b/src/commands/project/graph.ts
@@ -11,7 +11,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -66,7 +65,6 @@ export const projectGraphCommand = defineCommand({
     }
 
     checkSandbox("project.graph", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -108,8 +106,6 @@ export const projectGraphCommand = defineCommand({
         return
       }
     }
-
-    logger.info(`プロジェクト "${project}" のリンクグラフを取得中...`)
 
     const client = await buildRestClient(a)
 

--- a/src/commands/project/info.ts
+++ b/src/commands/project/info.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -31,11 +30,8 @@ export const projectInfoCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { name?: string }
     checkSandbox("project.info", a)
-    const logger = buildLogger(a)
     const project = a.name ?? requireProject(a)
     const startTime = Date.now()
-
-    logger.info(`プロジェクト "${project}" の情報を取得中...`)
 
     const client = await buildRestClient(a)
     const info = await client.getProject(project)

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -7,7 +7,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -22,10 +21,7 @@ export const projectListCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs
     checkSandbox("project.list", a)
-    const logger = buildLogger(a)
     const startTime = Date.now()
-
-    logger.info("プロジェクト一覧を取得中...")
 
     const client = await buildRestClient(a)
     const result = await client.listProjects()

--- a/src/commands/project/search.ts
+++ b/src/commands/project/search.ts
@@ -9,7 +9,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -34,10 +33,7 @@ export const projectSearchCommand = defineCommand({
   async run({ args }) {
     const a = args as CommonArgs & { query: string }
     checkSandbox("project.search", a)
-    const logger = buildLogger(a)
     const startTime = Date.now()
-
-    logger.info(`"${a.query}" を参加プロジェクト全体から検索中...`)
 
     const client = await buildRestClient(a)
     const result = await client.searchJoinedProjects(a.query)

--- a/src/commands/sync/diff.ts
+++ b/src/commands/sync/diff.ts
@@ -8,7 +8,6 @@
 import {
   type CommonArgs,
   buildJsonOpts,
-  buildLogger,
   buildRestClient,
   checkSandbox,
   commonArgs,
@@ -47,7 +46,6 @@ export const syncDiffCommand = defineCommand({
     }
 
     checkSandbox("sync.diff", a)
-    const logger = buildLogger(a)
     const project = requireProject(a)
     const startTime = Date.now()
 
@@ -94,7 +92,6 @@ export const syncDiffCommand = defineCommand({
       }
     } else {
       // --all: プロジェクト全ページの diff (ページネーションで全件取得)
-      logger.info(`${project} の全ページの差分を確認中...`)
       const allPages = []
       let skip = 0
       const pageLimit = 100

--- a/src/commands/sync/pull.ts
+++ b/src/commands/sync/pull.ts
@@ -96,7 +96,6 @@ export const syncPullCommand = defineCommand({
 
     if (a.title) {
       // 単一ページの pull
-      logger.info(`"${a.title}" を pull 中...`)
       try {
         const result = await syncPull(client, syncDir, project, a.title, { dryRun })
         if (a.json || !a.plain) {
@@ -119,7 +118,6 @@ export const syncPullCommand = defineCommand({
       }
     } else {
       // --all: プロジェクト全ページを一括 pull (ページネーションで全件取得)
-      logger.info(`${project} の全ページを pull 中...`)
       const allPages = []
       let skip = 0
       const pageLimit = 100

--- a/src/commands/sync/push.ts
+++ b/src/commands/sync/push.ts
@@ -95,7 +95,6 @@ export const syncPushCommand = defineCommand({
 
     if (a.title) {
       // 単一ページの push
-      logger.info(`"${a.title}" を push 中...`)
       try {
         const result = await syncPush(client, writer, syncDir, project, a.title, {
           dryRun,
@@ -152,8 +151,6 @@ export const syncPushCommand = defineCommand({
       }
     } else {
       // --all: 同期ディレクトリのメタファイルから全ページを push
-      logger.info(`${project} の全ページを push 中...`)
-
       const { readdirSync } = await import("node:fs")
       const { join } = await import("node:path")
       const metaDir = join(syncDir, ".coscli", project)


### PR DESCRIPTION
## Summary

- API 呼び出し前に出力していた `logger.info("〜中...")` 形式の中間進捗メッセージを 32 コマンドから削除
- パイプラインやスクリプト利用時に不要なノイズが混入しなくなり、stdout には結果のみが出力される
- `logger` を完全に使わなくなった 17 ファイルでは `buildLogger` のインポートと変数宣言も合わせて削除

## 変更の背景

UNIX 哲学の「沈黙の原則」（成功時はノイズを出さない）に反していた。`--quiet / --json / --plain` フラグで既に抑制可能だったが、デフォルト動作として出力されるべきでなかった。

## 変更方針

| 対象 | 対応 |
|---|---|
| `logger.info("〜中...")` 中間進捗メッセージ | **削除** |
| `logger.success("〜しました")` 最終確認メッセージ | 維持（書き込み系コマンドの結果） |
| `logger.warn()` / `logger.error()` | 維持（異常系） |
| `page/watch` · `project/stream` の「監視中...」 | 維持（長時間実行コマンドの操作ガイド） |
| `auth/login` のブラウザ起動メッセージ | 維持（対話型認証フロー） |

## Test plan

- [x] `bunx biome check src tests` — Lint 警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ
- [x] `bun test` — 1315 件 pass / 0 fail
- [x] CodeRabbit — No findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)