### PR TITLE
feat(watch-list): ウォッチリスト管理機能と project search --watch-list フラグを追加する

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -12,7 +12,7 @@ import { lintNotation } from "@/core/notation/lint"
 import { normalizeCodeBlockEmptyLines } from "@/core/notation/normalize"
 import { PolicyError, createPolicy } from "@/core/sandbox"
 import { resolvePolicy } from "@/core/sandbox/resolve"
-import { loadConfig } from "@/infra/config"
+import { loadConfig, saveConfig } from "@/infra/config"
 import { createTokenStore } from "@/infra/keychain/index"
 import { Logger } from "@/infra/logger"
 import { UnsafePathError, readFromFile, readStdinBounded } from "@/infra/safe-read"
@@ -380,6 +380,8 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
       )
       exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
     }
+    const projectForAutoWatch = args.project ?? process.env["COS_PROJECT"]
+    if (projectForAutoWatch) maybeAutoAddToWatchlist(projectForAutoWatch)
     return new CosenseRestClient({ serviceAccountKey: envKey })
   }
 
@@ -399,13 +401,30 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
         )
         exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
       }
+      maybeAutoAddToWatchlist(project)
       return new CosenseRestClient({ serviceAccountKey: saKey })
     }
   }
 
   // 3. SID 認証にフォールバック
   const sid = await requireSid(args.profile)
+  if (project) maybeAutoAddToWatchlist(project)
   return new CosenseRestClient({ sid })
+}
+
+/**
+ * maybeAutoAddToWatchlist は autoWatchlist が true のとき、
+ * project をウォッチリストに追加する。すでに存在する場合は何もしない。
+ *
+ * autoWatchlist: true の設定時に cos コマンドでアクセスしたプロジェクトを
+ * Cosense Web アプリの localStorage 相当として自動記録する。
+ */
+function maybeAutoAddToWatchlist(project: string): void {
+  const config = loadConfig()
+  if (config.autoWatchlist !== true) return
+  const current = config.watchlist ?? []
+  if (current.includes(project)) return
+  saveConfig({ ...config, watchlist: [...current, project] })
 }
 
 /** buildWriter は ScrapboxWriter を生成する。 */

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -59,6 +59,11 @@ import { syncDiffCommand } from "@/commands/sync/diff"
 import { syncPullCommand } from "@/commands/sync/pull"
 import { syncPushCommand } from "@/commands/sync/push"
 
+// ウォッチリストコマンド
+import { watchListAddCommand } from "@/commands/watch-list/add"
+import { watchListListCommand } from "@/commands/watch-list/list"
+import { watchListRemoveCommand } from "@/commands/watch-list/remove"
+
 // 変換コマンド
 import { convertCommand } from "@/commands/convert"
 
@@ -170,6 +175,19 @@ export const configCommand = defineCommand({
   run: showUsageIfNoSubCommand,
 })
 
