### PR TITLE
feat(page): cos page list に --icon フラグを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cos page new --project myproject --title "新しいページ" --body "本文"
 ## コマンド一覧
 
 ```
-cos page list           ページ一覧を取得 (--pinned でピン留めページのみ表示)
+cos page list           ページ一覧を取得 (--pinned でピン留めページのみ表示、--icon <name> でアイコンフィルタ)
 cos page get            ページ本文を取得
 cos page text           ページのテキスト (コードブロックなし) を取得
 cos page context        ページ起点の Smart Context (リンク先本文) を取得

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -4,6 +4,7 @@
  * プロジェクトのページ一覧を取得して出力する。
  * --json で envelope 形式、--plain で TSV 出力。
  * --pinned でピン留めページのみに絞り込む（クライアントサイドフィルタ）。
+ * --icon でアイコンが含まれるページのみに絞り込む（サーバーサイドフィルタ）。
  */
 
 import {
@@ -53,6 +54,10 @@ export const pageListCommand = defineCommand({
       description: "ピン留めされたページのみ表示する",
       default: false,
     },
+    icon: {
+      type: "string",
+      description: "指定したアイコンが含まれるページのみ表示する (例: --icon mtane0412)",
+    },
   },
   async run({ args }) {
     const a = args as CommonArgs & {
@@ -60,12 +65,19 @@ export const pageListCommand = defineCommand({
       skip?: string
       sort?: string
       pinned?: boolean
+      icon?: string
     }
     checkSandbox("page.list", a)
     const project = requireProject(a)
     const startTime = Date.now()
 
-    const listOpts: { project: string; limit?: number; skip?: number; sort?: string } = { project }
+    const listOpts: {
+      project: string
+      limit?: number
+      skip?: number
+      sort?: string
+      filterValue?: string
+    } = { project }
 
     let limitNum: number | undefined
 
@@ -116,6 +128,18 @@ export const pageListCommand = defineCommand({
       exitWithError(5, "VALIDATION_ERROR")
     }
     if (a.sort) listOpts.sort = a.sort
+
+    // --icon バリデーション: 空文字は不正（認証前に弾く）
+    if (a.icon !== undefined && a.icon.trim() === "") {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "--icon の値が無効です",
+        "アイコン名を指定してください (例: --icon mtane0412)",
+      )
+      exitWithError(5, "VALIDATION_ERROR")
+    }
+    if (a.icon) listOpts.filterValue = a.icon
+
     const client = await buildRestClient(a)
     const result = await listPages(client, listOpts)
 

--- a/src/commands/page/list.ts
+++ b/src/commands/page/list.ts
@@ -129,8 +129,9 @@ export const pageListCommand = defineCommand({
     }
     if (a.sort) listOpts.sort = a.sort
 
-    // --icon バリデーション: 空文字は不正（認証前に弾く）
-    if (a.icon !== undefined && a.icon.trim() === "") {
+    // --icon バリデーション: 空文字・空白のみは不正（認証前に弾く）
+    const normalizedIcon = a.icon?.trim()
+    if (normalizedIcon !== undefined && normalizedIcon === "") {
       writeErrorJson(
         "VALIDATION_ERROR",
         "--icon の値が無効です",
@@ -138,7 +139,7 @@ export const pageListCommand = defineCommand({
       )
       exitWithError(5, "VALIDATION_ERROR")
     }
-    if (a.icon) listOpts.filterValue = a.icon
+    if (normalizedIcon) listOpts.filterValue = normalizedIcon
 
     const client = await buildRestClient(a)
     const result = await listPages(client, listOpts)

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -119,12 +119,16 @@ export class CosenseRestClient {
   /** listPages は /api/pages/:project を叩いてページ一覧を返す。 */
   async listPages(
     project: string,
-    opts: { skip?: number; limit?: number; sort?: string } = {},
+    opts: { skip?: number; limit?: number; sort?: string; filterValue?: string } = {},
   ): Promise<PageListResponse> {
     const params = new URLSearchParams()
     if (opts.skip !== undefined) params.set("skip", String(opts.skip))
     if (opts.limit !== undefined) params.set("limit", String(opts.limit))
     if (opts.sort) params.set("sort", opts.sort)
+    if (opts.filterValue) {
+      params.set("filterType", "icon")
+      params.set("filterValue", opts.filterValue)
+    }
     const query = params.size > 0 ? `?${params.toString()}` : ""
     const data = await this.fetchJson(
       `${BASE_URL}/api/pages/${encodeURIComponent(project)}${query}`,

--- a/src/core/pages.ts
+++ b/src/core/pages.ts
@@ -12,7 +12,7 @@ import { CommitConflictError, PageLineError } from "@/core/errors"
 /** listPages はプロジェクトのページ一覧を取得する。 */
 export async function listPages(
   client: CosenseRestClient,
-  opts: { project: string; limit?: number; skip?: number; sort?: string },
+  opts: { project: string; limit?: number; skip?: number; sort?: string; filterValue?: string },
 ) {
   const { project, ...restOpts } = opts
   return client.listPages(project, restOpts)

--- a/src/core/server/rest.ts
+++ b/src/core/server/rest.ts
@@ -192,6 +192,7 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
         const skipStr = url.searchParams.get("skip")
         const limitStr = url.searchParams.get("limit")
         const sort = url.searchParams.get("sort") ?? undefined
+        const filterValue = url.searchParams.get("filterValue") ?? undefined
 
         // skip/limit は整数文字列のみ許可（parseInt は先頭数値を通すため正規表現で検証）
         const intPattern = /^-?\d+$/
@@ -221,6 +222,7 @@ export function createFetchHandler(ctx: ServerContext): (req: Request) => Promis
           ...(skip !== undefined ? { skip } : {}),
           ...(limit !== undefined ? { limit } : {}),
           ...(sort !== undefined ? { sort } : {}),
+          ...(filterValue !== undefined ? { filterValue } : {}),
         })
         return buildOkResponse(result)
       }

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -63,7 +63,7 @@ const pinnedPageListFixture = {
 }
 
 /** listPages に渡された opts をキャプチャする */
-const capturedListPagesCalls: { limit?: number; skip?: number }[] = []
+const capturedListPagesCalls: { limit?: number; skip?: number; filterValue?: string }[] = []
 
 let exitMock: ReturnType<typeof spyOn>
 let stdoutMock: ReturnType<typeof spyOn>
@@ -98,9 +98,10 @@ beforeEach(() => {
   capturedListPagesCalls.length = 0
   listPagesSpy = spyOn(pages, "listPages").mockImplementation(async (_client, opts) => {
     // exactOptionalPropertyTypes: true のためオプショナルプロパティへは条件付き代入を使う
-    const captured: { limit?: number; skip?: number } = {}
+    const captured: { limit?: number; skip?: number; filterValue?: string } = {}
     if (opts.limit !== undefined) captured.limit = opts.limit
     if (opts.skip !== undefined) captured.skip = opts.skip
+    if (opts.filterValue !== undefined) captured.filterValue = opts.filterValue
     capturedListPagesCalls.push(captured)
     return pageListFixture
   })
@@ -544,6 +545,72 @@ describe("pageListCommand", () => {
       }
       expect(exitMock).not.toHaveBeenCalled()
       expect(listPagesSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe("--icon フラグ", () => {
+    it("--icon mtane0412 を指定すると filterValue: 'mtane0412' が API に渡される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          icon: "mtane0412",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.filterValue).toBe("mtane0412")
+    })
+
+    it("--icon '' (空文字) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          icon: "",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+    })
+
+    it("--icon と --limit を同時指定した場合、filterValue と limit の両方が API に渡される", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: "5",
+          skip: undefined,
+          sort: undefined,
+          icon: "mtane0412",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      expect(exitMock).not.toHaveBeenCalled()
+      expect(capturedListPagesCalls).toHaveLength(1)
+      expect(capturedListPagesCalls[0]?.filterValue).toBe("mtane0412")
+      // --icon はサーバーサイドフィルタなので limit も API に渡される
+      expect(capturedListPagesCalls[0]?.limit).toBe(5)
     })
   })
 })

--- a/tests/unit/commands/page/list.test.ts
+++ b/tests/unit/commands/page/list.test.ts
@@ -590,6 +590,28 @@ describe("pageListCommand", () => {
       expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
     })
 
+    it("--icon '   ' (空白のみ) は VALIDATION_ERROR で exit 5 になる", async () => {
+      try {
+        await runList({
+          project: "テストプロジェクト",
+          limit: undefined,
+          skip: undefined,
+          sort: undefined,
+          icon: "   ",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // process.exit モック後の継続による throw は想定内
+      }
+      expect(exitMock).toHaveBeenCalledWith(5)
+      expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("VALIDATION_ERROR"))
+      // バリデーションで弾かれているため API は呼ばれない
+      expect(capturedListPagesCalls).toHaveLength(0)
+    })
+
     it("--icon と --limit を同時指定した場合、filterValue と limit の両方が API に渡される", async () => {
       try {
         await runList({

--- a/tests/unit/core/api/rest.test.ts
+++ b/tests/unit/core/api/rest.test.ts
@@ -223,6 +223,44 @@ describe("CosenseRestClient", () => {
       const client = new CosenseRestClient({ sid: TEST_SID })
       await expect(client.listPages("存在しないプロジェクト")).rejects.toThrow()
     })
+
+    it("filterValue 指定時に filterType=icon&filterValue=<value> がリクエスト URL に含まれる", async () => {
+      // await 後の TypeScript の変数フロー解析問題を回避するため配列でキャプチャする
+      const capturedUrls: URL[] = []
+      server.use(
+        http.get(`${BASE_URL}/api/pages/:project`, ({ request, params }) => {
+          capturedUrls.push(new URL(request.url))
+          if (params["project"] === TEST_PROJECT) {
+            return HttpResponse.json(pageListFixture)
+          }
+          return HttpResponse.json({ message: "Not found" }, { status: 404 })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await client.listPages(TEST_PROJECT, { filterValue: "mtane0412" })
+      const capturedUrl = capturedUrls[0]
+      expect(capturedUrl?.searchParams.get("filterType")).toBe("icon")
+      expect(capturedUrl?.searchParams.get("filterValue")).toBe("mtane0412")
+    })
+
+    it("filterValue 未指定時に filterType および filterValue がリクエスト URL に含まれない", async () => {
+      // await 後の TypeScript の変数フロー解析問題を回避するため配列でキャプチャする
+      const capturedUrls: URL[] = []
+      server.use(
+        http.get(`${BASE_URL}/api/pages/:project`, ({ request, params }) => {
+          capturedUrls.push(new URL(request.url))
+          if (params["project"] === TEST_PROJECT) {
+            return HttpResponse.json(pageListFixture)
+          }
+          return HttpResponse.json({ message: "Not found" }, { status: 404 })
+        }),
+      )
+      const client = new CosenseRestClient({ sid: TEST_SID })
+      await client.listPages(TEST_PROJECT)
+      const capturedUrl = capturedUrls[0]
+      expect(capturedUrl?.searchParams.has("filterType")).toBe(false)
+      expect(capturedUrl?.searchParams.has("filterValue")).toBe(false)
+    })
   })
 
   describe("getPage", () => {

--- a/tests/unit/core/pages.test.ts
+++ b/tests/unit/core/pages.test.ts
@@ -118,6 +118,12 @@ describe("listPages", () => {
     await listPages(client, { project: "proj", limit: 5, sort: "updated" })
     expect(client.listPages).toHaveBeenCalledWith("proj", { limit: 5, sort: "updated" })
   })
+
+  it("filterValue オプションを REST クライアントに渡す", async () => {
+    const client = createMockRestClient()
+    await listPages(client, { project: "proj", filterValue: "mtane0412" })
+    expect(client.listPages).toHaveBeenCalledWith("proj", { filterValue: "mtane0412" })
+  })
 })
 
 describe("getPage", () => {


### PR DESCRIPTION
## Summary

- `cos page list --icon <username>` フラグを追加
- Cosense REST API の `filterType=icon&filterValue=<username>` サーバーサイドフィルタを利用し、指定アイコンを含むページのみを返す
- 空文字・空白のみを渡した場合は exit code 5 の `VALIDATION_ERROR` で早期失敗
- `--limit` と組み合わせると limit も API に渡される（`--pinned` のクライアントサイドフィルタとは異なる）

## Background

Cosense の Web UI にアイコンフィルター機能が追加された（ソートメニューから特定ユーザーのアイコンを含むページのみ表示する機能）。`@cosense/std` v0.31.0 では `ListPagesOption.filterValue` として既に実装済みだったが、coscli 側が未対応だった。

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/core/api/rest.ts` | `listPages` opts に `filterValue?: string` 追加、`filterType=icon&filterValue=<value>` クエリ構築 |
| `src/core/pages.ts` | `listPages` 関数に `filterValue?: string` 追加・passthrough |
| `src/commands/page/list.ts` | `--icon` フラグ追加・空文字バリデーション |
| `src/core/server/rest.ts` | REST プロキシに `filterValue` パース追加 |
| テスト 3ファイル | TDD: RED → GREEN で各層のテストを追加 |
| `README.md` | コマンド一覧を更新 |

## Test plan

- [x] `--icon mtane0412` → `filterValue: "mtane0412"` が API に渡ること
- [x] `--icon ""` → exit 5 / VALIDATION_ERROR
- [x] `--icon` + `--limit` → limit も API に渡されること
- [x] `filterValue` 指定時に `filterType=icon&filterValue=<value>` がリクエスト URL に含まれること
- [x] `filterValue` 未指定時にこれらのパラメータが含まれないこと
- [x] 実機で `cos page list -p villagepump --icon mtane0412 --limit 3 --json` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `cos page list` コマンドに `--icon` オプションを追加しました。指定したアイコンを含むページのみをフィルタリングして表示できます。

* **ドキュメント**
  * `cos page list` コマンドのヘルプにアイコンフィルタ機能の説明を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->