### PR TITLE
fix(plain): page history と page snapshot list の --plain 出力を TSV に統一する

### DIFF
--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -17,6 +17,7 @@ import {
 } from "@/commands/_shared"
 import { getPage, getPageCommits } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 /** pageHistoryCommand はページのコミット履歴を取得するコマンドを返す。 */
@@ -94,13 +95,16 @@ export const pageHistoryCommand = defineCommand({
         return
       }
 
-      // plain 出力: 1 コミット 1 行
-      for (const commit of commits) {
-        const date = new Date(commit.created * 1000).toISOString().replace("T", " ").slice(0, 19)
-        process.stdout.write(
-          `${commit.id}  ${date}  user=${commit.userId}  changes=${commit.changes.length}\n`,
-        )
-      }
+      // plain 出力: TSV（ヘッダー行 + データ行）
+      writeTsv(
+        ["id", "created", "userId", "changes"],
+        commits.map((c) => [
+          c.id,
+          new Date(c.created * 1000).toISOString(),
+          c.userId,
+          String(c.changes.length),
+        ]),
+      )
     } catch (err) {
       handleRestError(err, { resourceKind: "page", resourceName: a.title })
       throw err

--- a/src/commands/page/snapshot/list.ts
+++ b/src/commands/page/snapshot/list.ts
@@ -17,6 +17,7 @@ import {
 } from "@/commands/_shared"
 import { getPage, getPageSnapshotList } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeTsv } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
 /** pageSnapshotListCommand はページのスナップショット一覧を取得するコマンドを返す。 */
@@ -64,11 +65,11 @@ export const pageSnapshotListCommand = defineCommand({
         return
       }
 
-      // plain 出力: 1 スナップショット 1 行 (<timestampId>  <YYYY-MM-DD HH:MM:SS>)
-      for (const ts of snapshotList.timestamps) {
-        const date = new Date(ts.created * 1000).toISOString().replace("T", " ").slice(0, 19)
-        process.stdout.write(`${ts.id}  ${date}\n`)
-      }
+      // plain 出力: TSV（ヘッダー行 + データ行）
+      writeTsv(
+        ["id", "created"],
+        snapshotList.timestamps.map((ts) => [ts.id, new Date(ts.created * 1000).toISOString()]),
+      )
     } catch (err) {
       handleRestError(err, { resourceKind: "page", resourceName: a.title })
       throw err

--- a/tests/unit/commands/page/history.test.ts
+++ b/tests/unit/commands/page/history.test.ts
@@ -202,6 +202,25 @@ describe("pageHistoryCommand", () => {
     })
   })
 
+  describe("--plain フラグ", () => {
+    it("--plain で TSV 形式（ヘッダー行 + データ行）が出力される", async () => {
+      try {
+        await runHistory({ ...defaultArgs, json: false, plain: true })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      // writeTsv: ヘッダー1行 + フィクスチャ3件 = 4回 write が呼ばれる
+      const writtenLines = stdoutMock.mock.calls.map((c: unknown[]) => c[0] as string)
+      expect(writtenLines).toHaveLength(4)
+      // ヘッダー行はタブ区切りの列名
+      expect(writtenLines[0]).toBe("id\tcreated\tuserId\tchanges\n")
+      // データ行はタブ区切りの id、ISO 8601 日時、userId、changes 数
+      expect(writtenLines[1]).toMatch(/^commit-id-2\t20\d{2}-/)
+    })
+  })
+
   describe("エラー系", () => {
     it("project 未指定は PROJECT_REQUIRED で exit 5 になる", async () => {
       try {

--- a/tests/unit/commands/page/snapshot/list.test.ts
+++ b/tests/unit/commands/page/snapshot/list.test.ts
@@ -120,7 +120,7 @@ describe("pageSnapshotListCommand", () => {
       expect(snapshotOpts.pageId).toBe(pageDetailFixture.id)
     })
 
-    it("--plain で <timestampId>  <日時> 形式の行が 1 件ずつ出力される", async () => {
+    it("--plain で TSV 形式（ヘッダー行 + データ行）が出力される", async () => {
       try {
         await runSnapshotList({ ...defaultArgs, json: false, plain: true })
       } catch {
@@ -129,11 +129,13 @@ describe("pageSnapshotListCommand", () => {
 
       expect(exitMock).not.toHaveBeenCalled()
 
-      // stdout.write が各スナップショット分 (3件) 呼ばれた
+      // writeTsv: ヘッダー1行 + フィクスチャ3件 = 4回 write が呼ばれる
       const writtenLines = stdoutMock.mock.calls.map((c: unknown[]) => c[0] as string)
-      expect(writtenLines).toHaveLength(3)
-      // 1 件目は "1700000000-snap2  2023-11-14 ..." 形式
-      expect(writtenLines[0]).toMatch(/^1700000000-snap2\s+20\d{2}-/)
+      expect(writtenLines).toHaveLength(4)
+      // ヘッダー行はタブ区切りの列名
+      expect(writtenLines[0]).toBe("id\tcreated\n")
+      // データ行はタブ区切りの id と ISO 8601 日時
+      expect(writtenLines[1]).toMatch(/^1700000000-snap2\t20\d{2}-/)
     })
   })
 


### PR DESCRIPTION
## Summary

- `cos page history --plain` のスペース区切り独自形式（`key=value` 含む）を `writeTsv()` によるヘッダー付き TSV に変更
- `cos page snapshot list --plain` の同様の独自形式を TSV に変更
- `--plain` フラグの説明「TSV 出力」と実装を一致させ、`awk`/`cut`/`sort` などの UNIX ツールとのパイプ処理を可能にする

## 変更前後

**変更前（`page history --plain`）:**
```
commit-id-2  2023-11-17 05:46:40  user=user-id-1  changes=1
```

**変更後:**
```
id	created	userId	changes
commit-id-2	2023-11-17T05:46:40.000Z	user-id-1	1
```

## 使用例

```bash
# changes 数で降順ソート
cos page history --plain MyPage | sort -t$'\t' -k4 -nr

# タイムスタンプだけ取り出す
cos page history --plain MyPage | cut -f2 | tail -n +2

# snapshot ID だけ取り出す
cos page snapshot list --plain MyPage | awk -F'\t' 'NR>1 {print $1}'
```

## Test plan

- [x] `page history --plain` が `id\tcreated\tuserId\tchanges` のヘッダー行 + データ行を出力する
- [x] `page snapshot list --plain` が `id\tcreated` のヘッダー行 + データ行を出力する
- [x] コミット 0 件・スナップショット 0 件のケースでヘッダー行のみ出力される
- [x] `--limit` フラグとの組み合わせが正常動作する
- [x] `--json` フラグが引き続き正常動作する（回帰なし）
- [x] Biome lint / typecheck / 全テスト 1395 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * `page history` コマンドの出力形式をTSV形式（タブ区切り）に統一しました
  * `page/snapshot/list` コマンドの出力形式もTSV形式に統一しました

* **Tests**
  * plain出力形式の変更に対応するテストケースを追加・更新しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->