+/** watch-list サブコマンドグループ */
+export const watchListCommand = defineCommand({
+  meta: { name: "watch-list", description: "ウォッチリスト管理 (list / add / remove)" },
+  subCommands: {
+    list: watchListListCommand,
+    ls: watchListListCommand,
+    add: watchListAddCommand,
+    remove: watchListRemoveCommand,
+    rm: watchListRemoveCommand,
+  },
+  run: showUsageIfNoSubCommand,
+})
+
 /** sync サブコマンドグループ */
 export const syncCommand = defineCommand({
   meta: { name: "sync", description: "ローカルファイルと Cosense の同期コマンド" },
@@ -193,6 +211,7 @@ export const rootSubCommands = {
   me: authWhoamiCommand,
   config: configCommand,
   sync: syncCommand,
+  "watch-list": watchListCommand,
   convert: convertCommand,
   serve: serveCommand,
   "exit-codes": exitCodesCommand,

--- a/src/commands/project/search.ts
+++ b/src/commands/project/search.ts
@@ -4,6 +4,10 @@
  * 参加プロジェクト全体を横断して query にマッチするプロジェクト一覧を返す。
  * 内部で /api/projects/search/query を叩き、結果をそのまま出力する。
  * --project は不要 (横断検索のため)。
+ *
+ * フラグ:
+ *   --joined     : 参加プロジェクトのみ対象 (デフォルト挙動と同じ)
+ *   --watch-list : ローカル config の watchlist に含まれるプロジェクトのみ返す
  */
 
 import {
@@ -12,7 +16,9 @@ import {
   buildRestClient,
   checkSandbox,
   commonArgs,
+  exitWithError,
 } from "@/commands/_shared"
+import { loadConfig } from "@/infra/config"
 import { writeJson } from "@/presenter/json"
 import { writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
@@ -29,23 +35,49 @@ export const projectSearchCommand = defineCommand({
       description: "検索キーワード",
       required: true,
     },
+    joined: {
+      type: "boolean" as const,
+      description: "参加プロジェクトのみを対象にする (デフォルト)",
+      default: false,
+    },
+    "watch-list": {
+      type: "boolean" as const,
+      description: "ウォッチリストに登録されたプロジェクトのみを対象にする",
+      default: false,
+    },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { query: string }
+    const a = args as CommonArgs & { query: string; joined: boolean; "watch-list": boolean }
     checkSandbox("project.search", a)
     const startTime = Date.now()
 
     const client = await buildRestClient(a)
     const result = await client.searchJoinedProjects(a.query)
 
+    let projects = result.projects
+
+    // --watch-list: ウォッチリストに含まれるプロジェクトのみフィルタリングする
+    if (a["watch-list"]) {
+      const config = loadConfig()
+      const watchlist = config.watchlist ?? []
+      if (watchlist.length === 0) {
+        exitWithError(
+          5,
+          "ウォッチリストが空です。cos watch-list add <project> でプロジェクトを追加してください",
+        )
+      }
+      const watchlistSet = new Set(watchlist)
+      projects = projects.filter((p) => watchlistSet.has(p.name))
+    }
+
     if (a.json) {
-      writeJson(result, { command: "project.search", startTime }, buildJsonOpts(a))
+      writeJson({ ...result, projects }, { command: "project.search", startTime }, buildJsonOpts(a))
       return
     }
 
     writeTsv(
       ["name", "displayName"],
-      result.projects.map((p) => [p.name, p.displayName]),
+      projects.map((p) => [p.name, p.displayName]),
     )
   },
 })

--- a/src/commands/project/search.ts
+++ b/src/commands/project/search.ts
@@ -19,7 +19,7 @@ import {
   exitWithError,
 } from "@/commands/_shared"
 import { loadConfig } from "@/infra/config"
-import { writeJson } from "@/presenter/json"
+import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
@@ -61,10 +61,12 @@ export const projectSearchCommand = defineCommand({
       const config = loadConfig()
       const watchlist = config.watchlist ?? []
       if (watchlist.length === 0) {
-        exitWithError(
-          5,
-          "ウォッチリストが空です。cos watch-list add <project> でプロジェクトを追加してください",
+        writeErrorJson(
+          "WATCHLIST_EMPTY",
+          "ウォッチリストが空です",
+          "cos watch-list add <project> でプロジェクトを追加してください",
         )
+        exitWithError(5, "WATCHLIST_EMPTY")
       }
       const watchlistSet = new Set(watchlist)
       projects = projects.filter((p) => watchlistSet.has(p.name))

--- a/src/commands/watch-list/add.ts
+++ b/src/commands/watch-list/add.ts
@@ -1,0 +1,37 @@
+/**
+ * watch-list/add.ts — `cos watch-list add <project>` コマンド。
+ *
+ * ローカル config の watchlist にプロジェクト名を追加する。
+ * すでに存在する場合は何もしない（重複防止）。
+ */
+
+import { type CommonArgs, checkSandbox, commonArgs } from "@/commands/_shared"
+import { loadConfig, saveConfig } from "@/infra/config"
+import { defineCommand } from "citty"
+
+export const watchListAddCommand = defineCommand({
+  meta: {
+    name: "add",
+    description: "プロジェクトをウォッチリストに追加する",
+  },
+  args: {
+    ...commonArgs,
+    project_name: {
+      type: "positional" as const,
+      description: "追加するプロジェクト名",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { project_name: string }
+    checkSandbox("watch-list.add", a)
+
+    const config = loadConfig()
+    const current = config.watchlist ?? []
+
+    // すでに存在する場合は何もしない
+    if (current.includes(a.project_name)) return
+
+    saveConfig({ ...config, watchlist: [...current, a.project_name] })
+  },
+})

--- a/src/commands/watch-list/list.ts
+++ b/src/commands/watch-list/list.ts
@@ -1,0 +1,37 @@
+/**
+ * watch-list/list.ts — `cos watch-list list` コマンド。
+ *
+ * ローカル config に保存されたウォッチリストのプロジェクト名を一覧表示する。
+ */
+
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
+import { loadConfig } from "@/infra/config"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const watchListListCommand = defineCommand({
+  meta: {
+    name: "list",
+    description: "ウォッチリストのプロジェクト一覧を表示する",
+  },
+  args: {
+    ...commonArgs,
+  },
+  async run({ args }) {
+    const a = args as CommonArgs
+    checkSandbox("watch-list.list", a)
+    const startTime = Date.now()
+
+    const config = loadConfig()
+    const watchlist = config.watchlist ?? []
+
+    if (a.json) {
+      writeJson({ watchlist }, { command: "watch-list.list", startTime }, buildJsonOpts(a))
+      return
+    }
+
+    for (const project of watchlist) {
+      process.stdout.write(`${project}\n`)
+    }
+  },
+})

--- a/src/commands/watch-list/remove.ts
+++ b/src/commands/watch-list/remove.ts
@@ -7,6 +7,7 @@
 
 import { type CommonArgs, checkSandbox, commonArgs, exitWithError } from "@/commands/_shared"
 import { loadConfig, saveConfig } from "@/infra/config"
+import { writeErrorJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
 export const watchListRemoveCommand = defineCommand({
@@ -30,7 +31,12 @@ export const watchListRemoveCommand = defineCommand({
     const current = config.watchlist ?? []
 
     if (!current.includes(a.project_name)) {
-      exitWithError(4, `ウォッチリストに "${a.project_name}" は登録されていません`)
+      writeErrorJson(
+        "NOT_FOUND",
+        `ウォッチリストに "${a.project_name}" は登録されていません`,
+        "cos watch-list list でウォッチリストを確認してください",
+      )
+      exitWithError(4, "NOT_FOUND")
     }
 
     saveConfig({ ...config, watchlist: current.filter((p) => p !== a.project_name) })

--- a/src/commands/watch-list/remove.ts
+++ b/src/commands/watch-list/remove.ts
@@ -1,0 +1,38 @@
+/**
+ * watch-list/remove.ts — `cos watch-list remove <project>` コマンド。
+ *
+ * ローカル config の watchlist からプロジェクト名を削除する。
+ * 存在しない場合は exit 4 で終了する。
+ */
+
+import { type CommonArgs, checkSandbox, commonArgs, exitWithError } from "@/commands/_shared"
+import { loadConfig, saveConfig } from "@/infra/config"
+import { defineCommand } from "citty"
+
+export const watchListRemoveCommand = defineCommand({
+  meta: {
+    name: "remove",
+    description: "プロジェクトをウォッチリストから削除する",
+  },
+  args: {
+    ...commonArgs,
+    project_name: {
+      type: "positional" as const,
+      description: "削除するプロジェクト名",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as CommonArgs & { project_name: string }
+    checkSandbox("watch-list.remove", a)
+
+    const config = loadConfig()
+    const current = config.watchlist ?? []
+
+    if (!current.includes(a.project_name)) {
+      exitWithError(4, `ウォッチリストに "${a.project_name}" は登録されていません`)
+    }
+
+    saveConfig({ ...config, watchlist: current.filter((p) => p !== a.project_name) })
+  },
+})

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -41,6 +41,7 @@ export const READ_COMMANDS: readonly string[] = [
   "search",
   "sync.diff",
   "sync.pull",
+  "watch-list.list",
 ]
 
 /** WRITE_COMMANDS は書き込み系コマンドの一覧。 */
@@ -62,6 +63,8 @@ export const WRITE_COMMANDS: readonly string[] = [
   "page.unpin",
   "serve.rest",
   "sync.push",
+  "watch-list.add",
+  "watch-list.remove",
 ]
 
 /** PermissionPreset はプロジェクト権限プリセットの型。 */

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -68,6 +68,14 @@ export const CoscliConfigSchema = z.object({
   /** 全プロジェクト共通の絶対禁止コマンドリスト。CLI フラグで上書き可能。 */
   disableCommands: z.array(CommandPatternSchema).optional(),
   projects: z.record(z.string(), ProjectConfigSchema).optional(),
+  /** ローカルウォッチリスト。プロジェクト名の配列。 */
+  watchlist: z.array(z.string()).optional(),
+  /**
+   * プロジェクトアクセス時にウォッチリストへ自動追加するか。
+   * true にすると --project 指定時に自動で watchlist に追加される。
+   * デフォルト: false (opt-in)。
+   */
+  autoWatchlist: z.boolean().optional(),
   output: z
     .object({
       color: z.enum(["auto", "always", "never"]).optional(),

--- a/tests/unit/commands/_shared.test.ts
+++ b/tests/unit/commands/_shared.test.ts
@@ -5,7 +5,10 @@
  * 書き込み系コマンドは commonArgs に加えて dryRunArg をスプレッドし --dry-run を持つ。
  */
 
-import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   type CommonArgs,
   ServiceAccountKeyValidationError,
@@ -14,11 +17,14 @@ import {
   assertValidSid,
   buildJsonOpts,
   buildLogger,
+  buildRestClient,
   commonArgs,
   dryRunArg,
   getRawFlagValue,
   isStdinPath,
 } from "@/commands/_shared"
+import type { CoscliConfig } from "@/infra/config"
+import { loadConfig, saveConfig } from "@/infra/config"
 
 /** テスト用デフォルト CommonArgs を生成するヘルパー */
 function makeArgs(overrides: Partial<CommonArgs> = {}): CommonArgs {
@@ -302,5 +308,93 @@ describe("getRawFlagValue", () => {
   it("同一フラグが複数回指定された場合は最後の値を返す (CLI の一般的な挙動に合わせる)", () => {
     // --after 3 --after -1 のように複数回指定された場合、最後の -1 が優先される
     expect(getRawFlagValue(["node", "cos", "--after", "3", "--after", "-1"], "after")).toBe("-1")
+  })
+})
+
+describe("buildRestClient - auto-watch 機能", () => {
+  /** 一時設定ディレクトリ */
+  const TEST_CONFIG_DIR = join(tmpdir(), `coscli-auto-watch-test-${Date.now()}`)
+  const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+  function writeTestConfig(config: CoscliConfig): void {
+    saveConfig(config, TEST_CONFIG_FILE)
+  }
+  function readTestConfig(): CoscliConfig {
+    return loadConfig(TEST_CONFIG_FILE)
+  }
+
+  beforeEach(() => {
+    process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+    // ダミー SID でキーチェーン呼び出しをスキップする
+    process.env["COS_SID"] = "s%3Atest-session-id"
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    try {
+      rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+    } catch {
+      // クリーンアップ失敗は無視する
+    }
+  })
+
+  it("autoWatchlist: true のとき、--project 指定プロジェクトがウォッチリストに自動追加される", async () => {
+    writeTestConfig({ autoWatchlist: true })
+    await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+      project: "auto-added-project",
+    })
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["auto-added-project"])
+  })
+
+  it("autoWatchlist: true のとき、すでにウォッチリストにあるプロジェクトは重複追加されない", async () => {
+    writeTestConfig({ autoWatchlist: true, watchlist: ["already-listed"] })
+    await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+      project: "already-listed",
+    })
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["already-listed"])
+  })
+
+  it("autoWatchlist: false のとき、プロジェクトは自動追加されない", async () => {
+    writeTestConfig({ autoWatchlist: false })
+    await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+      project: "not-added",
+    })
+    const config = readTestConfig()
+    expect(config.watchlist).toBeUndefined()
+  })
+
+  it("autoWatchlist 未設定のとき、プロジェクトは自動追加されない", async () => {
+    writeTestConfig({})
+    await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+      project: "not-added",
+    })
+    const config = readTestConfig()
+    expect(config.watchlist).toBeUndefined()
+  })
+
+  it("--project が未指定のとき、autoWatchlist: true でもウォッチリストに追加されない", async () => {
+    writeTestConfig({ autoWatchlist: true })
+    await buildRestClient({ json: false, plain: false, "results-only": false, quiet: true })
+    const config = readTestConfig()
+    expect(config.watchlist).toBeUndefined()
   })
 })

--- a/tests/unit/commands/project/search.test.ts
+++ b/tests/unit/commands/project/search.test.ts
@@ -2,11 +2,26 @@
  * project/search.test.ts — `cos project search` コマンドのテスト。
  *
  * 参加プロジェクト横断検索でマッチしたプロジェクト一覧を返す動作を検証する。
+ * --watch-list / --joined フラグの動作も検証する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { projectSearchCommand } from "@/commands/project/search"
 import { CosenseRestClient } from "@/core/api/rest"
+import type { CoscliConfig } from "@/infra/config"
+import { saveConfig } from "@/infra/config"
+
+/** 一時設定ディレクトリ (--watch-list フラグのテスト用) */
+const TEST_CONFIG_DIR = join(tmpdir(), `coscli-project-search-test-${Date.now()}`)
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+/** テスト用設定を書き込むヘルパー */
+function writeTestConfig(config: CoscliConfig): void {
+  saveConfig(config, TEST_CONFIG_FILE)
+}
 
 /** ProjectSearchResult の最小限フィクスチャ */
 const SEARCH_JOINED_FIXTURE = {
@@ -71,6 +86,12 @@ afterEach(() => {
   stderrMock.mockRestore()
   searchJoinedProjectsSpy.mockRestore()
   Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+  try {
+    rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+  } catch {
+    // クリーンアップ失敗は無視する
+  }
 })
 
 describe("projectSearchCommand", () => {
@@ -96,5 +117,60 @@ describe("projectSearchCommand", () => {
   it("クエリが API に正しく渡される", async () => {
     await runProjectSearch(baseArgs({ query: "テスト検索ワード" }))
     expect(searchJoinedProjectsSpy).toHaveBeenCalledWith("テスト検索ワード")
+  })
+})
+
+describe("projectSearchCommand - --joined フラグ", () => {
+  it("--joined フラグで参加プロジェクト全体を検索する (フラグなし時と同じ挙動)", async () => {
+    await runProjectSearch(baseArgs({ joined: true }))
+    expect(searchJoinedProjectsSpy).toHaveBeenCalledTimes(1)
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("myproject")
+    expect(output).toContain("helpproject")
+  })
+})
+
+describe("projectSearchCommand - --watch-list フラグ", () => {
+  beforeEach(() => {
+    process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+  })
+
+  it("--watch-list でウォッチリスト内のプロジェクトのみ返す", async () => {
+    // myproject のみウォッチリストに登録
+    writeTestConfig({ watchlist: ["myproject"] })
+    await runProjectSearch(baseArgs({ "watch-list": true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("myproject")
+    // helpproject はウォッチリスト外なので出力されない
+    expect(output).not.toContain("helpproject")
+  })
+
+  it("--watch-list でウォッチリストが空のとき exit 5 で終了する", async () => {
+    writeTestConfig({})
+    // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
+    try {
+      await runProjectSearch(baseArgs({ "watch-list": true }))
+    } catch {
+      // 期待通りの throw
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--watch-list の JSON 出力でウォッチリスト内プロジェクトのみ含む", async () => {
+    writeTestConfig({ watchlist: ["myproject"] })
+    await runProjectSearch(baseArgs({ "watch-list": true, json: true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    const parsed = JSON.parse(output)
+    expect(parsed.data.projects).toHaveLength(1)
+    expect(parsed.data.projects[0].name).toBe("myproject")
+  })
+
+  it("--joined と --watch-list を同時指定するとすべての参加プロジェクトから watch-list でフィルタする", async () => {
+    // 両方指定した場合の動作確認
+    writeTestConfig({ watchlist: ["helpproject"] })
+    await runProjectSearch(baseArgs({ joined: true, "watch-list": true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("helpproject")
+    expect(output).not.toContain("myproject")
   })
 })

--- a/tests/unit/commands/project/search.test.ts
+++ b/tests/unit/commands/project/search.test.ts
@@ -145,7 +145,7 @@ describe("projectSearchCommand - --watch-list フラグ", () => {
     expect(output).not.toContain("helpproject")
   })
 
-  it("--watch-list でウォッチリストが空のとき exit 5 で終了する", async () => {
+  it("--watch-list でウォッチリストが空のとき exit 5 で終了しエラーメッセージを出力する", async () => {
     writeTestConfig({})
     // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
     try {
@@ -154,6 +154,8 @@ describe("projectSearchCommand - --watch-list フラグ", () => {
       // 期待通りの throw
     }
     expect(exitMock).toHaveBeenCalledWith(5)
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("ウォッチリストが空")
   })
 
   it("--watch-list の JSON 出力でウォッチリスト内プロジェクトのみ含む", async () => {

--- a/tests/unit/commands/watch-list/add.test.ts
+++ b/tests/unit/commands/watch-list/add.test.ts
@@ -1,0 +1,125 @@
+/**
+ * watch-list/add.test.ts — `cos watch-list add` コマンドのテスト。
+ *
+ * ローカル config の watchlist フィールドにプロジェクトを追加する動作を検証する。
+ * XDG_CONFIG_HOME を一時ディレクトリに向けて副作用を隔離する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { watchListAddCommand } from "@/commands/watch-list/add"
+import type { CoscliConfig } from "@/infra/config"
+import { loadConfig, saveConfig } from "@/infra/config"
+
+/** 一時設定ディレクトリ */
+const TEST_CONFIG_DIR = join(tmpdir(), `coscli-watchlist-add-test-${Date.now()}`)
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+/** テスト用設定を書き込むヘルパー */
+function writeTestConfig(config: CoscliConfig): void {
+  saveConfig(config, TEST_CONFIG_FILE)
+}
+
+/** 現在の設定を読み込むヘルパー */
+function readTestConfig(): CoscliConfig {
+  return loadConfig(TEST_CONFIG_FILE)
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runWatchListAdd(args: Record<string, unknown>) {
+  await (
+    watchListAddCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 共通の args ベース */
+function baseArgs(project: string, overrides: Record<string, unknown> = {}) {
+  return {
+    project_name: project,
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+  try {
+    rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+  } catch {
+    // クリーンアップ失敗は無視する
+  }
+})
+
+describe("watchListAddCommand", () => {
+  it("watchlist が空のとき、プロジェクトを追加できる", async () => {
+    writeTestConfig({})
+    await runWatchListAdd(baseArgs("my-project"))
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["my-project"])
+  })
+
+  it("既存の watchlist にプロジェクトを追加できる", async () => {
+    writeTestConfig({ watchlist: ["project-alpha"] })
+    await runWatchListAdd(baseArgs("project-beta"))
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["project-alpha", "project-beta"])
+  })
+
+  it("すでにウォッチリストにあるプロジェクトは重複追加されない", async () => {
+    writeTestConfig({ watchlist: ["project-alpha"] })
+    await runWatchListAdd(baseArgs("project-alpha"))
+    const config = readTestConfig()
+    // 重複なし: 1件のまま
+    expect(config.watchlist).toEqual(["project-alpha"])
+  })
+
+  it("config が存在しないとき、新規作成してプロジェクトを追加できる", async () => {
+    // 設定ファイルなしの状態で実行する
+    await runWatchListAdd(baseArgs("brand-new-project"))
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["brand-new-project"])
+  })
+
+  it("--disable-commands で watch-list.add を禁止するとエラー終了する", async () => {
+    writeTestConfig({})
+    // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
+    try {
+      await runWatchListAdd(baseArgs("my-project", { "disable-commands": "watch-list.add" }))
+    } catch {
+      // 期待通りの throw
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+    // config は変更されない
+    const config = readTestConfig()
+    expect(config.watchlist).toBeUndefined()
+  })
+})

--- a/tests/unit/commands/watch-list/list.test.ts
+++ b/tests/unit/commands/watch-list/list.test.ts
@@ -1,0 +1,116 @@
+/**
+ * watch-list/list.test.ts — `cos watch-list list` コマンドのテスト。
+ *
+ * ローカル config の watchlist フィールドを読み込んで出力する動作を検証する。
+ * XDG_CONFIG_HOME を一時ディレクトリに向けて副作用を隔離する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { watchListListCommand } from "@/commands/watch-list/list"
+import type { CoscliConfig } from "@/infra/config"
+import { saveConfig } from "@/infra/config"
+
+/** 一時設定ディレクトリ */
+const TEST_CONFIG_DIR = join(tmpdir(), `coscli-watchlist-list-test-${Date.now()}`)
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+/** テスト用設定を書き込むヘルパー */
+function writeTestConfig(config: CoscliConfig): void {
+  saveConfig(config, TEST_CONFIG_FILE)
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runWatchListList(args: Record<string, unknown>) {
+  await (
+    watchListListCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 共通の args ベース */
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+  try {
+    rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+  } catch {
+    // クリーンアップ失敗は無視する
+  }
+})
+
+describe("watchListListCommand", () => {
+  it("ウォッチリストのプロジェクト名を1行ずつ出力する", async () => {
+    writeTestConfig({ watchlist: ["project-alpha", "project-beta", "project-gamma"] })
+    await runWatchListList(baseArgs())
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("project-alpha")
+    expect(output).toContain("project-beta")
+    expect(output).toContain("project-gamma")
+  })
+
+  it("watchlist が空のとき何も出力しない", async () => {
+    writeTestConfig({ watchlist: [] })
+    await runWatchListList(baseArgs())
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toBe("")
+  })
+
+  it("config に watchlist がないとき何も出力しない", async () => {
+    writeTestConfig({})
+    await runWatchListList(baseArgs())
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toBe("")
+  })
+
+  it("--json で watchlist 配列を含む JSON envelope を出力する", async () => {
+    writeTestConfig({ watchlist: ["project-alpha", "project-beta"] })
+    await runWatchListList(baseArgs({ json: true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    const parsed = JSON.parse(output)
+    expect(parsed.meta.command).toBe("watch-list.list")
+    expect(parsed.data.watchlist).toEqual(["project-alpha", "project-beta"])
+  })
+
+  it("--json で watchlist が空のとき空配列を返す", async () => {
+    writeTestConfig({})
+    await runWatchListList(baseArgs({ json: true }))
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    const parsed = JSON.parse(output)
+    expect(parsed.data.watchlist).toEqual([])
+  })
+})

--- a/tests/unit/commands/watch-list/remove.test.ts
+++ b/tests/unit/commands/watch-list/remove.test.ts
@@ -94,7 +94,7 @@ describe("watchListRemoveCommand", () => {
     expect(config.watchlist).toEqual([])
   })
 
-  it("ウォッチリストに存在しないプロジェクトを削除しようとすると exit 4 で終了する", async () => {
+  it("ウォッチリストに存在しないプロジェクトを削除しようとすると exit 4 で終了しエラーメッセージを出力する", async () => {
     writeTestConfig({ watchlist: ["project-alpha"] })
     // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
     try {
@@ -103,6 +103,8 @@ describe("watchListRemoveCommand", () => {
       // 期待通りの throw
     }
     expect(exitMock).toHaveBeenCalledWith(4)
+    const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+    expect(output).toContain("存在しないプロジェクト")
     // config は変更されない
     const config = readTestConfig()
     expect(config.watchlist).toEqual(["project-alpha"])

--- a/tests/unit/commands/watch-list/remove.test.ts
+++ b/tests/unit/commands/watch-list/remove.test.ts
@@ -1,0 +1,137 @@
+/**
+ * watch-list/remove.test.ts — `cos watch-list remove` コマンドのテスト。
+ *
+ * ローカル config の watchlist フィールドからプロジェクトを削除する動作を検証する。
+ * XDG_CONFIG_HOME を一時ディレクトリに向けて副作用を隔離する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { watchListRemoveCommand } from "@/commands/watch-list/remove"
+import type { CoscliConfig } from "@/infra/config"
+import { loadConfig, saveConfig } from "@/infra/config"
+
+/** 一時設定ディレクトリ */
+const TEST_CONFIG_DIR = join(tmpdir(), `coscli-watchlist-remove-test-${Date.now()}`)
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "coscli", "config.json5")
+
+/** テスト用設定を書き込むヘルパー */
+function writeTestConfig(config: CoscliConfig): void {
+  saveConfig(config, TEST_CONFIG_FILE)
+}
+
+/** 現在の設定を読み込むヘルパー */
+function readTestConfig(): CoscliConfig {
+  return loadConfig(TEST_CONFIG_FILE)
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** コマンド run ヘルパー */
+async function runWatchListRemove(args: Record<string, unknown>) {
+  await (
+    watchListRemoveCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** 共通の args ベース */
+function baseArgs(project: string, overrides: Record<string, unknown> = {}) {
+  return {
+    project_name: project,
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  process.env["XDG_CONFIG_HOME"] = TEST_CONFIG_DIR
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "XDG_CONFIG_HOME")
+  try {
+    rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
+  } catch {
+    // クリーンアップ失敗は無視する
+  }
+})
+
+describe("watchListRemoveCommand", () => {
+  it("ウォッチリストからプロジェクトを削除できる", async () => {
+    writeTestConfig({ watchlist: ["project-alpha", "project-beta"] })
+    await runWatchListRemove(baseArgs("project-alpha"))
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["project-beta"])
+  })
+
+  it("1件だけのウォッチリストを削除すると空配列になる", async () => {
+    writeTestConfig({ watchlist: ["only-project"] })
+    await runWatchListRemove(baseArgs("only-project"))
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual([])
+  })
+
+  it("ウォッチリストに存在しないプロジェクトを削除しようとすると exit 4 で終了する", async () => {
+    writeTestConfig({ watchlist: ["project-alpha"] })
+    // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
+    try {
+      await runWatchListRemove(baseArgs("存在しないプロジェクト"))
+    } catch {
+      // 期待通りの throw
+    }
+    expect(exitMock).toHaveBeenCalledWith(4)
+    // config は変更されない
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["project-alpha"])
+  })
+
+  it("watchlist が空のとき削除しようとすると exit 4 で終了する", async () => {
+    writeTestConfig({})
+    // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
+    try {
+      await runWatchListRemove(baseArgs("my-project"))
+    } catch {
+      // 期待通りの throw
+    }
+    expect(exitMock).toHaveBeenCalledWith(4)
+  })
+
+  it("--disable-commands で watch-list.remove を禁止するとエラー終了する", async () => {
+    writeTestConfig({ watchlist: ["project-alpha"] })
+    // exitWithError が process.exit モック後に throw するため try-catch で握り潰す
+    try {
+      await runWatchListRemove(
+        baseArgs("project-alpha", { "disable-commands": "watch-list.remove" }),
+      )
+    } catch {
+      // 期待通りの throw
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+    // config は変更されない
+    const config = readTestConfig()
+    expect(config.watchlist).toEqual(["project-alpha"])
+  })
+})

--- a/tests/unit/infra/config.test.ts
+++ b/tests/unit/infra/config.test.ts
@@ -226,6 +226,44 @@ describe("setConfigValue - permission/disableCommands 設定フィールド", ()
   })
 })
 
+describe("setConfigValue - watchlist 設定フィールド", () => {
+  it("watchlist にプロジェクト名の配列を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "watchlist", ["プロジェクトA", "プロジェクトB"])
+    expect(updated.watchlist).toEqual(["プロジェクトA", "プロジェクトB"])
+  })
+
+  it("watchlist に空配列を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "watchlist", [])
+    expect(updated.watchlist).toEqual([])
+  })
+
+  it("autoWatchlist に true を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "autoWatchlist", true)
+    expect(updated.autoWatchlist).toBe(true)
+  })
+
+  it("autoWatchlist に false を設定できる", () => {
+    const config = {}
+    const updated = setConfigValue(config, "autoWatchlist", false)
+    expect(updated.autoWatchlist).toBe(false)
+  })
+
+  it("watchlist と autoWatchlist を含む設定をファイルに保存・読み込みできる", () => {
+    const { join } = require("node:path")
+    const { tmpdir } = require("node:os")
+    const { unlinkSync } = require("node:fs")
+    const path = join(tmpdir(), `coscli-watchlist-test-${Date.now()}.json5`)
+    saveConfig({ watchlist: ["プロジェクトA"], autoWatchlist: true }, path)
+    const loaded = loadConfig(path)
+    expect(loaded.watchlist).toEqual(["プロジェクトA"])
+    expect(loaded.autoWatchlist).toBe(true)
+    unlinkSync(path)
+  })
+})
+
 describe("prototype 汚染への防御", () => {
   afterAll(() => {
     // RED フェーズで汚染が発生した場合に備えてクリーンアップする


### PR DESCRIPTION
## Summary

- `cos watch-list add/remove/list` コマンドを新規追加し、ローカル config にプロジェクトのウォッチリストを手動管理できるようにする
- `cos project search` に `--watch-list` フラグを追加し、ウォッチリストに登録済みのプロジェクトのみに結果を絞り込めるようにする
- `autoWatchlist: true` を config に設定すると、`--project` でアクセスしたプロジェクトを自動でウォッチリストに追加する機能を追加する (opt-in)

## Changes

### 新規ファイル
- `src/commands/watch-list/add.ts` — プロジェクトをウォッチリストに追加
- `src/commands/watch-list/remove.ts` — プロジェクトをウォッチリストから削除
- `src/commands/watch-list/list.ts` — ウォッチリストを表示
- `tests/unit/commands/watch-list/add.test.ts`
- `tests/unit/commands/watch-list/remove.test.ts`
- `tests/unit/commands/watch-list/list.test.ts`

### 修正ファイル
- `src/infra/config.ts` — `watchlist`, `autoWatchlist` フィールドを追加
- `src/commands/_shared.ts` — `maybeAutoAddToWatchlist()` ヘルパー追加、`buildRestClient()` に auto-watch ロジック追加
- `src/commands/project/search.ts` — `--joined` / `--watch-list` フラグ追加
- `src/core/command-classification.ts` — watch-list コマンドを read/write に分類追加
- `src/commands/index.ts` — `watchListCommand` をルートサブコマンドに追加

## Test plan

- [ ] `cos watch-list add <project>` でプロジェクトが追加されること
- [ ] `cos watch-list add <project>` で重複は無視されること
- [ ] `cos watch-list remove <project>` でプロジェクトが削除されること
- [ ] `cos watch-list remove <存在しないproject>` で exit 4 になること
- [ ] `cos watch-list list` でウォッチリストが一覧表示されること
- [ ] `cos project search --watch-list <query>` でウォッチリストのプロジェクトに絞り込まれること
- [ ] `--watch-list` 指定時にウォッチリストが空なら exit 5 になること
- [ ] sandbox 違反 (exit 7) が各コマンドで正しく機能すること
- [ ] `autoWatchlist: true` の設定で --project アクセス時に自動追加されること

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)