### PR TITLE
docs: watch-list コマンドと project search フラグを README に反映する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ bun test                     # テスト全件 pass 必須
 1. `src/commands/<noun>/<verb>.ts` — 実装
 2. `tests/unit/commands/<noun>/<verb>.test.ts` — テスト
 3. alias がある場合は `src/cli.ts` の両方の登録箇所を更新
+4. `README.md` のコマンド一覧を更新する
+
+**コマンドの変更・削除時も同様に `README.md` を更新すること。**
 
 ### alias ルール
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ cos project list    参加プロジェクト一覧を取得
 cos project info    プロジェクト情報を取得
 cos project stream  プロジェクトの最近更新フィードを取得 (--watch でポーリング監視)
 cos project graph   ページ間リンクをグラフとして export する (DOT / JSON / TSV)
-cos project search  参加プロジェクト全体を横断してプロジェクトを検索する
+cos project search  参加プロジェクト全体を横断してプロジェクトを検索する (--watch-list でウォッチリスト絞り込み、--joined で参加プロジェクト全体を明示)
+
+cos watch-list list    ウォッチリストのプロジェクト一覧を表示する
+cos watch-list add     プロジェクトをウォッチリストに追加する
+cos watch-list remove  プロジェクトをウォッチリストから削除する
 
 cos search          全文検索 (--vector でベクトル検索、--infobox で infobox 定義ページを検索)
 
@@ -367,6 +371,8 @@ cos config set <key> <value>  # 設定値を保存
 |---|---|---|
 | `defaultProject` | string | `--project` 省略時のデフォルトプロジェクト名 (注: sandbox の権限解決では使用されない — `defaultPermission` はプロジェクトを明示指定した場合にのみ適用される) |
 | `defaultProfile` | string | 認証プロファイル名 (未設定: `"default"`) |
+| `watchlist` | string[] | ウォッチリストに登録されたプロジェクト名の一覧 (`cos watch-list` で管理) |
+| `autoWatchlist` | boolean | `true` にすると `--project` 指定時にそのプロジェクトをウォッチリストへ自動追加する |
 
 #### 出力設定 (`output`)
 


### PR DESCRIPTION
## Summary

- コマンド一覧に `cos watch-list list` / `cos watch-list add` / `cos watch-list remove` を追加（#151 で実装済み）
- `cos project search` の説明に `--watch-list` / `--joined` フラグを追記
- 設定リファレンスに `watchlist` / `autoWatchlist` キーを追加
- CLAUDE.md のコマンド追加ルールに「README.md を更新する」必須項目を追記

## Test plan

- [ ] README.md のコマンド一覧に `cos watch-list list/add/remove` が記載されていることを確認
- [ ] `cos project search` の説明に `--watch-list` / `--joined` が含まれていることを確認
- [ ] 設定リファレンスに `watchlist` / `autoWatchlist` が記載されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * ウォッチリスト管理コマンド（list/add/remove）をドキュメントに追加
  * プロジェクト検索機能の説明を更新（ウォッチリストおよび参加プロジェクトフィルター対応）
  * 設定リファレンスにウォッチリスト関連の新設定オプションを追記

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->