### PR TITLE
feat(page): update-links コマンドと cos page rename --update-links フラグを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ cos page edit           ページを編集 (楽観ロック付き)
 cos page append         ページ末尾に行を追記
 cos page prepend        ページ先頭 (タイトル直後) に行を挿入
 cos page insert         指定行の後ろに行を挿入 (--after <n>)
-cos page rename         ページタイトルを変更
+cos page rename         ページタイトルを変更 (--update-links でリネーム後に被リンクを一括更新)
+cos page update-links   プロジェクト内のリンクを一括置換する
 cos page pin            ページをピン留め
 cos page unpin          ページのピン留めを解除
 cos page watch          ページ更新をリアルタイム監視 (WebSocket)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -30,6 +30,7 @@ import { pageSnapshotListCommand } from "@/commands/page/snapshot/list"
 import { pageTableCommand } from "@/commands/page/table"
 import { pageTextCommand } from "@/commands/page/text"
 import { pageUnpinCommand } from "@/commands/page/unpin"
+import { pageUpdateLinksCommand } from "@/commands/page/update-links"
 import { pageUrlCommand } from "@/commands/page/url"
 import { pageWatchCommand } from "@/commands/page/watch"
 
@@ -121,6 +122,8 @@ export const pageCommand = defineCommand({
     insert: pageInsertCommand,
     rename: pageRenameCommand,
     mv: pageRenameCommand,
+    "update-links": pageUpdateLinksCommand,
+    "replace-links": pageUpdateLinksCommand,
     pin: pagePinCommand,
     unpin: pageUnpinCommand,
     icon: pageIconCommand,

--- a/src/commands/page/rename.ts
+++ b/src/commands/page/rename.ts
@@ -24,7 +24,7 @@ import {
   requireProject,
 } from "@/commands/_shared"
 import { EXIT_NOT_FOUND } from "@/core/exit-codes"
-import { renamePage } from "@/core/pages"
+import { renamePage, updateLinks } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
 
@@ -48,12 +48,18 @@ export const pageRenameCommand = defineCommand({
       description: "重複タイトル時に @cosense/std の suggestUnDupTitle による自動補正を許可する",
       default: false,
     },
+    "update-links": {
+      type: "boolean",
+      description: "リネーム後にプロジェクト内の被リンクを一括更新する",
+      default: false,
+    },
   },
   async run({ args }) {
     const a = args as WriteCommonArgs & {
       title: string
       "new-title": string
       "force-fallback": boolean
+      "update-links": boolean
     }
     checkSandbox("page.rename", a)
     const logger = buildLogger(a)
@@ -113,17 +119,33 @@ export const pageRenameCommand = defineCommand({
     }
 
     const writer = await buildWriter(a)
-    const result = await renamePage(writer, {
+    const renameResult = await renamePage(writer, {
       project,
       title: a.title,
       newTitle: a["new-title"],
     })
 
+    // --update-links: リネーム後に被リンクを一括更新する
+    let linksUpdated: number | undefined
+    if (a["update-links"] && !a["dry-run"]) {
+      const client = await buildRestClient(a)
+      const updateResult = await updateLinks(client, {
+        project,
+        from: a.title,
+        to: a["new-title"],
+      })
+      linksUpdated = updateResult.updatedCount
+    }
+
     if (a.json || a["dry-run"]) {
-      writeJson(result, { command: "page.rename", startTime }, buildJsonOpts(a))
+      const data = linksUpdated !== undefined ? { ...renameResult, linksUpdated } : renameResult
+      writeJson(data, { command: "page.rename", startTime }, buildJsonOpts(a))
       return
     }
 
     logger.success(`ページ "${a.title}" を "${a["new-title"]}" に変更しました`)
+    if (linksUpdated !== undefined) {
+      logger.success(`被リンクを ${linksUpdated} ページで更新しました`)
+    }
   },
 })

--- a/src/commands/page/update-links.ts
+++ b/src/commands/page/update-links.ts
@@ -1,0 +1,65 @@
+/**
+ * page/update-links.ts — `cos page update-links <from> <to>` コマンド。
+ *
+ * プロジェクト内の指定テキストで構成されているリンクを一括で新テキストに置換する。
+ * 主にページリネーム後に被リンクを更新するために使用する。
+ */
+
+import {
+  type WriteCommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  dryRunArg,
+  requireProject,
+} from "@/commands/_shared"
+import { updateLinks } from "@/core/pages"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+export const pageUpdateLinksCommand = defineCommand({
+  meta: { name: "update-links", description: "プロジェクト内のリンクを一括置換する" },
+  args: {
+    ...commonArgs,
+    ...dryRunArg,
+    from: {
+      type: "positional",
+      description: "置換元リンクテキスト",
+      required: true,
+    },
+    to: {
+      type: "positional",
+      description: "置換先リンクテキスト",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const a = args as WriteCommonArgs & { from: string; to: string }
+    checkSandbox("page.update-links", a)
+    const logger = buildLogger(a)
+    const project = requireProject(a)
+    const startTime = Date.now()
+
+    if (a["dry-run"]) {
+      writeJson(
+        { from: a.from, to: a.to, dryRun: true },
+        { command: "page.update-links", startTime },
+        buildJsonOpts(a),
+      )
+      logger.success(`"${a.from}" → "${a.to}" のリンク置換をプレビューしました (--dry-run)`)
+      return
+    }
+
+    const client = await buildRestClient(a)
+    const result = await updateLinks(client, { project, from: a.from, to: a.to })
+
+    writeJson(
+      { from: a.from, to: a.to, updatedCount: result.updatedCount },
+      { command: "page.update-links", startTime },
+      buildJsonOpts(a),
+    )
+    logger.success(`"${a.from}" → "${a.to}" を ${result.updatedCount} ページで更新しました`)
+  },
+})

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -281,6 +281,20 @@ export class CosenseRestClient {
     return PageSnapshotResultSchema.parse(data)
   }
 
+  /** replaceLinks は /api/pages/:project/replace/links を叩いてプロジェクト内リンクを一括置換する。 */
+  async replaceLinks(project: string, from: string, to: string): Promise<{ updatedCount: number }> {
+    // CSRF トークンを /api/users/me から取得する
+    const me = await this.getMe()
+    const data = await this.postJson(
+      `${BASE_URL}/api/pages/${encodeURIComponent(project)}/replace/links`,
+      JSON.stringify({ from, to }),
+      me.csrfToken,
+    )
+    const { message } = data as { message: string }
+    const updatedCount = Number.parseInt(message.match(/\d+/)?.[0] ?? "0")
+    return { updatedCount }
+  }
+
   /** getProjectStream は /api/stream/:project/ を叩いてプロジェクトの最近更新フィードを返す。 */
   async getProjectStream(project: string, opts: { limit?: number } = {}): Promise<StreamResponse> {
     const params = new URLSearchParams()
@@ -290,6 +304,27 @@ export class CosenseRestClient {
       `${BASE_URL}/api/stream/${encodeURIComponent(project)}/${query}`,
     )
     return StreamResponseSchema.parse(data)
+  }
+
+  private async postJson(url: string, body: string, csrfToken: string): Promise<unknown> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeout)
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          ...this.buildHeaders(),
+          "Content-Type": "application/json;charset=utf-8",
+          "X-CSRF-TOKEN": csrfToken,
+        },
+        body,
+        signal: controller.signal,
+      })
+      if (!response.ok) await this.handleError(response, url)
+      return response.json()
+    } finally {
+      clearTimeout(timer)
+    }
   }
 
   private buildHeaders(): Record<string, string> {

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -61,6 +61,7 @@ export const WRITE_COMMANDS: readonly string[] = [
   "page.prepend",
   "page.rename",
   "page.unpin",
+  "page.update-links",
   "serve.rest",
   "sync.push",
   "watch-list.add",

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -289,6 +289,14 @@ export async function deleteLinesFromPage(
   })
 }
 
