### PR TITLE
feat(auth): cos auth login --pat と buildRestClient の PAT 対応を追加する

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -276,8 +276,32 @@ export class SidValidationError extends Error {
 
 /** assertValidSid は SID 文字列のフォーマットを検証し、違反時は SidValidationError をスローする。 */
 export function assertValidSid(sid: string): void {
+  // PAT を SID に誤投入した場合の明示ガード (SID_PATTERN は pat_ + hex を素通しするため)
+  if (sid.startsWith("pat_")) {
+    throw new SidValidationError()
+  }
   if (sid.length === 0 || sid.length > SID_MAX_LENGTH || !SID_PATTERN.test(sid)) {
     throw new SidValidationError()
+  }
+}
+
+// Personal Access Token は pat_ プレフィックスと 64桁小文字16進数から構成される
+const PAT_PATTERN = /^pat_[0-9a-f]{64}$/
+
+/** PersonalAccessTokenValidationError は PAT フォーマット違反を表すエラー。 */
+export class PersonalAccessTokenValidationError extends Error {
+  constructor() {
+    super(
+      "Personal Access Token のフォーマットが不正です。pat_ で始まる 68 文字 (pat_ + 64 桁小文字 16 進数) を指定してください",
+    )
+    this.name = "PersonalAccessTokenValidationError"
+  }
+}
+
+/** assertValidPersonalAccessToken は PAT のフォーマットを検証し、違反時は PersonalAccessTokenValidationError をスローする。 */
+export function assertValidPersonalAccessToken(pat: string): void {
+  if (!PAT_PATTERN.test(pat)) {
+    throw new PersonalAccessTokenValidationError()
   }
 }
 

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -386,12 +386,31 @@ export function requireProject(args: CommonArgs): string {
  * buildRestClient は認証情報を解決して REST クライアントを生成する。
  *
  * 認証解決の優先順位:
+ * 0. COS_PERSONAL_ACCESS_TOKEN 環境変数 (PAT 認証、最優先)
  * 1. COS_SERVICE_ACCOUNT_KEY 環境変数 (Service Account キー認証)
  * 2. --project 指定時 + 設定ファイルの serviceAccounts に該当プロジェクトが存在 (Service Account キー認証)
- * 3. SID 認証 (connect.sid Cookie)
+ * 3. キーチェーン / COS_SID 環境変数 (PAT または SID 認証、値の pat_ プレフィックスで自動判別)
  */
 export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClient> {
-  // 1. 環境変数 COS_SERVICE_ACCOUNT_KEY を最優先チェック
+  // 0. 環境変数 COS_PERSONAL_ACCESS_TOKEN を最優先チェック (PAT > SA Key > sid)
+  const envPat = process.env["COS_PERSONAL_ACCESS_TOKEN"]
+  if (envPat !== undefined) {
+    try {
+      assertValidPersonalAccessToken(envPat)
+    } catch {
+      writeErrorJson(
+        "INVALID_PERSONAL_ACCESS_TOKEN",
+        "COS_PERSONAL_ACCESS_TOKEN のフォーマットが不正です",
+        "pat_ で始まる 68 文字の Personal Access Token を指定してください",
+      )
+      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+    }
+    const projectForAutoWatch = args.project ?? process.env["COS_PROJECT"]
+    if (projectForAutoWatch) maybeAutoAddToWatchlist(projectForAutoWatch)
+    return new CosenseRestClient({ personalAccessToken: envPat })
+  }
+
+  // 1. 環境変数 COS_SERVICE_ACCOUNT_KEY を次優先チェック
   const envKey = process.env["COS_SERVICE_ACCOUNT_KEY"]
   if (envKey !== undefined) {
     try {
@@ -430,10 +449,52 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
     }
   }
 
-  // 3. SID 認証にフォールバック
-  const sid = await requireSid(args.profile)
+  // 3. キーチェーン / COS_SID 環境変数から認証情報を取得 (PAT / SID 自動判別)
+  // requireSid は pat_ を拒否するため、buildRestClient では直接 loadSession を使う
+  if (!args.profile) {
+    const envSid = process.env["COS_SID"]
+    if (envSid !== undefined) {
+      try {
+        assertValidSid(envSid)
+      } catch {
+        writeErrorJson(
+          "INVALID_SID",
+          "COS_SID のフォーマットが不正です",
+          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
+        )
+        exitWithError(5, "INVALID_SID")
+      }
+      if (project) maybeAutoAddToWatchlist(project)
+      return new CosenseRestClient({ sid: envSid })
+    }
+  }
+  const store = createTokenStore()
+  const sessionOpts = args.profile !== undefined ? { profile: args.profile } : {}
+  const token = await loadSession(store, sessionOpts)
+  if (!token) {
+    writeErrorJson(
+      "AUTH_REQUIRED",
+      "認証情報が見つかりません",
+      "`cos auth login` を実行してログインしてください",
+    )
+    exitWithError(2, "AUTH_REQUIRED")
+  }
   if (project) maybeAutoAddToWatchlist(project)
-  return new CosenseRestClient({ sid })
+  // PAT プレフィックスの場合は PAT 認証、それ以外は SID 認証
+  if (token.startsWith("pat_")) {
+    return new CosenseRestClient({ personalAccessToken: token })
+  }
+  try {
+    assertValidSid(token)
+  } catch {
+    writeErrorJson(
+      "INVALID_SID",
+      "キーチェーンに保存された SID のフォーマットが不正です",
+      "`cos auth logout` 後に再ログインしてください",
+    )
+    exitWithError(5, "INVALID_SID")
+  }
+  return new CosenseRestClient({ sid: token })
 }
 
 /**

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -454,6 +454,21 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
   if (!args.profile) {
     const envSid = process.env["COS_SID"]
     if (envSid !== undefined) {
+      // pat_ プレフィックスの場合は PAT として処理する (COS_PERSONAL_ACCESS_TOKEN への移行を推奨)
+      if (envSid.startsWith("pat_")) {
+        try {
+          assertValidPersonalAccessToken(envSid)
+        } catch {
+          writeErrorJson(
+            "INVALID_PERSONAL_ACCESS_TOKEN",
+            "COS_SID に設定された Personal Access Token のフォーマットが不正です",
+            "pat_ で始まる 68 文字の Personal Access Token を COS_PERSONAL_ACCESS_TOKEN 環境変数で指定してください",
+          )
+          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+        }
+        if (project) maybeAutoAddToWatchlist(project)
+        return new CosenseRestClient({ personalAccessToken: envSid })
+      }
       try {
         assertValidSid(envSid)
       } catch {
@@ -482,6 +497,16 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
   if (project) maybeAutoAddToWatchlist(project)
   // PAT プレフィックスの場合は PAT 認証、それ以外は SID 認証
   if (token.startsWith("pat_")) {
+    try {
+      assertValidPersonalAccessToken(token)
+    } catch {
+      writeErrorJson(
+        "INVALID_PERSONAL_ACCESS_TOKEN",
+        "キーチェーンに保存された Personal Access Token のフォーマットが不正です",
+        "`cos auth logout` 後に `cos auth login --pat <token>` で再ログインしてください",
+      )
+      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+    }
     return new CosenseRestClient({ personalAccessToken: token })
   }
   try {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -23,7 +23,9 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   type CommonArgs,
+  PersonalAccessTokenValidationError,
   SidValidationError,
+  assertValidPersonalAccessToken,
   assertValidSid,
   buildJsonOpts,
   buildLogger,
@@ -78,6 +80,11 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
         type: "string",
         description: "connect.sid の値 (--no-input 時に使用)",
       },
+      pat: {
+        type: "string",
+        description:
+          "Personal Access Token (pat_ で始まる 68 文字)。読み取り REST 専用。書き込みコマンドは sid が必要",
+      },
       input: {
         type: "boolean",
         description:
@@ -107,6 +114,7 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
     async run({ args }) {
       type LoginArgs = CommonArgs & {
         sid?: string
+        pat?: string
         input: boolean
         browser: boolean
         "browser-path"?: string
@@ -128,6 +136,24 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
         exitWithError(5, "BROWSER_SID_EXCLUSIVE")
       }
 
+      // 排他チェック: --browser と --pat
+      if (a.browser && a.pat) {
+        writeErrorJson(
+          "PAT_BROWSER_EXCLUSIVE",
+          "--browser と --pat は同時に指定できません。どちらか一方を使用してください。",
+        )
+        exitWithError(5, "PAT_BROWSER_EXCLUSIVE")
+      }
+
+      // 排他チェック: --sid と --pat
+      if (a.sid && a.pat) {
+        writeErrorJson(
+          "PAT_SID_EXCLUSIVE",
+          "--sid と --pat は同時に指定できません。どちらか一方を使用してください。",
+        )
+        exitWithError(5, "PAT_SID_EXCLUSIVE")
+      }
+
       // 排他チェック: --browser と --no-input
       if (a.browser && !a.input) {
         writeErrorJson(
@@ -135,6 +161,36 @@ export function createAuthLoginCommand(deps: AuthLoginCommandDeps = {}) {
           "--browser フラグはブラウザでの手動ログインが必要なため --no-input と併用できません。",
         )
         exitWithError(5, "BROWSER_REQUIRES_INPUT")
+      }
+
+      // --pat フロー: PAT を検証して TokenStore に保存する
+      if (a.pat !== undefined) {
+        try {
+          assertValidPersonalAccessToken(a.pat)
+        } catch (err) {
+          if (err instanceof PersonalAccessTokenValidationError) {
+            writeErrorJson(
+              "INVALID_PERSONAL_ACCESS_TOKEN",
+              err.message,
+              "pat_ で始まる 68 文字の Personal Access Token を指定してください",
+            )
+            exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+          }
+          throw err
+        }
+        const client = new CosenseRestClient({ personalAccessToken: a.pat })
+        const me = await client.getMe()
+        const store = storeFactory()
+        await saveSession(store, { profile, sid: a.pat })
+        logger.success(`${me.name} としてログインしました (プロファイル: ${profile}, 認証: PAT)`)
+        if (a.json) {
+          writeJson(
+            { profile, name: me.name, authMethod: "pat" },
+            { command: "auth.login", startTime },
+            buildJsonOpts(a),
+          )
+        }
+        return
       }
 
       let sid: string

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -3,11 +3,15 @@
  *
  * connect.sid を対話入力、--sid フラグ、または --browser (CDP 自動取得) で受け取り、
  * /api/users/me で検証後に TokenStore に保存する。
+ * Personal Access Token (PAT) は --pat フラグで指定する。PAT は読み取り REST 専用で
+ * 書き込みコマンドには使用できない。
  *
  * フラグ排他ルール:
  * - --browser と --sid は同時指定不可 (exit 5)
+ * - --browser と --pat は同時指定不可 (exit 5)
+ * - --sid と --pat は同時指定不可 (exit 5)
  * - --browser と --no-input は同時指定不可 (exit 5、ブラウザログインは対話前提)
- * - --no-input 時は --sid が必須 (exit 5)
+ * - --no-input 時は --sid または --pat が必須 (exit 5)
  *
  * 実装上の注意: citty は --no-X を args.X = false に自動変換するため、
  * args 定義は `input: { default: true }` とし、--no-input で input = false になることを利用する。
@@ -16,6 +20,11 @@
  * 1. Chrome/Chromium を CDP デバッグポートで起動する
  * 2. https://scrapbox.io/login を表示してユーザーにログインさせる
  * 3. connect.sid Cookie が取得できたら検証・保存して終了する
+ *
+ * --pat フロー:
+ * 1. PAT のフォーマットを検証する (pat_ + 64 桁小文字 16 進数)
+ * 2. /api/users/me で PAT の有効性を確認する
+ * 3. TokenStore に保存する (pat_ プレフィックスで SID と区別)
  */
 
 import { mkdir, rm } from "node:fs/promises"

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -9,6 +9,7 @@
 
 import {
   type CommonArgs,
+  assertValidPersonalAccessToken,
   buildJsonOpts,
   checkSandbox,
   commonArgs,
@@ -53,6 +54,18 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
 
       // pat_ プレフィックスで PAT / SID を自動判別
       const authMethod: "pat" | "sid" = token.startsWith("pat_") ? "pat" : "sid"
+      if (authMethod === "pat") {
+        try {
+          assertValidPersonalAccessToken(token)
+        } catch {
+          writeErrorJson(
+            "INVALID_PERSONAL_ACCESS_TOKEN",
+            "キーチェーンに保存された Personal Access Token のフォーマットが不正です",
+            "`cos auth logout` 後に `cos auth login --pat <token>` で再ログインしてください",
+          )
+          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+        }
+      }
       const client =
         authMethod === "pat"
           ? new CosenseRestClient({ personalAccessToken: token })

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -41,8 +41,8 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
       const startTime = Date.now()
 
       const store = createStore()
-      const sid = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
-      if (!sid) {
+      const token = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
+      if (!token) {
         writeErrorJson(
           "AUTH_REQUIRED",
           "認証情報が見つかりません",
@@ -51,13 +51,22 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
         exitWithError(2, "AUTH_REQUIRED")
       }
 
-      const client = new CosenseRestClient({ sid })
+      // pat_ プレフィックスで PAT / SID を自動判別
+      const authMethod: "pat" | "sid" = token.startsWith("pat_") ? "pat" : "sid"
+      const client =
+        authMethod === "pat"
+          ? new CosenseRestClient({ personalAccessToken: token })
+          : new CosenseRestClient({ sid: token })
       const me = await client.getMe()
 
       if (a.json || !a.plain) {
         // csrfToken は機密情報のため出力から除外する
         const { csrfToken: _csrfToken, ...safeMe } = me
-        writeJson(safeMe, { command: "auth.whoami", startTime }, buildJsonOpts(a))
+        writeJson(
+          { ...safeMe, authMethod },
+          { command: "auth.whoami", startTime },
+          buildJsonOpts(a),
+        )
         return
       }
 
@@ -66,6 +75,7 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
         [
           ["名前", me.name],
           ["ID", me.id],
+          ["認証種別", authMethod],
         ],
       )
     },

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -82,12 +82,14 @@ export class RateLimitError extends CosenseApiError {
   }
 }
 
-/** CosenseRestClientOptions は REST クライアントの設定オプション。sid と serviceAccountKey は排他。 */
+/** CosenseRestClientOptions は REST クライアントの設定オプション。sid / serviceAccountKey / personalAccessToken は排他。 */
 export interface CosenseRestClientOptions {
-  /** connect.sid 値 (Cookie ヘッダ認証)。serviceAccountKey と排他。 */
+  /** connect.sid 値 (Cookie ヘッダ認証)。他の認証オプションと排他。 */
   sid?: string
-  /** Service Account Access Key (x-service-account-access-key ヘッダ認証)。sid と排他。 */
+  /** Service Account Access Key (x-service-account-access-key ヘッダ認証)。他の認証オプションと排他。 */
   serviceAccountKey?: string
+  /** Personal Access Token (x-personal-access-token ヘッダ認証、読み取り REST のみ)。他の認証オプションと排他。 */
+  personalAccessToken?: string
   /** リクエストタイムアウト (ミリ秒、デフォルト 30000) */
   timeout?: number
 }
@@ -96,17 +98,25 @@ export interface CosenseRestClientOptions {
 export class CosenseRestClient {
   private readonly sid: string | undefined
   private readonly serviceAccountKey: string | undefined
+  private readonly personalAccessToken: string | undefined
   private readonly timeout: number
 
   constructor(opts: CosenseRestClientOptions) {
-    if (opts.sid === undefined && opts.serviceAccountKey === undefined) {
-      throw new Error("sid または serviceAccountKey のいずれかが必要です")
+    // sid / serviceAccountKey / personalAccessToken は 1 つのみ必須
+    const specifiedCount = [opts.sid, opts.serviceAccountKey, opts.personalAccessToken].filter(
+      (v) => v !== undefined,
+    ).length
+    if (specifiedCount === 0) {
+      throw new Error("sid / serviceAccountKey / personalAccessToken のいずれかが必要です")
     }
-    if (opts.sid !== undefined && opts.serviceAccountKey !== undefined) {
-      throw new Error("sid と serviceAccountKey は同時に指定できません")
+    if (specifiedCount > 1) {
+      throw new Error(
+        "sid / serviceAccountKey / personalAccessToken は同時に指定できません。1 つのみ指定してください",
+      )
     }
     this.sid = opts.sid
     this.serviceAccountKey = opts.serviceAccountKey
+    this.personalAccessToken = opts.personalAccessToken
     this.timeout = opts.timeout ?? 30_000
   }
 
@@ -289,6 +299,12 @@ export class CosenseRestClient {
   async replaceLinks(project: string, from: string, to: string): Promise<{ updatedCount: number }> {
     // CSRF トークンを /api/users/me から取得する
     const me = await this.getMe()
+    // PAT セッションでは csrfToken が返らないため書き込み不可
+    if (me.csrfToken === undefined) {
+      throw new Error(
+        "AUTH_WRITE_NOT_SUPPORTED: Personal Access Token では書き込み操作を実行できません。`cos auth login --sid <value>` で connect.sid を保存してください",
+      )
+    }
     const data = await this.postJson(
       `${BASE_URL}/api/pages/${encodeURIComponent(project)}/replace/links`,
       JSON.stringify({ from, to }),
@@ -335,7 +351,9 @@ export class CosenseRestClient {
     const headers: Record<string, string> = {
       Accept: "application/json",
     }
-    if (this.serviceAccountKey) {
+    if (this.personalAccessToken) {
+      headers["x-personal-access-token"] = this.personalAccessToken
+    } else if (this.serviceAccountKey) {
       headers["x-service-account-access-key"] = this.serviceAccountKey
     } else if (this.sid) {
       headers["Cookie"] = `connect.sid=${this.sid}`

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -82,6 +82,16 @@ export class RateLimitError extends CosenseApiError {
   }
 }
 
+/** AuthWriteNotSupportedError は PAT 認証では書き込み操作を実行できない場合のエラー。HTTP エラーではないため CosenseApiError を継承しない。 */
+export class AuthWriteNotSupportedError extends Error {
+  constructor() {
+    super(
+      "AUTH_WRITE_NOT_SUPPORTED: Personal Access Token では書き込み操作を実行できません。`cos auth login --sid <value>` で connect.sid を保存してください",
+    )
+    this.name = "AuthWriteNotSupportedError"
+  }
+}
+
 /** CosenseRestClientOptions は REST クライアントの設定オプション。sid / serviceAccountKey / personalAccessToken は排他。 */
 export interface CosenseRestClientOptions {
   /** connect.sid 値 (Cookie ヘッダ認証)。他の認証オプションと排他。 */
@@ -301,9 +311,7 @@ export class CosenseRestClient {
     const me = await this.getMe()
     // PAT セッションでは csrfToken が返らないため書き込み不可
     if (me.csrfToken === undefined) {
-      throw new Error(
-        "AUTH_WRITE_NOT_SUPPORTED: Personal Access Token では書き込み操作を実行できません。`cos auth login --sid <value>` で connect.sid を保存してください",
-      )
+      throw new AuthWriteNotSupportedError()
     }
     const data = await this.postJson(
       `${BASE_URL}/api/pages/${encodeURIComponent(project)}/replace/links`,

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -11,7 +11,7 @@ export const MeSchema = z.object({
   displayName: z.string(),
   email: z.string().optional(),
   photo: z.string().optional(),
-  csrfToken: z.string(),
+  csrfToken: z.string().optional(),
   isPasswordUser: z.boolean().optional(),
   isGitHubUser: z.boolean().optional(),
   config: z

--- a/tests/fixtures/me-pat.json
+++ b/tests/fixtures/me-pat.json
@@ -1,0 +1,9 @@
+{
+  "id": "user-id-me",
+  "name": "テストユーザー",
+  "displayName": "テストユーザー表示名",
+  "email": "test@example.com",
+  "photo": "https://example.com/photo.jpg",
+  "isPasswordUser": false,
+  "isGitHubUser": true
+}

--- a/tests/unit/commands/_shared.pat.test.ts
+++ b/tests/unit/commands/_shared.pat.test.ts
@@ -1,0 +1,94 @@
+/**
+ * _shared.pat.test.ts — Personal Access Token (PAT) バリデーションの単体テスト。
+ *
+ * PAT は `pat_` + 64 桁小文字 16 進数から構成される。
+ * SID と同じ TokenStore に同居させ、値のプレフィックスで識別する設計のため
+ * `assertValidSid` が `pat_` を誤って通過させないことも合わせて検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  PersonalAccessTokenValidationError,
+  SidValidationError,
+  assertValidPersonalAccessToken,
+  assertValidSid,
+} from "@/commands/_shared"
+
+// pat_ + 64桁小文字16進数の有効な PAT
+const VALID_PAT = `pat_${"a".repeat(64)}`
+
+describe("assertValidPersonalAccessToken / PersonalAccessTokenValidationError", () => {
+  it("正常な PAT は検証を通過する", () => {
+    expect(() => assertValidPersonalAccessToken(VALID_PAT)).not.toThrow()
+  })
+
+  it("実際の形式 (pat_ + 64桁小文字16進数) の PAT は検証を通過する", () => {
+    const pat = "pat_edcc66c74a7ab280adcb33be05eaabd1158ec4e6d6b604284ccc83e99d094ac6"
+    expect(() => assertValidPersonalAccessToken(pat)).not.toThrow()
+  })
+
+  it("空文字列は PersonalAccessTokenValidationError をスローする", () => {
+    expect(() => assertValidPersonalAccessToken("")).toThrow(PersonalAccessTokenValidationError)
+  })
+
+  it("pat_ プレフィックスがない場合は PersonalAccessTokenValidationError をスローする", () => {
+    // 64桁の16進数だけ (プレフィックスなし)
+    expect(() => assertValidPersonalAccessToken("a".repeat(64))).toThrow(
+      PersonalAccessTokenValidationError,
+    )
+  })
+
+  it("cs_ プレフィックス (Service Account Key) は PersonalAccessTokenValidationError をスローする", () => {
+    const saKey = `cs_${"0".repeat(64)}`
+    expect(() => assertValidPersonalAccessToken(saKey)).toThrow(PersonalAccessTokenValidationError)
+  })
+
+  it("pat_ の後が 64 桁未満は PersonalAccessTokenValidationError をスローする", () => {
+    const shortPat = `pat_${"a".repeat(63)}`
+    expect(() => assertValidPersonalAccessToken(shortPat)).toThrow(
+      PersonalAccessTokenValidationError,
+    )
+  })
+
+  it("pat_ の後が 64 桁より長い場合は PersonalAccessTokenValidationError をスローする", () => {
+    const longPat = `pat_${"a".repeat(65)}`
+    expect(() => assertValidPersonalAccessToken(longPat)).toThrow(
+      PersonalAccessTokenValidationError,
+    )
+  })
+
+  it("大文字 16 進数を含む場合は PersonalAccessTokenValidationError をスローする", () => {
+    // PAT は小文字 16 進数のみ有効
+    const upperPat = `pat_${"A".repeat(64)}`
+    expect(() => assertValidPersonalAccessToken(upperPat)).toThrow(
+      PersonalAccessTokenValidationError,
+    )
+  })
+
+  it("16 進数以外の文字を含む場合は PersonalAccessTokenValidationError をスローする", () => {
+    // 'g' は 16 進数文字ではない
+    const invalidPat = `pat_${"g".repeat(64)}`
+    expect(() => assertValidPersonalAccessToken(invalidPat)).toThrow(
+      PersonalAccessTokenValidationError,
+    )
+  })
+
+  it("PersonalAccessTokenValidationError は Error を継承し分かりやすいメッセージを持つ", () => {
+    const err = new PersonalAccessTokenValidationError()
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe("PersonalAccessTokenValidationError")
+    expect(err.message).toContain("pat_")
+  })
+})
+
+describe("assertValidSid — pat_ プレフィックスの誤通過防止", () => {
+  it("pat_ で始まる 68 文字の値は SidValidationError をスローする (PAT を SID に誤投入した場合の明示ガード)", () => {
+    // TokenStore に PAT を保存した値を誤って SID 経路に流し込んだ場合、
+    // SID_PATTERN だけでは通過してしまうバグへの明示対処
+    expect(() => assertValidSid(VALID_PAT)).toThrow(SidValidationError)
+  })
+
+  it("pat_xxx (短い) も SidValidationError をスローする", () => {
+    expect(() => assertValidSid("pat_abc123")).toThrow(SidValidationError)
+  })
+})

--- a/tests/unit/commands/_shared.pat.test.ts
+++ b/tests/unit/commands/_shared.pat.test.ts
@@ -161,3 +161,55 @@ describe("buildRestClient — COS_PERSONAL_ACCESS_TOKEN 環境変数", () => {
     expect(client).toBeDefined()
   })
 })
+
+describe("buildRestClient — COS_SID 環境変数に PAT が設定された場合", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  })
+
+  it("COS_SID に有効な PAT が設定されている場合は PAT クライアントを返す", async () => {
+    // COS_SID に誤って PAT を設定した場合、PAT として処理される
+    process.env["COS_SID"] = VALID_PAT
+    const client = await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+    })
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(client).toBeDefined()
+  })
+
+  it("COS_SID に不正な PAT (pat_ プレフィックスだが形式が不正) が設定されている場合は exit 5 で終了する", async () => {
+    // pat_ プレフィックスはあるが 64桁の16進数でない
+    process.env["COS_SID"] = `pat_${"z".repeat(64)}`
+    try {
+      await buildRestClient({
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: true,
+      })
+    } catch {
+      // exitWithError による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("INVALID_PERSONAL_ACCESS_TOKEN")
+  })
+})

--- a/tests/unit/commands/_shared.pat.test.ts
+++ b/tests/unit/commands/_shared.pat.test.ts
@@ -1,17 +1,18 @@
 /**
- * _shared.pat.test.ts — Personal Access Token (PAT) バリデーションの単体テスト。
+ * _shared.pat.test.ts — Personal Access Token (PAT) バリデーションおよび buildRestClient の単体テスト。
  *
  * PAT は `pat_` + 64 桁小文字 16 進数から構成される。
  * SID と同じ TokenStore に同居させ、値のプレフィックスで識別する設計のため
  * `assertValidSid` が `pat_` を誤って通過させないことも合わせて検証する。
  */
 
-import { describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import {
   PersonalAccessTokenValidationError,
   SidValidationError,
   assertValidPersonalAccessToken,
   assertValidSid,
+  buildRestClient,
 } from "@/commands/_shared"
 
 // pat_ + 64桁小文字16進数の有効な PAT
@@ -90,5 +91,73 @@ describe("assertValidSid — pat_ プレフィックスの誤通過防止", () =
 
   it("pat_xxx (短い) も SidValidationError をスローする", () => {
     expect(() => assertValidSid("pat_abc123")).toThrow(SidValidationError)
+  })
+})
+
+describe("buildRestClient — COS_PERSONAL_ACCESS_TOKEN 環境変数", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  })
+
+  it("COS_PERSONAL_ACCESS_TOKEN が有効な PAT の場合は PAT クライアントを返す", async () => {
+    // 環境変数に有効な PAT をセット
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = VALID_PAT
+    const client = await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+    })
+    // exit が呼ばれずに CosenseRestClient が返ること
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(client).toBeDefined()
+  })
+
+  it("COS_PERSONAL_ACCESS_TOKEN に不正な値が設定されている場合は exit 5 で終了する", async () => {
+    // 不正フォーマット (pat_ プレフィックスがない)
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = "invalid-pat-format"
+    try {
+      await buildRestClient({
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: true,
+      })
+    } catch {
+      // exitWithError による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("INVALID_PERSONAL_ACCESS_TOKEN")
+  })
+
+  it("COS_PERSONAL_ACCESS_TOKEN が COS_SERVICE_ACCOUNT_KEY より優先される", async () => {
+    // 両方設定されている場合、PAT が優先 (env の優先順位: PAT > SA Key > sid)
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = VALID_PAT
+    process.env["COS_SERVICE_ACCOUNT_KEY"] = `cs_${"0".repeat(64)}`
+    const client = await buildRestClient({
+      json: false,
+      plain: false,
+      "results-only": false,
+      quiet: true,
+    })
+    // exit が呼ばれずに返ること
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(client).toBeDefined()
   })
 })

--- a/tests/unit/commands/auth/login.test.ts
+++ b/tests/unit/commands/auth/login.test.ts
@@ -284,3 +284,98 @@ describe("authLoginCommand — --sid フロー (回帰)", () => {
     expect(exitMock).toHaveBeenCalledWith(5)
   })
 })
+
+// ---------------------------------------------------------------------------
+// --pat フロー
+// ---------------------------------------------------------------------------
+
+// テスト用 PAT (pat_ + 64桁小文字16進数)
+const VALID_PAT = `pat_${"a".repeat(64)}`
+
+describe("authLoginCommand — --pat フロー", () => {
+  it("--pat で有効な PAT を渡した場合に TokenStore に保存される", async () => {
+    // InMemoryTokenStore への参照を保持して保存後に確認する
+    const store = new InMemoryTokenStore()
+    const command = createAuthLoginCommand({ createStore: () => store })
+    await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)(
+      {
+        args: {
+          pat: VALID_PAT,
+          input: true,
+          profile: "default",
+          json: false,
+          plain: false,
+          quiet: false,
+          verbose: false,
+        },
+        cmd: {} as never,
+        rawArgs: [],
+      },
+    )
+    // PAT 値が default プロファイルに保存されていること
+    const saved = await store.load("default")
+    expect(saved).toBe(VALID_PAT)
+  })
+
+  it("--pat と --sid を同時指定した場合は exit 5 で終了する (PAT_SID_EXCLUSIVE)", async () => {
+    try {
+      await runLogin({
+        pat: VALID_PAT,
+        sid: "s%3Atest-sid",
+        input: true,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+      })
+    } catch {
+      // exitWithError による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    // writeErrorJson は stdout に書き込む
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("PAT_SID_EXCLUSIVE")
+  })
+
+  it("--pat と --browser を同時指定した場合は exit 5 で終了する (PAT_BROWSER_EXCLUSIVE)", async () => {
+    try {
+      await runLogin({
+        pat: VALID_PAT,
+        browser: true,
+        input: true,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+        "browser-port": 9222,
+        "browser-timeout": 300,
+      })
+    } catch {
+      // exitWithError による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("PAT_BROWSER_EXCLUSIVE")
+  })
+
+  it("--pat にフォーマット不正な値を渡した場合は exit 5 で終了する (INVALID_PERSONAL_ACCESS_TOKEN)", async () => {
+    try {
+      await runLogin({
+        pat: "pat_invalid_too_short",
+        input: true,
+        profile: "default",
+        json: false,
+        plain: false,
+        quiet: false,
+        verbose: false,
+      })
+    } catch {
+      // exitWithError による throw は想定内
+    }
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("INVALID_PERSONAL_ACCESS_TOKEN")
+  })
+})

--- a/tests/unit/commands/auth/whoami.pat.test.ts
+++ b/tests/unit/commands/auth/whoami.pat.test.ts
@@ -1,0 +1,190 @@
+/**
+ * whoami.pat.test.ts — PAT 認証時の `cos auth whoami` 動作テスト。
+ *
+ * keychain に PAT (pat_ プレフィックス値) が保存されている場合:
+ * - JSON 出力に authMethod: "pat" が含まれること
+ * - プレーン出力に「認証種別」行が含まれること
+ * - csrfToken は JSON 出力から除外されること
+ *
+ * SID 認証の場合も authMethod: "sid" を含むことを合わせて検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthWhoamiCommand } from "@/commands/auth/whoami"
+import { saveSession } from "@/core/auth/session"
+import { InMemoryTokenStore } from "@/core/auth/store"
+import { http, HttpResponse } from "msw"
+import { useMswServer } from "../../../helpers/msw"
+
+// ---------------------------------------------------------------------------
+// MSW サーバーセットアップ
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://scrapbox.io"
+const VALID_PAT = `pat_${"a".repeat(64)}`
+const testSid = "s%3Atest-whoami-sid-abc123"
+
+useMswServer([
+  http.get(`${BASE_URL}/api/users/me`, ({ request }) => {
+    const pat = request.headers.get("x-personal-access-token")
+    if (pat === VALID_PAT) {
+      // PAT セッション: csrfToken なし
+      return HttpResponse.json({
+        id: "tanaka-hanako-id",
+        name: "tanaka-hanako",
+        displayName: "田中花子",
+        email: "tanaka@example.co.jp",
+        isPasswordUser: false,
+      })
+    }
+    // SID セッション: csrfToken あり
+    return HttpResponse.json({
+      id: "yamada-taro-id",
+      name: "yamada-taro",
+      displayName: "山田太郎",
+      email: "yamada@example.co.jp",
+      csrfToken: "秘密のCSRFトークン",
+      isPasswordUser: true,
+    })
+  }),
+])
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+/** PAT を keychain に保存してコマンドを実行するヘルパー。 */
+async function runWhoamiWithPat(args: Record<string, unknown>) {
+  const store = new InMemoryTokenStore()
+  // PAT を sid フィールドとして保存 (TokenStore は単一 string を保持する設計)
+  await saveSession(store, { profile: "default", sid: VALID_PAT })
+  const command = createAuthWhoamiCommand({ createStore: () => store })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** SID を keychain に保存してコマンドを実行するヘルパー。 */
+async function runWhoamiWithSid(args: Record<string, unknown>) {
+  const store = new InMemoryTokenStore()
+  await saveSession(store, { profile: "default", sid: testSid })
+  const command = createAuthWhoamiCommand({ createStore: () => store })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+/** stdout 出力をキャプチャして JSON として返すヘルパー。 */
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => JSON.parse(chunks.join(""))
+}
+
+/** stdout 出力をキャプチャしてテキストとして返すヘルパー。 */
+function capturePlainOutput(): () => string {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => chunks.join("")
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock.mockRestore()
+})
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+const jsonArgs = {
+  json: true,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: "default",
+  "results-only": false,
+}
+
+const plainArgs = {
+  json: false,
+  plain: true,
+  quiet: false,
+  verbose: false,
+  profile: "default",
+  "results-only": false,
+}
+
+describe("authWhoamiCommand — PAT 認証時の出力", () => {
+  it("PAT 認証時: JSON 出力に authMethod: 'pat' が含まれること", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoamiWithPat(jsonArgs)
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).toHaveProperty("authMethod", "pat")
+  })
+
+  it("PAT 認証時: JSON 出力に csrfToken が含まれないこと", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoamiWithPat(jsonArgs)
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).not.toHaveProperty("csrfToken")
+  })
+
+  it("PAT 認証時: JSON 出力に name・id が含まれること", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoamiWithPat(jsonArgs)
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).toHaveProperty("name", "tanaka-hanako")
+    expect(output.data).toHaveProperty("id", "tanaka-hanako-id")
+  })
+
+  it("PAT 認証時: プレーン出力に「認証種別」行が含まれること", async () => {
+    const getPlain = capturePlainOutput()
+    await runWhoamiWithPat(plainArgs)
+    const output = getPlain()
+    expect(output).toContain("認証種別")
+    expect(output).toContain("pat")
+  })
+})
+
+describe("authWhoamiCommand — SID 認証時の authMethod 出力", () => {
+  it("SID 認証時: JSON 出力に authMethod: 'sid' が含まれること", async () => {
+    const getJson = captureJsonOutput()
+    await runWhoamiWithSid(jsonArgs)
+    const output = getJson() as { data?: Record<string, unknown> }
+    expect(output.data).toHaveProperty("authMethod", "sid")
+  })
+
+  it("SID 認証時: プレーン出力に「認証種別」行と sid が含まれること", async () => {
+    const getPlain = capturePlainOutput()
+    await runWhoamiWithSid(plainArgs)
+    const output = getPlain()
+    expect(output).toContain("認証種別")
+    expect(output).toContain("sid")
+  })
+})

--- a/tests/unit/core/api/rest.pat.test.ts
+++ b/tests/unit/core/api/rest.pat.test.ts
@@ -1,0 +1,162 @@
+/**
+ * rest.pat.test.ts — Personal Access Token (PAT) を使った REST クライアントのテスト。
+ *
+ * PAT 認証では x-personal-access-token ヘッダを送り、
+ * csrfToken が /api/users/me から返らないため replaceLinks は使用不可になる。
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test"
+import { CosenseRestClient } from "@/core/api/rest"
+import { http, HttpResponse } from "msw"
+import { useMswServer } from "../../../helpers/msw"
+
+import mePATFixture from "../../../fixtures/me-pat.json"
+import pageListFixture from "../../../fixtures/page-list.json"
+import searchTitlesFixture from "../../../fixtures/search-titles.json"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+// テスト用 PAT (pat_ + 64桁小文字16進数)
+const VALID_PAT = `pat_${"a".repeat(64)}`
+
+const _server = useMswServer([
+  // /api/users/me — PAT ヘッダで認証、csrfToken なしで返す
+  http.get(`${BASE_URL}/api/users/me`, ({ request }) => {
+    const pat = request.headers.get("x-personal-access-token")
+    if (pat === VALID_PAT) {
+      return HttpResponse.json(mePATFixture)
+    }
+    // Cookie のみ or 無効なヘッダは 401
+    return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+  }),
+
+  // /api/pages/:project — PAT ヘッダで認証 (msw は path params を自動デコードする)
+  http.get(`${BASE_URL}/api/pages/:project`, ({ params, request }) => {
+    const pat = request.headers.get("x-personal-access-token")
+    if (pat !== VALID_PAT) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] === TEST_PROJECT) {
+      return HttpResponse.json(pageListFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  // /api/pages/:project/search/titles — PAT ヘッダで認証 (msw は path params を自動デコードする)
+  http.get(`${BASE_URL}/api/pages/:project/search/titles`, ({ params, request }) => {
+    const pat = request.headers.get("x-personal-access-token")
+    if (pat !== VALID_PAT) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+    if (params["project"] === TEST_PROJECT) {
+      return HttpResponse.json(searchTitlesFixture)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+
+  // /api/smart-context — PAT ヘッダで認証
+  http.get(`${BASE_URL}/api/smart-context/export-1hop-links/:project`, ({ params, request }) => {
+    const pat = request.headers.get("x-personal-access-token")
+    if (pat !== VALID_PAT) {
+      return new HttpResponse("Unauthorized", { status: 401 })
+    }
+    const projectParam = decodeURIComponent(params["project"] as string)
+    const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+    const url = new URL(request.url)
+    const title = url.searchParams.get("title")
+    if (project === TEST_PROJECT && title === "テストページ") {
+      return new HttpResponse("PAT Smart Context テキスト")
+    }
+    return new HttpResponse("Not found", { status: 404 })
+  }),
+])
+
+describe("CosenseRestClient — コンストラクタの 3-way 排他チェック", () => {
+  it("sid のみ指定: 正常に生成できる", () => {
+    expect(() => new CosenseRestClient({ sid: "s%3Atest-sid" })).not.toThrow()
+  })
+
+  it("serviceAccountKey のみ指定: 正常に生成できる", () => {
+    const saKey = `cs_${"0".repeat(64)}`
+    expect(() => new CosenseRestClient({ serviceAccountKey: saKey })).not.toThrow()
+  })
+
+  it("personalAccessToken のみ指定: 正常に生成できる", () => {
+    expect(() => new CosenseRestClient({ personalAccessToken: VALID_PAT })).not.toThrow()
+  })
+
+  it("何も指定しない場合はエラーをスローする", () => {
+    expect(() => new CosenseRestClient({})).toThrow()
+  })
+
+  it("sid + personalAccessToken を同時指定するとエラーをスローする", () => {
+    expect(
+      () => new CosenseRestClient({ sid: "s%3Atest-sid", personalAccessToken: VALID_PAT }),
+    ).toThrow()
+  })
+
+  it("serviceAccountKey + personalAccessToken を同時指定するとエラーをスローする", () => {
+    const saKey = `cs_${"0".repeat(64)}`
+    expect(
+      () => new CosenseRestClient({ serviceAccountKey: saKey, personalAccessToken: VALID_PAT }),
+    ).toThrow()
+  })
+
+  it("sid + serviceAccountKey を同時指定するとエラーをスローする (既存の排他チェック維持)", () => {
+    const saKey = `cs_${"0".repeat(64)}`
+    expect(() => new CosenseRestClient({ sid: "s%3Atest-sid", serviceAccountKey: saKey })).toThrow()
+  })
+
+  it("sid + serviceAccountKey + personalAccessToken を同時指定するとエラーをスローする", () => {
+    const saKey = `cs_${"0".repeat(64)}`
+    expect(
+      () =>
+        new CosenseRestClient({
+          sid: "s%3Atest-sid",
+          serviceAccountKey: saKey,
+          personalAccessToken: VALID_PAT,
+        }),
+    ).toThrow()
+  })
+})
+
+describe("CosenseRestClient — PAT 認証で REST 読み取り API", () => {
+  let client: CosenseRestClient
+
+  beforeEach(() => {
+    // PAT を使用した REST クライアント
+    client = new CosenseRestClient({ personalAccessToken: VALID_PAT })
+  })
+
+  it("getMe: x-personal-access-token ヘッダを送り、csrfToken なしでユーザー情報を返す", async () => {
+    const me = await client.getMe()
+    expect(me.name).toBe("テストユーザー")
+    // PAT セッションでは csrfToken が返らない
+    expect(me.csrfToken).toBeUndefined()
+  })
+
+  it("listPages: PAT 認証でページ一覧を取得できる", async () => {
+    const result = await client.listPages(TEST_PROJECT)
+    expect(result.pages.length).toBeGreaterThan(0)
+  })
+
+  it("searchTitles: PAT 認証でタイトル検索できる", async () => {
+    const result = await client.searchTitles(TEST_PROJECT)
+    expect(Array.isArray(result.pages)).toBe(true)
+  })
+
+  it("getSmartContext (1hop): PAT 認証でリンク先テキストを取得できる", async () => {
+    const text = await client.getSmartContext(TEST_PROJECT, "テストページ", 1)
+    expect(text).toBe("PAT Smart Context テキスト")
+  })
+})
+
+describe("CosenseRestClient — PAT 認証での replaceLinks", () => {
+  it("csrfToken が返らない PAT セッションで replaceLinks を呼ぶと AUTH_WRITE_NOT_SUPPORTED エラーをスローする", async () => {
+    // PAT セッションでは getMe が csrfToken を返さないため、replaceLinks は使用不可
+    const client = new CosenseRestClient({ personalAccessToken: VALID_PAT })
+    await expect(client.replaceLinks(TEST_PROJECT, "旧リンク", "新リンク")).rejects.toThrow(
+      "AUTH_WRITE_NOT_SUPPORTED",
+    )
+  })
+})

--- a/tests/unit/core/api/rest.pat.test.ts
+++ b/tests/unit/core/api/rest.pat.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "bun:test"
-import { CosenseRestClient } from "@/core/api/rest"
+import { AuthWriteNotSupportedError, CosenseRestClient } from "@/core/api/rest"
 import { http, HttpResponse } from "msw"
 import { useMswServer } from "../../../helpers/msw"
 
@@ -152,11 +152,11 @@ describe("CosenseRestClient — PAT 認証で REST 読み取り API", () => {
 })
 
 describe("CosenseRestClient — PAT 認証での replaceLinks", () => {
-  it("csrfToken が返らない PAT セッションで replaceLinks を呼ぶと AUTH_WRITE_NOT_SUPPORTED エラーをスローする", async () => {
+  it("csrfToken が返らない PAT セッションで replaceLinks を呼ぶと AuthWriteNotSupportedError をスローする", async () => {
     // PAT セッションでは getMe が csrfToken を返さないため、replaceLinks は使用不可
     const client = new CosenseRestClient({ personalAccessToken: VALID_PAT })
-    await expect(client.replaceLinks(TEST_PROJECT, "旧リンク", "新リンク")).rejects.toThrow(
-      "AUTH_WRITE_NOT_SUPPORTED",
-    )
+    const error = await client.replaceLinks(TEST_PROJECT, "旧リンク", "新リンク").catch((e) => e)
+    expect(error).toBeInstanceOf(AuthWriteNotSupportedError)
+    expect(error.message).toContain("AUTH_WRITE_NOT_SUPPORTED")
   })
 })


### PR DESCRIPTION
## Summary

- `cos auth login --pat <token>` フラグを追加し、PAT (Personal Access Token) を TokenStore (Keychain) に保存できるようにする
- `buildRestClient` に `COS_PERSONAL_ACCESS_TOKEN` 環境変数の優先チェックを追加する（優先順位: PAT env > SA Key env > config SA > keychain 値の pat_/sid 自動判別）
- `cos auth whoami` が keychain の PAT を自動検出し、JSON/プレーン出力に `authMethod: "pat" | "sid"` を追加する
- `--pat` と `--sid` / `--browser` の排他チェックを追加する (exit 5)

## 実装詳細

### `cos auth login --pat`
- `pat_` + 64桁小文字16進数のフォーマット検証を実行
- `--sid` / `--browser` との同時指定は `PAT_SID_EXCLUSIVE` / `PAT_BROWSER_EXCLUSIVE` で exit 5
- フォーマット不正は `INVALID_PERSONAL_ACCESS_TOKEN` で exit 5
- 検証通過後は `CosenseRestClient({ personalAccessToken })` で getMe を確認し、TokenStore に保存する

### `buildRestClient` の優先順位拡張
1. 環境変数 `COS_PERSONAL_ACCESS_TOKEN` (PAT, 最優先)
2. 環境変数 `COS_SERVICE_ACCOUNT_KEY` (SA Key)
3. 設定ファイルの SA Key
4. Keychain / `COS_SID` (値の `pat_` プレフィックスで PAT/SID 自動判別)

Phase 1 で `assertValidSid` に `pat_` 拒否ガードを追加したため、`requireSid` を介さず直接 `loadSession` を使用してキーチェーン値を取得し、プレフィックスで分岐する実装とした。

### `cos auth whoami` の `authMethod` 追加
- `token.startsWith("pat_")` で認証種別を判定
- JSON 出力: `authMethod: "pat" | "sid"` を追加 (csrfToken 除外は維持)
- プレーン出力: `["認証種別", authMethod]` 行を追加

## Test plan

- [x] `bun test` 全件 pass (1433 pass, 0 fail)
- [x] `bunx biome check src tests` エラーゼロ
- [x] `bun run typecheck` 型エラーゼロ (src/ のみ)
- [x] `tests/unit/commands/auth/login.test.ts` — `--pat` フロー 4 ケース追加
- [x] `tests/unit/commands/_shared.pat.test.ts` — `buildRestClient — COS_PERSONAL_ACCESS_TOKEN` 3 ケース追加
- [x] `tests/unit/commands/auth/whoami.pat.test.ts` — PAT / SID の `authMethod` 出力 6 ケース新規作成
- [x] テスト間の環境変数リーク防止 (`afterEach` で `Reflect.deleteProperty`)

Refs #159 (PAT 実装 Phase 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Personal Access Token (PAT) による認証方式を追加
  * `cos auth login` コマンドに `--pat` オプションを追加
  * `cos auth whoami` コマンドに認証方式の表示機能を追加
  * PAT形式のバリデーション機能を実装

* **テスト**
  * PAT認証フローに関する網羅的なユニットテストを追加
  * REST APIクライアントのPAT対応テストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->