### PR TITLE
chore: v0.6.1 リリース

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coscli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Cosense in your terminal — CLI for pages, projects, search, sync, and AI agents.",
   "bin": {
     "cos": "./dist/cos"


### PR DESCRIPTION
## Summary

- `package.json` バージョンを `0.6.1` に更新

## 変更内容

v0.6.0 直後に `cos page find-infobox` を `cos search --infobox` へ統合する破壊的変更 (#145) をマージしたため、v0.6.1 としてリリースする。

Closes なし（リリース PR のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)