+/** updateLinks はプロジェクト内のリンクテキストを一括置換する。 */
+export async function updateLinks(
+  client: CosenseRestClient,
+  opts: { project: string; from: string; to: string },
+) {
+  return client.replaceLinks(opts.project, opts.from, opts.to)
+}
+
 /** pinPage はページをピン留めする (WebSocket commit)。 */
 export async function pinPage(
   writer: ScrapboxWriter,

--- a/tests/unit/commands/page/rename.test.ts
+++ b/tests/unit/commands/page/rename.test.ts
@@ -4,9 +4,11 @@
  * 重複チェックおよびリネーム元 persistent チェックのロジックを検証する。
  * issue #57: persistent:false のスタブページを重複と誤判定しないよう修正。
  * issue #112: リネーム元が persistent:false/404 の場合に NOT_FOUND (exit 4) で終了する。
+ * issue #150: --update-links フラグでリネーム後に被リンクを一括更新する。
  *
  * - REST getPage は msw でモックする。
  * - WebSocket 書き込み (renamePage) は spyOn でモックして WS 接続を回避する。
+ * - updateLinks は spyOn でモックして REST 呼び出しを回避する。
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -43,6 +45,7 @@ afterAll(() => server.close())
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
 let renamePageSpy: ReturnType<typeof spyOn>
+let updateLinksSpy: ReturnType<typeof spyOn>
 
 /** コマンド run ヘルパー */
 async function runRename(args: Record<string, unknown>) {
@@ -71,12 +74,17 @@ beforeEach(() => {
     commitId: "ダミーコミットID",
     pageId: "ダミーページID",
   }))
+  // updateLinks をモックして REST 呼び出しを回避する
+  updateLinksSpy = spyOn(pages, "updateLinks").mockImplementation(async () => ({
+    updatedCount: 3,
+  }))
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock.mockRestore()
   renamePageSpy.mockRestore()
+  updateLinksSpy.mockRestore()
   server.resetHandlers()
   Reflect.deleteProperty(process.env, "COS_SID")
 })
