### PR TITLE
fix(page): cos page list --sort の誤記修正・updatedWithMe 追加・バリデーション実装

### DIFF
--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -20,6 +20,18 @@ import { writeErrorJson, writeJson } from "@/presenter/json"
 import { writePlainTable, writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
+/** --sort に指定できる有効な値 */
+const VALID_SORT_VALUES = [
+  "updated",
+  "created",
+  "accessed",
+  "pageRank",
+  "linked",
+  "views",
+  "title",
+  "updatedWithMe",
+] as const
+
 export const pageListCommand = defineCommand({
   meta: { name: "list", description: "ページ一覧を取得する" },
   args: {
@@ -34,7 +46,7 @@ export const pageListCommand = defineCommand({
     },
     sort: {
       type: "string",
-      description: "ソート順 (updated/created/accessed/pageRank/links/views/title)",
+      description: "ソート順 (updated/created/accessed/pageRank/linked/views/title/updatedWithMe)",
     },
     pinned: {
       type: "boolean",
@@ -94,6 +106,15 @@ export const pageListCommand = defineCommand({
       listOpts.skip = Number(a.skip)
     }
 
+    // --sort バリデーション: 許可された値のみ受け付ける
+    if (a.sort !== undefined && !(VALID_SORT_VALUES as readonly string[]).includes(a.sort)) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--sort=${a.sort} は無効な値です`,
+        `有効な値: ${VALID_SORT_VALUES.join(", ")}`,
+      )
+      exitWithError(5, "VALIDATION_ERROR")
+    }
     if (a.sort) listOpts.sort = a.sort
     const client = await buildRestClient(a)
     const result = await listPages(client, listOpts)

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -486,4 +486,64 @@ describe("pageListCommand", () => {
       expect(capturedListPagesCalls[0]?.skip).toBe(0)
     })
   })
+
+  describe("--sort のバリデーション", () => {
+    it("--sort invalid (無効な値) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: "invalid",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("invalid"))
+    })
+
+    it("--sort linked (有効な値) は正常動作し API が呼び出される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: "linked",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(listPagesSpy).toHaveBeenCalled()
+    })
+
+    it("--sort updatedWithMe (有効な値) は正常動作し API が呼び出される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: "updatedWithMe",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(listPagesSpy).toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- `--sort` ヘルプの誤記 `links` を正しい API 値 `linked` に修正
- `updatedWithMe`（更新日時・自分の変更含む）を有効なソート値として追加
- 無効な値を渡した場合に `VALIDATION_ERROR` (exit 5) を返すバリデーションを追加

## Changes

### `src/commands/page/list.ts`
- `VALID_SORT_VALUES` 定数を追加（`updated` / `created` / `accessed` / `pageRank` / `linked` / `views` / `title` / `updatedWithMe`）
- `--sort` フラグの description を修正（`links` → `linked`、`updatedWithMe` 追加）
- 無効な値に対するバリデーションブロックを追加

### `tests/unit/commands/page/list.test.ts`
- `--sort invalid` → VALIDATION_ERROR (exit 5) のテスト追加
- `--sort linked` → 正常動作のテスト追加
- `--sort updatedWithMe` → 正常動作のテスト追加

## Test plan

- [ ] `cos page list --sort invalid` → VALIDATION_ERROR / exit 5
- [ ] `cos page list --sort links`（旧誤記）→ VALIDATION_ERROR / exit 5
- [ ] `cos page list --sort linked` → 正常動作
- [ ] `cos page list --sort updatedWithMe` → 正常動作
- [ ] `bun test` 全件パス（1387 pass / 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)