### PR TITLE
feat(page): cos page list に --pinned フラグを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cos page new --project myproject --title "新しいページ" --body "本文"
 ## コマンド一覧
 
 ```
-cos page list           ページ一覧を取得
+cos page list           ページ一覧を取得 (--pinned でピン留めページのみ表示)
 cos page get            ページ本文を取得
 cos page text           ページのテキスト (コードブロックなし) を取得
 cos page context        ページ起点の Smart Context (リンク先本文) を取得

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -3,6 +3,7 @@
  *
  * プロジェクトのページ一覧を取得して出力する。
  * --json で envelope 形式、--plain で TSV 出力。
+ * --pinned でピン留めページのみに絞り込む（クライアントサイドフィルタ）。
  */
 
 import {
@@ -35,63 +36,84 @@ export const pageListCommand = defineCommand({
       type: "string",
       description: "ソート順 (updated/created/accessed/pageRank/links/views/title)",
     },
+    pinned: {
+      type: "boolean",
+      description: "ピン留めされたページのみ表示する",
+      default: false,
+    },
   },
   async run({ args }) {
-    const commonArgs = args as CommonArgs & { limit?: string; skip?: string; sort?: string }
-    checkSandbox("page.list", commonArgs)
-    const project = requireProject(commonArgs)
+    const a = args as CommonArgs & {
+      limit?: string
+      skip?: string
+      sort?: string
+      pinned?: boolean
+    }
+    checkSandbox("page.list", a)
+    const project = requireProject(a)
     const startTime = Date.now()
 
     const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
 
+    let limitNum: number | undefined
+
     // --limit バリデーション: 10進数整数のみ許可 (指数表記・16進数を除外、認証前に弾く)
-    if (commonArgs.limit !== undefined) {
-      if (!/^\d+$/.test(commonArgs.limit)) {
+    if (a.limit !== undefined) {
+      if (!/^\d+$/.test(a.limit)) {
         writeErrorJson(
           "VALIDATION_ERROR",
-          `--limit の値が無効です: "${commonArgs.limit}"`,
+          `--limit の値が無効です: "${a.limit}"`,
           "1 以上の整数を指定してください",
         )
         exitWithError(5, "VALIDATION_ERROR")
       }
-      const limit = Number(commonArgs.limit)
+      const limit = Number(a.limit)
       if (limit < 1) {
         writeErrorJson(
           "VALIDATION_ERROR",
-          `--limit の値が無効です: "${commonArgs.limit}"`,
+          `--limit の値が無効です: "${a.limit}"`,
           "1 以上の整数を指定してください",
         )
         exitWithError(5, "VALIDATION_ERROR")
       }
-      listOpts.limit = limit
+      limitNum = limit
+      // --pinned 時はクライアントサイドでフィルタするため API には limit を渡さない
+      if (!a.pinned) listOpts.limit = limitNum
     }
 
     // --skip バリデーション: 10進数整数のみ許可 (0 はスキップなしとして有効、認証前に弾く)
-    if (commonArgs.skip !== undefined) {
-      if (!/^\d+$/.test(commonArgs.skip)) {
+    if (a.skip !== undefined) {
+      if (!/^\d+$/.test(a.skip)) {
         writeErrorJson(
           "VALIDATION_ERROR",
-          `--skip の値が無効です: "${commonArgs.skip}"`,
+          `--skip の値が無効です: "${a.skip}"`,
           "0 以上の整数を指定してください",
         )
         exitWithError(5, "VALIDATION_ERROR")
       }
-      listOpts.skip = Number(commonArgs.skip)
+      listOpts.skip = Number(a.skip)
     }
 
-    if (commonArgs.sort) listOpts.sort = commonArgs.sort
-    const client = await buildRestClient(commonArgs)
+    if (a.sort) listOpts.sort = a.sort
+    const client = await buildRestClient(a)
     const result = await listPages(client, listOpts)
 
-    if (commonArgs.json) {
-      writeJson(result, { command: "page.list", startTime }, buildJsonOpts(commonArgs))
+    // --pinned フィルタ: pin > 0 のページのみ残し、limit はフィルタ後に適用する
+    let pages = result.pages
+    if (a.pinned) {
+      pages = pages.filter((p) => (p.pin ?? 0) > 0)
+      if (limitNum !== undefined) pages = pages.slice(0, limitNum)
+    }
+
+    if (a.json) {
+      writeJson({ ...result, pages }, { command: "page.list", startTime }, buildJsonOpts(a))
       return
     }
 
-    if (commonArgs.plain) {
+    if (a.plain) {
       writeTsv(
         ["title", "updated", "views", "linked"],
-        result.pages.map((p) => [
+        pages.map((p) => [
           p.title,
           new Date(p.updated * 1000).toISOString(),
           String(p.views),
@@ -103,7 +125,7 @@ export const pageListCommand = defineCommand({
 
     writePlainTable(
       ["タイトル", "更新日時", "閲覧数", "被リンク"],
-      result.pages.map((p) => [
+      pages.map((p) => [
         p.title,
         new Date(p.updated * 1000).toLocaleString("ja-JP"),
         String(p.views),

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -10,6 +10,58 @@ import { pageListCommand } from "@/commands/page/list"
 import * as pages from "@/core/pages"
 import pageListFixture from "../../../fixtures/page-list.json"
 
+/** ピン留めテスト用フィクスチャ: pin: 0 が2件 + pin > 0 が1件 */
+const pinnedPageListFixture = {
+  projectName: "テストプロジェクト",
+  skip: 0,
+  limit: 30,
+  count: 3,
+  pages: [
+    {
+      id: "page-id-hello",
+      title: "Hello World",
+      image: null,
+      descriptions: ["最初の行", "2行目"],
+      user: { id: "user-id-1" },
+      pin: 0,
+      views: 10,
+      linked: 3,
+      created: 1700000000,
+      updated: 1700100000,
+      accessed: 1700200000,
+      snapshotCreated: null,
+    },
+    {
+      id: "page-id-japanese",
+      title: "日本語タイトル",
+      image: null,
+      descriptions: ["日本語の説明文"],
+      user: { id: "user-id-1" },
+      pin: 0,
+      views: 5,
+      linked: 0,
+      created: 1700050000,
+      updated: 1700150000,
+      accessed: 1700250000,
+      snapshotCreated: null,
+    },
+    {
+      id: "page-id-pinned",
+      title: "ピン留めページ",
+      image: null,
+      descriptions: ["ピン留めされたページの説明"],
+      user: { id: "user-id-1" },
+      pin: 1700000001,
+      views: 20,
+      linked: 5,
+      created: 1700000000,
+      updated: 1700100001,
+      accessed: 1700200001,
+      snapshotCreated: null,
+    },
+  ],
+}
+
 /** listPages に渡された opts をキャプチャする */
 const capturedListPagesCalls: { limit?: number; skip?: number }[] = []
 
@@ -219,6 +271,138 @@ describe("pageListCommand", () => {
       expect(exitMock).not.toHaveBeenCalled()
       expect(capturedListPagesCalls).toHaveLength(1)
       expect(capturedListPagesCalls[0]?.limit).toBe(100)
+    })
+  })
+
+  describe("--pinned フィルタリング", () => {
+    beforeEach(() => {
+      // ピン留めテスト専用フィクスチャ（pin: 0 × 2件 + pin > 0 × 1件）を返すよう上書きする
+      listPagesSpy.mockImplementation(
+        async (
+          _client: Parameters<typeof pages.listPages>[0],
+          opts: Parameters<typeof pages.listPages>[1],
+        ) => {
+          const captured: { limit?: number; skip?: number } = {}
+          if (opts.limit !== undefined) captured.limit = opts.limit
+          if (opts.skip !== undefined) captured.skip = opts.skip
+          capturedListPagesCalls.push(captured)
+          return pinnedPageListFixture
+        },
+      )
+    })
+
+    it("--pinned なしのとき pin: 0 のページも含む全ページが出力される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          pinned: false,
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      expect(output).toContain("Hello World")
+      expect(output).toContain("日本語タイトル")
+      expect(output).toContain("ピン留めページ")
+    })
+
+    it("--pinned ありのとき pin > 0 のページのみ出力される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          pinned: true,
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      // pin > 0 のページのみ出力される
+      expect(output).toContain("ピン留めページ")
+      // pin: 0 のページは除外される
+      expect(output).not.toContain("Hello World")
+      expect(output).not.toContain("日本語タイトル")
+    })
+
+    it("--pinned + --limit 1 のとき pin フィルタ後に limit が適用される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "1",
+          skip: undefined,
+          sort: undefined,
+          pinned: true,
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      expect(output).toContain("ピン留めページ")
+    })
+
+    it("--pinned のとき API 呼び出しに limit が渡らない", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "5",
+          skip: undefined,
+          sort: undefined,
+          pinned: true,
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      // --pinned 時はクライアントサイドでフィルタするため API には limit を渡さない
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.limit).toBeUndefined()
+    })
+
+    it("--pinned + --json のとき JSON 出力の pages にピン留めページのみ含まれる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          pinned: true,
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls as string[][]).map((c) => c[0]).join("")
+      const parsed = JSON.parse(output) as { data: { pages: { title: string }[] } }
+      expect(parsed.data.pages).toHaveLength(1)
+      expect(parsed.data.pages[0]?.title).toBe("ピン留めページ")
     })
   })
 


### PR DESCRIPTION
## Summary

- `cos page list --pinned` でピン留めされたページのみを表示するフィルタリング機能を追加
- フィルタはクライアントサイドで実施（Cosense の page list API は pin フィルタをサポートしていないため）
- `--limit` との併用時は pin フィルタ後に件数制限を適用する（`--infobox` の limit 適用パターンと同様）
- ピン留め判定: `pin > 0`（`pin` は Unix timestamp、0 または未設定は未ピン留め）

## Test plan

- [x] `--pinned` なし: 全ページが出力される
- [x] `--pinned` あり: `pin > 0` のページのみ出力される
- [x] `--pinned` + `--limit N`: pin フィルタ後に limit が適用される
- [x] `--pinned` 指定時は API 呼び出しに `limit` が渡らない
- [x] `--pinned` + `--json`: JSON 出力の `pages` にピン留めページのみ含まれる
- [x] 型チェック・Lint・全テスト（1384件）パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `page list` コマンドに `--pinned` オプションを追加しました。ピン留めされたページのみを表示できるようになります。

* **Documentation**
  * `cos page list` コマンドの説明文を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->