@@ -557,5 +565,123 @@ describe("pageRenameCommand", () => {
     expect(stdoutOutput).toContain("NOT_FOUND")
     // persistent が不明なページへの rename は実行されない
     expect(renamePageSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// --update-links フラグのテスト (issue #150)
+// ---------------------------------------------------------------------------
+
+describe("pageRenameCommand --update-links", () => {
+  /** persistent:true の実体ページを返すハンドラーを設定する */
+  function setupPersistentPageHandler(project: string, title: string) {
+    server.use(
+      http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+        const p = decodeURIComponent(params["project"] as string)
+        const t = decodeURIComponent(params["title"] as string)
+        if (p === project && t === title) {
+          return HttpResponse.json({
+            id: "source-page-id",
+            title,
+            persistent: true,
+            created: 1700000000,
+            updated: 1700000000,
+            lines: [
+              { id: "l1", text: title, userId: "u1", created: 1700000000, updated: 1700000000 },
+            ],
+          })
+        }
+        // 新タイトルは存在しない (404)
+        return HttpResponse.json({ message: "Not found" }, { status: 404 })
+      }),
+    )
+  }
+
+  it("--update-links を指定するとリネーム後に updateLinks が呼ばれる", async () => {
+    setupPersistentPageHandler(TEST_PROJECT, "旧タイトル")
+
+    await runRename({
+      title: "旧タイトル",
+      "new-title": "新タイトル",
+      project: TEST_PROJECT,
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+      "force-fallback": false,
+      "update-links": true,
+    })
+
+    // renamePage が呼ばれていること
+    expect(renamePageSpy).toHaveBeenCalledTimes(1)
+    // updateLinks が正しい引数で呼ばれていること
+    expect(updateLinksSpy).toHaveBeenCalledTimes(1)
+    expect(updateLinksSpy).toHaveBeenCalledWith(
+      expect.objectContaining({}), // REST クライアント
+      { project: TEST_PROJECT, from: "旧タイトル", to: "新タイトル" },
+    )
+  })
+
+  it("--update-links なしの場合は updateLinks が呼ばれない", async () => {
+    setupPersistentPageHandler(TEST_PROJECT, "旧タイトル")
+
+    await runRename({
+      title: "旧タイトル",
+      "new-title": "新タイトル",
+      project: TEST_PROJECT,
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+      "force-fallback": false,
+      "update-links": false,
+    })
+
+    expect(renamePageSpy).toHaveBeenCalledTimes(1)
+    expect(updateLinksSpy).not.toHaveBeenCalled()
+  })
+
+  it("--dry-run 時は updateLinks が呼ばれない", async () => {
+    // 前提: --dry-run のとき DryRunWriter 経由で renamePage は呼ばれるが、
+    //       updateLinks はリネームが確定しないため呼ばれない。
+    await runRename({
+      title: "旧タイトル",
+      "new-title": "新タイトル",
+      project: TEST_PROJECT,
+      json: false,
+      plain: false,
+      "results-only": false,
+      "dry-run": true,
+      quiet: false,
+      "force-fallback": false,
+      "update-links": true,
+    })
+
+    // updateLinks は呼ばれない (--update-links && !dry-run の条件を満たさない)
+    expect(updateLinksSpy).not.toHaveBeenCalled()
+  })
+
+  it("--update-links 指定時の JSON 出力に linksUpdated が含まれる", async () => {
+    setupPersistentPageHandler(TEST_PROJECT, "旧タイトル")
+
+    await runRename({
+      title: "旧タイトル",
+      "new-title": "新タイトル",
+      project: TEST_PROJECT,
+      json: true,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+      "force-fallback": false,
+      "update-links": true,
+    })
+
+    const output = stdoutMock.mock.calls.flat().join("") as string
+    const parsed = JSON.parse(output)
+    // updateLinks スパイが updatedCount: 3 を返すため linksUpdated: 3 が含まれること
+    expect(parsed.data.linksUpdated).toBe(3)
   })
 })

--- a/tests/unit/commands/page/update-links.test.ts
+++ b/tests/unit/commands/page/update-links.test.ts
@@ -1,0 +1,141 @@
+/**
+ * page/update-links.test.ts — `cos page update-links <from> <to>` コマンドのテスト。
+ *
+ * updateLinks のロジックは REST クライアントを spyOn でモックして WS 接続を回避する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageUpdateLinksCommand } from "@/commands/page/update-links"
+import * as pages from "@/core/pages"
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+async function runUpdateLinks(args: Record<string, unknown>) {
+  await (
+    pageUpdateLinksCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// セットアップ
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let updateLinksSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+  updateLinksSpy = spyOn(pages, "updateLinks").mockImplementation(async () => ({
+    updatedCount: 5,
+  }))
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  updateLinksSpy.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("pageUpdateLinksCommand", () => {
+  it("プロジェクト未指定の場合は exit 5 で終了する", async () => {
+    try {
+      await runUpdateLinks({
+        from: "旧タイトル",
+        to: "新タイトル",
+        project: undefined,
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+  })
+
+  it("--dry-run 時は API を呼ばずに dryRun: true を出力する", async () => {
+    await runUpdateLinks({
+      from: "Node.js",
+      to: "Node",
+      project: "テストプロジェクト",
+      json: true,
+      plain: false,
+      "results-only": false,
+      "dry-run": true,
+      quiet: false,
+    })
+
+    // API 呼び出しなし
+    expect(updateLinksSpy).not.toHaveBeenCalled()
+
+    // JSON 出力に dryRun: true が含まれること
+    const output = stdoutMock.mock.calls.flat().join("") as string
+    const parsed = JSON.parse(output)
+    expect(parsed.data.dryRun).toBe(true)
+    expect(parsed.data.from).toBe("Node.js")
+    expect(parsed.data.to).toBe("Node")
+  })
+
+  it("正常実行時に updatedCount を含む JSON を出力する", async () => {
+    await runUpdateLinks({
+      from: "Node.js",
+      to: "Node",
+      project: "テストプロジェクト",
+      json: true,
+      plain: false,
+      "results-only": false,
+      "dry-run": false,
+      quiet: false,
+    })
+
+    expect(updateLinksSpy).toHaveBeenCalledTimes(1)
+
+    const output = stdoutMock.mock.calls.flat().join("") as string
+    const parsed = JSON.parse(output)
+    expect(parsed.data.from).toBe("Node.js")
+    expect(parsed.data.to).toBe("Node")
+    expect(parsed.data.updatedCount).toBe(5)
+  })
+
+  it("sandbox 違反の場合は exit 7 で終了する", async () => {
+    try {
+      await runUpdateLinks({
+        from: "旧タイトル",
+        to: "新タイトル",
+        project: "テストプロジェクト",
+        json: false,
+        plain: false,
+        "results-only": false,
+        "dry-run": false,
+        quiet: false,
+        "enable-commands": "page.list",
+      })
+    } catch {
+      // process.exit モック後の継続による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -460,6 +460,80 @@ describe("CosenseRestClient", () => {
     })
   })
 
+  describe("replaceLinks", () => {
+    beforeEach(() => {
+      // replaceLinks 用の POST ハンドラーを登録する (afterEach でリセットされる)
+      server.use(
+        http.post(`${BASE_URL}/api/pages/:project/replace/links`, async ({ request, params }) => {
+          const cookie = request.headers.get("Cookie")
+          if (!cookie?.includes("connect.sid")) {
+            return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+          }
+          if (params["project"] !== TEST_PROJECT) {
+            return HttpResponse.json({ message: "Not found" }, { status: 404 })
+          }
+          return HttpResponse.json({ message: "3 pages have been successfully updated!" })
+        }),
+      )
+    })
+
+    it("リンクを置換して更新ページ数を返す", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.replaceLinks(TEST_PROJECT, "旧タイトル", "新タイトル")
+      expect(result.updatedCount).toBe(3)
+    })
+
+    it("リクエストに X-CSRF-TOKEN ヘッダが付与されていること", async () => {
+      // me.json の csrfToken が X-CSRF-TOKEN として送信されることを検証する
+      let capturedCsrfToken = ""
+      server.use(
+        http.post(`${BASE_URL}/api/pages/:project/replace/links`, async ({ request }) => {
+          capturedCsrfToken = request.headers.get("X-CSRF-TOKEN") ?? ""
+          return HttpResponse.json({ message: "0 pages have been successfully updated!" })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await client.replaceLinks(TEST_PROJECT, "旧タイトル", "新タイトル")
+      expect(capturedCsrfToken).toBe("test-csrf-token-12345")
+    })
+
+    it("リクエストボディに from / to が含まれること", async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.post(`${BASE_URL}/api/pages/:project/replace/links`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({ message: "2 pages have been successfully updated!" })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await client.replaceLinks(TEST_PROJECT, "Node.js", "Node")
+      expect(capturedBody).toEqual({ from: "Node.js", to: "Node" })
+    })
+
+    it("更新ページ数 0 の場合は updatedCount: 0 を返す", async () => {
+      server.use(
+        http.post(`${BASE_URL}/api/pages/:project/replace/links`, async () => {
+          return HttpResponse.json({ message: "0 pages have been successfully updated!" })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      const result = await client.replaceLinks(TEST_PROJECT, "存在しないリンク", "新タイトル")
+      expect(result.updatedCount).toBe(0)
+    })
+
+    it("存在しないプロジェクトは NotFoundError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await expect(
+        client.replaceLinks("存在しないプロジェクト", "旧タイトル", "新タイトル"),
+      ).rejects.toThrow()
+    })
+
+    it("未認証の場合は AuthError をスローする", async () => {
+      const client = new CosenseRestClient({ sid: "" })
+      await expect(client.replaceLinks(TEST_PROJECT, "旧タイトル", "新タイトル")).rejects.toThrow()
+    })
+  })
+
   describe("Service Account 認証", () => {
     // テスト用 SA キー (cs_ + 64桁16進数)
     const TEST_SA_KEY = "cs_0000000000000000000000000000000000000000000000000000000000000001"

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -26,6 +26,7 @@ import {
   renamePage,
   replaceLinesInPage,
   unpinPage,
+  updateLinks,
 } from "@/core/pages"
 import { createTestWriter } from "../../helpers/scrapbox-writer"
 
@@ -687,5 +688,19 @@ describe("unpinPage", () => {
       project: "proj",
       title: "ピン解除ページ",
     })
+  })
+})
+
+describe("updateLinks", () => {
+  it("REST クライアントの replaceLinks を正しい引数で呼ぶ", async () => {
+    const replaceLinks = mock(async () => ({ updatedCount: 5 }))
+    const client = createMockRestClient({ replaceLinks })
+    const result = await updateLinks(client, {
+      project: "テストプロジェクト",
+      from: "Node.js",
+      to: "Node",
+    })
+    expect(replaceLinks).toHaveBeenCalledWith("テストプロジェクト", "Node.js", "Node")
+    expect(result.updatedCount).toBe(5)
   })
 })


### PR DESCRIPTION
## Summary

- `POST /api/pages/:project/replace/links` を叩く `CosenseRestClient.replaceLinks` を実装
- `cos page update-links <from> <to>` コマンドを新規追加（`replace-links` alias あり）
- `cos page rename` に `--update-links` フラグを追加し、リネーム後の被リンク一括置換を可能にする

## 背景

Cosense UI には、ページをリネームする際に「被リンクを一括更新するか？」を確認するダイアログがある（issue #150）。本 PR でこの "Update links" 機能を coscli に実装する。

## 変更内容

### 新規追加
- `src/commands/page/update-links.ts` — `cos page update-links <from> <to>` コマンド
- `tests/unit/commands/page/update-links.test.ts` — 上記テスト

### 修正
- `src/core/api/rest.ts` — `replaceLinks` メソッドと `postJson` プライベートメソッドを追加
- `src/core/pages.ts` — `updateLinks` ユースケース関数を追加
- `src/commands/page/rename.ts` — `--update-links` フラグを追加
- `src/commands/index.ts` — `update-links` / `replace-links` コマンドを登録
- `src/core/command-classification.ts` — `page.update-links` を `WRITE_COMMANDS` に追加
- `README.md` — コマンド一覧に `cos page update-links` を追記

## Test plan

- [x] `bun test` 全テストパス (1379 pass, 0 fail)
- [x] `bunx biome check` Lint エラーゼロ
- [x] `bun run typecheck` 型エラーゼロ

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)