### PR TITLE
feat(auth): Credential 型統合と resolveActiveCredential による 7 段優先順位認証解決 (Phase 1-3)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -7,7 +7,13 @@
 
 import { AuthError, CosenseRestClient, ForbiddenError, NotFoundError } from "@/core/api/rest"
 import { createScrapboxWriter } from "@/core/api/ws"
-import { isValidSaKeyFormat, parseCredential } from "@/core/auth/credential"
+import {
+  type Credential,
+  detectCredentialKind,
+  isValidSaKeyFormat,
+  parseCredential,
+} from "@/core/auth/credential"
+import type { CredentialStore } from "@/core/auth/credential-store"
 import { loadSession } from "@/core/auth/session"
 import { lintNotation } from "@/core/notation/lint"
 import { normalizeCodeBlockEmptyLines } from "@/core/notation/normalize"
@@ -332,6 +338,106 @@ export function assertValidServiceAccountKey(key: string): void {
   if (!isValidSaKeyFormat(key)) {
     throw new ServiceAccountKeyValidationError()
   }
+}
+
+/**
+ * resolveActiveCredential は認証情報を優先順位に従って解決して Credential を返す。
+ *
+ * 解決優先順位:
+ * 1. COS_PERSONAL_ACCESS_TOKEN env → 匿名 PAT Credential
+ * 2. COS_SERVICE_ACCOUNT_KEY env   → 匿名 SA Credential (COS_PROJECT / --project を defaultProject に設定)
+ * 3. COS_SID env (profile 未指定時) → SID Credential。pat_* の場合は互換 PAT + stderr 警告
+ * 4-7. CredentialStore の該当プロファイル (--profile > "default")
+ *
+ * @param args - コマンドの共通引数 (profile, project 等)
+ * @param store - Credential ストア実装 (テストでは InMemoryCredentialStore を注入)
+ */
+export async function resolveActiveCredential(
+  args: CommonArgs,
+  store: CredentialStore,
+): Promise<Credential> {
+  // 1. COS_PERSONAL_ACCESS_TOKEN を最優先チェック
+  const envPat = process.env["COS_PERSONAL_ACCESS_TOKEN"]
+  if (envPat !== undefined) {
+    try {
+      const cred = parseCredential(envPat)
+      if (cred.kind !== "pat") throw new Error("PAT 形式でありません")
+      return cred
+    } catch {
+      writeErrorJson(
+        "INVALID_PERSONAL_ACCESS_TOKEN",
+        "COS_PERSONAL_ACCESS_TOKEN のフォーマットが不正です",
+        "pat_ で始まる 68 文字の Personal Access Token を指定してください",
+      )
+      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+    }
+  }
+
+  // 2. COS_SERVICE_ACCOUNT_KEY を次優先チェック
+  const envKey = process.env["COS_SERVICE_ACCOUNT_KEY"]
+  if (envKey !== undefined) {
+    if (!isValidSaKeyFormat(envKey)) {
+      writeErrorJson(
+        "INVALID_SERVICE_ACCOUNT_KEY",
+        "COS_SERVICE_ACCOUNT_KEY のフォーマットが不正です",
+        "cs_ で始まる 67 文字のキーを指定してください",
+      )
+      exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
+    }
+    const project = args.project ?? process.env["COS_PROJECT"]
+    const credSa: { kind: "sa"; value: string; defaultProject?: string } = {
+      kind: "sa",
+      value: envKey,
+    }
+    if (project !== undefined) credSa.defaultProject = project
+    return credSa
+  }
+
+  // 3. COS_SID env (profile 未指定時のみ)
+  if (!args.profile) {
+    const envSid = process.env["COS_SID"]
+    if (envSid !== undefined) {
+      // PAT が COS_SID に設定された場合の互換処理 (Phase 6 で hard error に切り替え)
+      if (detectCredentialKind(envSid) === "pat") {
+        process.stderr.write(
+          "警告: COS_SID に Personal Access Token が設定されています。COS_PERSONAL_ACCESS_TOKEN 環境変数の使用を推奨します。\n",
+        )
+        try {
+          return parseCredential(envSid)
+        } catch {
+          writeErrorJson(
+            "INVALID_PERSONAL_ACCESS_TOKEN",
+            "COS_SID に設定された Personal Access Token のフォーマットが不正です",
+            "pat_ で始まる 68 文字の Personal Access Token を COS_PERSONAL_ACCESS_TOKEN 環境変数で指定してください",
+          )
+          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+        }
+      }
+      try {
+        return parseCredential(envSid)
+      } catch {
+        writeErrorJson(
+          "INVALID_SID",
+          "COS_SID のフォーマットが不正です",
+          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
+        )
+        exitWithError(5, "INVALID_SID")
+      }
+    }
+  }
+
+  // 4-7. CredentialStore からプロファイルを解決 (--profile > "default")
+  const profile = args.profile ?? "default"
+  const cred = await store.load(profile)
+  if (cred === null) {
+    writeErrorJson(
+      "AUTH_REQUIRED",
+      "認証情報が見つかりません",
+      "`cos auth login` を実行してログインしてください",
+    )
+    exitWithError(2, "AUTH_REQUIRED")
+  }
+  return cred
 }
 
 /** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -7,6 +7,7 @@
 
 import { AuthError, CosenseRestClient, ForbiddenError, NotFoundError } from "@/core/api/rest"
 import { createScrapboxWriter } from "@/core/api/ws"
+import { isValidSaKeyFormat, parseCredential } from "@/core/auth/credential"
 import { loadSession } from "@/core/auth/session"
 import { lintNotation } from "@/core/notation/lint"
 import { normalizeCodeBlockEmptyLines } from "@/core/notation/normalize"
@@ -262,10 +263,6 @@ export function getRawFlagValue(argv: string[], flagName: string): string | unde
   return result
 }
 
-const SID_MAX_LENGTH = 4096
-// RFC 6265 cookie-octet: DQUOTE(0x22), comma(0x2C), semicolon(0x3B), backslash(0x5C), CTL, SP を除外
-const SID_PATTERN = /^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/
-
 /** SidValidationError は SID フォーマット違反を表すエラー。 */
 export class SidValidationError extends Error {
   constructor() {
@@ -274,19 +271,22 @@ export class SidValidationError extends Error {
   }
 }
 
-/** assertValidSid は SID 文字列のフォーマットを検証し、違反時は SidValidationError をスローする。 */
+/**
+ * assertValidSid は SID 文字列のフォーマットを検証し、違反時は SidValidationError をスローする。
+ *
+ * PAT/SA Key を誤投入した場合も SidValidationError をスローする。
+ * フォーマット検証は credential.ts の parseCredential に委譲する。
+ */
 export function assertValidSid(sid: string): void {
-  // PAT を SID に誤投入した場合の明示ガード (SID_PATTERN は pat_ + hex を素通しするため)
-  if (sid.startsWith("pat_")) {
-    throw new SidValidationError()
-  }
-  if (sid.length === 0 || sid.length > SID_MAX_LENGTH || !SID_PATTERN.test(sid)) {
+  try {
+    const cred = parseCredential(sid)
+    // PAT または SA として判別された場合は SID として無効
+    if (cred.kind !== "sid") throw new SidValidationError()
+  } catch (e) {
+    if (e instanceof SidValidationError) throw e
     throw new SidValidationError()
   }
 }
-
-// Personal Access Token は pat_ プレフィックスと 64桁小文字16進数から構成される
-const PAT_PATTERN = /^pat_[0-9a-f]{64}$/
 
 /** PersonalAccessTokenValidationError は PAT フォーマット違反を表すエラー。 */
 export class PersonalAccessTokenValidationError extends Error {
@@ -298,15 +298,20 @@ export class PersonalAccessTokenValidationError extends Error {
   }
 }
 
-/** assertValidPersonalAccessToken は PAT のフォーマットを検証し、違反時は PersonalAccessTokenValidationError をスローする。 */
+/**
+ * assertValidPersonalAccessToken は PAT のフォーマットを検証し、違反時は PersonalAccessTokenValidationError をスローする。
+ *
+ * フォーマット検証は credential.ts の parseCredential に委譲する。
+ */
 export function assertValidPersonalAccessToken(pat: string): void {
-  if (!PAT_PATTERN.test(pat)) {
+  try {
+    const cred = parseCredential(pat)
+    if (cred.kind !== "pat") throw new PersonalAccessTokenValidationError()
+  } catch (e) {
+    if (e instanceof PersonalAccessTokenValidationError) throw e
     throw new PersonalAccessTokenValidationError()
   }
 }
-
-// Service Account Access Key は cs_ プレフィックスと 64桁小文字16進数から構成される
-const SA_KEY_PATTERN = /^cs_[0-9a-f]{64}$/
 
 /** ServiceAccountKeyValidationError は Service Account キーのフォーマット違反を表すエラー。 */
 export class ServiceAccountKeyValidationError extends Error {
@@ -318,9 +323,13 @@ export class ServiceAccountKeyValidationError extends Error {
   }
 }
 
-/** assertValidServiceAccountKey は Service Account キーのフォーマットを検証し、違反時は ServiceAccountKeyValidationError をスローする。 */
+/**
+ * assertValidServiceAccountKey は Service Account キーのフォーマットを検証し、違反時は ServiceAccountKeyValidationError をスローする。
+ *
+ * project を必要としないフォーマット検証は credential.ts の isValidSaKeyFormat に委譲する。
+ */
 export function assertValidServiceAccountKey(key: string): void {
-  if (!SA_KEY_PATTERN.test(key)) {
+  if (!isValidSaKeyFormat(key)) {
     throw new ServiceAccountKeyValidationError()
   }
 }

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -9,12 +9,13 @@ import { AuthError, CosenseRestClient, ForbiddenError, NotFoundError } from "@/c
 import { createScrapboxWriter } from "@/core/api/ws"
 import {
   type Credential,
+  canWrite,
   detectCredentialKind,
   isValidSaKeyFormat,
   parseCredential,
 } from "@/core/auth/credential"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
 import type { CredentialStore } from "@/core/auth/credential-store"
-import { loadSession } from "@/core/auth/session"
 import { lintNotation } from "@/core/notation/lint"
 import { normalizeCodeBlockEmptyLines } from "@/core/notation/normalize"
 import { PolicyError, createPolicy } from "@/core/sandbox"
@@ -440,65 +441,32 @@ export async function resolveActiveCredential(
   return cred
 }
 
-/** requireSid はセッション ID を取得し、未認証の場合はエラーで終了する。 */
+/**
+ * requireSid はセッション ID を取得し、未認証または書き込み不可の場合はエラーで終了する。
+ *
+ * 認証解決は resolveActiveCredential に委譲し、canWrite で書き込み可否を判定する。
+ * SID Credential (kind === "sid") のみ通過させ、PAT / SA は exit 2 で拒否する。
+ */
 export async function requireSid(profile?: string): Promise<string> {
-  // CI・エージェント向けに COS_SID 環境変数を優先チェック (プロファイル指定時は無視)
-  if (!profile) {
-    const envSid = process.env["COS_SID"]
-    if (envSid !== undefined) {
-      // PAT を COS_SID に誤投入した場合: 書き込み不可を明示 (exit 2)
-      if (envSid.startsWith("pat_")) {
-        writeErrorJson(
-          "AUTH_WRITE_NOT_SUPPORTED",
-          "Personal Access Token (PAT) では書き込み操作を実行できません",
-          "書き込みコマンドには connect.sid が必要です。`cos auth login --sid <connect.sid>` でログインしてください",
-        )
-        exitWithError(2, "AUTH_WRITE_NOT_SUPPORTED")
-      }
-      try {
-        assertValidSid(envSid)
-      } catch {
-        writeErrorJson(
-          "INVALID_SID",
-          "COS_SID のフォーマットが不正です",
-          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
-        )
-        exitWithError(5, "INVALID_SID")
-      }
-      return envSid
-    }
+  const argsForResolve: CommonArgs = {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: false,
   }
-  const store = createTokenStore()
-  const sessionOpts = profile !== undefined ? { profile } : {}
-  const sid = await loadSession(store, sessionOpts)
-  if (!sid) {
-    writeErrorJson(
-      "AUTH_REQUIRED",
-      "認証情報が見つかりません",
-      "`cos auth login` を実行してログインしてください",
-    )
-    exitWithError(2, "AUTH_REQUIRED")
-  }
-  // キーチェーンに PAT が保存されている場合: 書き込み不可を明示 (exit 2)
-  if (sid.startsWith("pat_")) {
+  if (profile !== undefined) argsForResolve.profile = profile
+  const store = new TokenStoreCredentialAdapter(createTokenStore())
+  const cred = await resolveActiveCredential(argsForResolve, store)
+
+  if (!canWrite(cred)) {
     writeErrorJson(
       "AUTH_WRITE_NOT_SUPPORTED",
-      "Personal Access Token (PAT) では書き込み操作を実行できません",
-      "書き込みコマンドには connect.sid が必要です。`cos auth login` で SID でログインしてください",
+      "この認証方式では書き込み操作を実行できません",
+      "書き込みコマンドには connect.sid が必要です。`cos auth login --sid <connect.sid>` でログインしてください",
     )
     exitWithError(2, "AUTH_WRITE_NOT_SUPPORTED")
   }
-  try {
-    assertValidSid(sid)
-  } catch {
-    writeErrorJson(
-      "INVALID_SID",
-      "キーチェーンに保存された SID のフォーマットが不正です",
-      "`cos auth logout` 後に再ログインしてください",
-    )
-    exitWithError(5, "INVALID_SID")
-  }
-  return sid
+  return cred.value
 }
 
 /** requireProject はプロジェクト名を取得し、未指定の場合はエラーで終了する。 */
@@ -519,51 +487,21 @@ export function requireProject(args: CommonArgs): string {
  * buildRestClient は認証情報を解決して REST クライアントを生成する。
  *
  * 認証解決の優先順位:
- * 0. COS_PERSONAL_ACCESS_TOKEN 環境変数 (PAT 認証、最優先)
- * 1. COS_SERVICE_ACCOUNT_KEY 環境変数 (Service Account キー認証)
- * 2. --project 指定時 + 設定ファイルの serviceAccounts に該当プロジェクトが存在 (Service Account キー認証)
- * 3. キーチェーン / COS_SID 環境変数 (PAT または SID 認証、値の pat_ プレフィックスで自動判別)
+ * 1. COS_PERSONAL_ACCESS_TOKEN env → PAT 認証
+ * 2. COS_SERVICE_ACCOUNT_KEY env   → SA Key 認証
+ * 3. config.serviceAccounts[project] → SA Key 認証 (Phase 4 で削除予定)
+ * 4-7. resolveActiveCredential (COS_SID / keychain)
  */
 export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClient> {
-  // 0. 環境変数 COS_PERSONAL_ACCESS_TOKEN を最優先チェック (PAT > SA Key > sid)
-  const envPat = process.env["COS_PERSONAL_ACCESS_TOKEN"]
-  if (envPat !== undefined) {
-    try {
-      assertValidPersonalAccessToken(envPat)
-    } catch {
-      writeErrorJson(
-        "INVALID_PERSONAL_ACCESS_TOKEN",
-        "COS_PERSONAL_ACCESS_TOKEN のフォーマットが不正です",
-        "pat_ で始まる 68 文字の Personal Access Token を指定してください",
-      )
-      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
-    }
-    const projectForAutoWatch = args.project ?? process.env["COS_PROJECT"]
-    if (projectForAutoWatch) maybeAutoAddToWatchlist(projectForAutoWatch)
-    return new CosenseRestClient({ personalAccessToken: envPat })
-  }
-
-  // 1. 環境変数 COS_SERVICE_ACCOUNT_KEY を次優先チェック
-  const envKey = process.env["COS_SERVICE_ACCOUNT_KEY"]
-  if (envKey !== undefined) {
-    try {
-      assertValidServiceAccountKey(envKey)
-    } catch {
-      writeErrorJson(
-        "INVALID_SERVICE_ACCOUNT_KEY",
-        "COS_SERVICE_ACCOUNT_KEY のフォーマットが不正です",
-        "cs_ で始まる 67 文字のキーを指定してください",
-      )
-      exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
-    }
-    const projectForAutoWatch = args.project ?? process.env["COS_PROJECT"]
-    if (projectForAutoWatch) maybeAutoAddToWatchlist(projectForAutoWatch)
-    return new CosenseRestClient({ serviceAccountKey: envKey })
-  }
-
-  // 2. --project 指定時は設定ファイルから SA キーを検索
   const project = args.project ?? process.env["COS_PROJECT"]
-  if (project) {
+
+  // config.serviceAccounts フォールバック (Phase 4 で削除予定)
+  // env vars が未設定かつプロジェクト指定時のみ config から SA キーを検索する
+  if (
+    project &&
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] === undefined &&
+    process.env["COS_SERVICE_ACCOUNT_KEY"] === undefined
+  ) {
     const config = loadConfig()
     const saKey = config.serviceAccounts?.[project]
     if (saKey !== undefined) {
@@ -582,77 +520,18 @@ export async function buildRestClient(args: CommonArgs): Promise<CosenseRestClie
     }
   }
 
-  // 3. キーチェーン / COS_SID 環境変数から認証情報を取得 (PAT / SID 自動判別)
-  // requireSid は pat_ を拒否するため、buildRestClient では直接 loadSession を使う
-  if (!args.profile) {
-    const envSid = process.env["COS_SID"]
-    if (envSid !== undefined) {
-      // pat_ プレフィックスの場合は PAT として処理する (COS_PERSONAL_ACCESS_TOKEN への移行を推奨)
-      if (envSid.startsWith("pat_")) {
-        try {
-          assertValidPersonalAccessToken(envSid)
-        } catch {
-          writeErrorJson(
-            "INVALID_PERSONAL_ACCESS_TOKEN",
-            "COS_SID に設定された Personal Access Token のフォーマットが不正です",
-            "pat_ で始まる 68 文字の Personal Access Token を COS_PERSONAL_ACCESS_TOKEN 環境変数で指定してください",
-          )
-          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
-        }
-        if (project) maybeAutoAddToWatchlist(project)
-        return new CosenseRestClient({ personalAccessToken: envSid })
-      }
-      try {
-        assertValidSid(envSid)
-      } catch {
-        writeErrorJson(
-          "INVALID_SID",
-          "COS_SID のフォーマットが不正です",
-          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
-        )
-        exitWithError(5, "INVALID_SID")
-      }
-      if (project) maybeAutoAddToWatchlist(project)
-      return new CosenseRestClient({ sid: envSid })
-    }
-  }
-  const store = createTokenStore()
-  const sessionOpts = args.profile !== undefined ? { profile: args.profile } : {}
-  const token = await loadSession(store, sessionOpts)
-  if (!token) {
-    writeErrorJson(
-      "AUTH_REQUIRED",
-      "認証情報が見つかりません",
-      "`cos auth login` を実行してログインしてください",
-    )
-    exitWithError(2, "AUTH_REQUIRED")
-  }
+  // env vars / COS_SID / keychain を resolveActiveCredential に委譲
+  const credStore = new TokenStoreCredentialAdapter(createTokenStore())
+  const cred = await resolveActiveCredential(args, credStore)
   if (project) maybeAutoAddToWatchlist(project)
-  // PAT プレフィックスの場合は PAT 認証、それ以外は SID 認証
-  if (token.startsWith("pat_")) {
-    try {
-      assertValidPersonalAccessToken(token)
-    } catch {
-      writeErrorJson(
-        "INVALID_PERSONAL_ACCESS_TOKEN",
-        "キーチェーンに保存された Personal Access Token のフォーマットが不正です",
-        "`cos auth logout` 後に `cos auth login --pat <token>` で再ログインしてください",
-      )
-      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
-    }
-    return new CosenseRestClient({ personalAccessToken: token })
+
+  if (cred.kind === "pat") {
+    return new CosenseRestClient({ personalAccessToken: cred.value })
   }
-  try {
-    assertValidSid(token)
-  } catch {
-    writeErrorJson(
-      "INVALID_SID",
-      "キーチェーンに保存された SID のフォーマットが不正です",
-      "`cos auth logout` 後に再ログインしてください",
-    )
-    exitWithError(5, "INVALID_SID")
+  if (cred.kind === "sa") {
+    return new CosenseRestClient({ serviceAccountKey: cred.value })
   }
-  return new CosenseRestClient({ sid: token })
+  return new CosenseRestClient({ sid: cred.value })
 }
 
 /**

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -9,17 +9,16 @@
 
 import {
   type CommonArgs,
-  assertValidPersonalAccessToken,
   buildJsonOpts,
   checkSandbox,
   commonArgs,
-  exitWithError,
+  resolveActiveCredential,
 } from "@/commands/_shared"
 import { CosenseRestClient } from "@/core/api/rest"
-import { loadSession } from "@/core/auth/session"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
 import type { TokenStore } from "@/core/auth/store"
 import { createTokenStore } from "@/infra/keychain/index"
-import { writeErrorJson, writeJson } from "@/presenter/json"
+import { writeJson } from "@/presenter/json"
 import { writePlainTable } from "@/presenter/plain"
 import { defineCommand } from "citty"
 
@@ -41,35 +40,19 @@ export function createAuthWhoamiCommand(deps: AuthWhoamiCommandDeps = {}) {
       checkSandbox("auth.whoami", a)
       const startTime = Date.now()
 
-      const store = createStore()
-      const token = await loadSession(store, a.profile !== undefined ? { profile: a.profile } : {})
-      if (!token) {
-        writeErrorJson(
-          "AUTH_REQUIRED",
-          "認証情報が見つかりません",
-          "`cos auth login` を実行してログインしてください",
-        )
-        exitWithError(2, "AUTH_REQUIRED")
-      }
+      // Credential を 7 段優先順位で解決する (env > keychain)
+      const tokenStore = createStore()
+      const credStore = new TokenStoreCredentialAdapter(tokenStore)
+      const cred = await resolveActiveCredential(a, credStore)
 
-      // pat_ プレフィックスで PAT / SID を自動判別
-      const authMethod: "pat" | "sid" = token.startsWith("pat_") ? "pat" : "sid"
-      if (authMethod === "pat") {
-        try {
-          assertValidPersonalAccessToken(token)
-        } catch {
-          writeErrorJson(
-            "INVALID_PERSONAL_ACCESS_TOKEN",
-            "キーチェーンに保存された Personal Access Token のフォーマットが不正です",
-            "`cos auth logout` 後に `cos auth login --pat <token>` で再ログインしてください",
-          )
-          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
-        }
-      }
+      // kind で認証方式を決定してクライアントを生成する
+      const authMethod = cred.kind
       const client =
-        authMethod === "pat"
-          ? new CosenseRestClient({ personalAccessToken: token })
-          : new CosenseRestClient({ sid: token })
+        cred.kind === "pat"
+          ? new CosenseRestClient({ personalAccessToken: cred.value })
+          : cred.kind === "sa"
+            ? new CosenseRestClient({ serviceAccountKey: cred.value })
+            : new CosenseRestClient({ sid: cred.value })
       const me = await client.getMe()
 
       if (a.json || !a.plain) {

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -64,6 +64,10 @@ function deserializeCredential(raw: string): Credential | null {
         typeof (env as CredentialEnvelope).value === "string"
       ) {
         const envelope = env as CredentialEnvelope
+        // 未知の kind は null を返して無効化する (壊れた JSON への防御)
+        if (envelope.kind !== "sid" && envelope.kind !== "pat" && envelope.kind !== "sa") {
+          return null
+        }
         if (envelope.kind === "sa") {
           if (!envelope.defaultProject) return null
           return { kind: "sa", value: envelope.value, defaultProject: envelope.defaultProject }

--- a/src/core/auth/credential-store.ts
+++ b/src/core/auth/credential-store.ts
@@ -1,0 +1,154 @@
+/**
+ * credential-store.ts — Credential の永続化抽象層。
+ *
+ * TokenStore を内部バックエンドとして使い、Credential 型で CRUD できる CredentialStore を提供する。
+ * keychain の値は JSON エンベロープ形式 {"kind":"sid"|"pat"|"sa","value":"...","defaultProject"?:"..."} で保存し、
+ * 旧バージョンの平文 SID/PAT 値は legacy 互換として自動解釈する。
+ */
+
+import { type Credential, type CredentialKind, detectCredentialKind } from "@/core/auth/credential"
+import type { TokenStore } from "@/core/auth/store"
+
+/** CredentialListEntry は list() が返すプロファイルの要約エントリ。 */
+export interface CredentialListEntry {
+  profile: string
+  kind: CredentialKind
+  defaultProject?: string
+}
+
+/** CredentialStore は Credential の CRUD 操作を抽象化する interface。 */
+export interface CredentialStore {
+  /** save はプロファイル名に紐づいて Credential を保存する。 */
+  save(profile: string, cred: Credential): Promise<void>
+  /** load はプロファイル名に紐づいた Credential を返す。見つからない場合は null。 */
+  load(profile: string): Promise<Credential | null>
+  /** delete はプロファイルの Credential を削除する。 */
+  delete(profile: string): Promise<void>
+  /** list は保存済みプロファイルの一覧を kind/defaultProject 付きで返す。 */
+  list(): Promise<CredentialListEntry[]>
+}
+
+/** CredentialEnvelope は keychain に JSON で保存する内部形式。 */
+interface CredentialEnvelope {
+  kind: CredentialKind
+  value: string
+  defaultProject?: string
+}
+
+/**
+ * serializeCredential は Credential を JSON エンベロープ文字列に変換する。
+ */
+function serializeCredential(cred: Credential): string {
+  const env: CredentialEnvelope = { kind: cred.kind, value: cred.value }
+  if (cred.defaultProject !== undefined) env.defaultProject = cred.defaultProject
+  return JSON.stringify(env)
+}
+
+/**
+ * deserializeCredential は JSON エンベロープ文字列または legacy 平文値を Credential に変換する。
+ *
+ * JSON エンベロープを優先し、パース失敗時は legacy 平文として detectCredentialKind で種別判定する。
+ * SA Key の legacy 平文値は defaultProject が不明なため null を返す。
+ */
+function deserializeCredential(raw: string): Credential | null {
+  // JSON エンベロープ形式の判定: {"kind": で始まるかどうかで区別
+  if (raw.startsWith('{"kind":')) {
+    try {
+      const env = JSON.parse(raw) as unknown
+      if (
+        typeof env === "object" &&
+        env !== null &&
+        "kind" in env &&
+        "value" in env &&
+        typeof (env as CredentialEnvelope).kind === "string" &&
+        typeof (env as CredentialEnvelope).value === "string"
+      ) {
+        const envelope = env as CredentialEnvelope
+        if (envelope.kind === "sa") {
+          if (!envelope.defaultProject) return null
+          return { kind: "sa", value: envelope.value, defaultProject: envelope.defaultProject }
+        }
+        const cred: Credential =
+          envelope.kind === "pat"
+            ? { kind: "pat", value: envelope.value }
+            : { kind: "sid", value: envelope.value }
+        if (envelope.defaultProject !== undefined) {
+          ;(cred as { defaultProject?: string }).defaultProject = envelope.defaultProject
+        }
+        return cred
+      }
+    } catch {
+      // JSON パース失敗時は legacy 平文として扱う
+    }
+  }
+
+  // legacy 平文値: pat_/cs_ プレフィックスで種別判定
+  const kind = detectCredentialKind(raw)
+  if (kind === "pat") return { kind: "pat", value: raw }
+  if (kind === "sid") return { kind: "sid", value: raw }
+  // SA Key の legacy 平文値は defaultProject が不明なため null
+  return null
+}
+
+/**
+ * TokenStoreCredentialAdapter は既存の TokenStore を使って CredentialStore を実装するアダプタ。
+ *
+ * keychain への実際の永続化は TokenStore に委譲する。
+ */
+export class TokenStoreCredentialAdapter implements CredentialStore {
+  constructor(private readonly tokenStore: TokenStore) {}
+
+  async save(profile: string, cred: Credential): Promise<void> {
+    await this.tokenStore.save(profile, serializeCredential(cred))
+  }
+
+  async load(profile: string): Promise<Credential | null> {
+    const raw = await this.tokenStore.load(profile)
+    if (raw === null) return null
+    return deserializeCredential(raw)
+  }
+
+  async delete(profile: string): Promise<void> {
+    await this.tokenStore.delete(profile)
+  }
+
+  async list(): Promise<CredentialListEntry[]> {
+    const profiles = await this.tokenStore.list()
+    const entries: CredentialListEntry[] = []
+    for (const profile of profiles) {
+      const cred = await this.load(profile)
+      if (cred === null) continue
+      const entry: CredentialListEntry = { profile, kind: cred.kind }
+      if (cred.defaultProject !== undefined) entry.defaultProject = cred.defaultProject
+      entries.push(entry)
+    }
+    return entries
+  }
+}
+
+/** InMemoryCredentialStore はテスト用のインメモリ実装。 */
+export class InMemoryCredentialStore implements CredentialStore {
+  private readonly store = new Map<string, Credential>()
+
+  async save(profile: string, cred: Credential): Promise<void> {
+    this.store.set(profile, cred)
+  }
+
+  async load(profile: string): Promise<Credential | null> {
+    return this.store.get(profile) ?? null
+  }
+
+  async delete(profile: string): Promise<void> {
+    this.store.delete(profile)
+  }
+
+  async list(): Promise<CredentialListEntry[]> {
+    const entries: CredentialListEntry[] = []
+    for (const [profile, cred] of this.store) {
+      const entry: CredentialListEntry = { profile, kind: cred.kind }
+      if (cred.defaultProject !== undefined) entry.defaultProject = cred.defaultProject
+      entries.push(entry)
+    }
+    return entries
+  }
+}

--- a/src/core/auth/credential.ts
+++ b/src/core/auth/credential.ts
@@ -24,12 +24,13 @@ export type CredentialKind = "sid" | "pat" | "sa"
  *
  * - sid: connect.sid Cookie。書き込み操作が可能な唯一の方式。defaultProject は省略可能。
  * - pat: Personal Access Token。読み取り専用。defaultProject は省略可能。
- * - sa: Service Account Key。読み取り専用。プロジェクト固有のため defaultProject は必須。
+ * - sa: Service Account Key。読み取り専用。defaultProject は省略可能 (keychain 保存時は必須)。
+ *   環境変数経由の匿名 SA Credential ではプロジェクトが不明な場合があるため省略可能とする。
  */
 export type Credential =
   | { kind: "sid"; value: string; defaultProject?: string }
   | { kind: "pat"; value: string; defaultProject?: string }
-  | { kind: "sa"; value: string; defaultProject: string }
+  | { kind: "sa"; value: string; defaultProject?: string }
 
 /** CredentialParseError は Credential の構築に失敗したことを表すエラー。 */
 export class CredentialParseError extends Error {

--- a/src/core/auth/credential.ts
+++ b/src/core/auth/credential.ts
@@ -1,0 +1,160 @@
+/**
+ * credential.ts — 認証情報 (Credential) のドメイン型と判別・構築関数。
+ *
+ * SID / PAT / SA Key の 3 種類の認証方式を統一的に扱う Credential タグ付きユニオン型を定義する。
+ * 判別ロジック (pat_/cs_ プレフィックス) はこのモジュールに集約し、
+ * 他のモジュールが独自に文字列マッチを行うことを排除する。
+ */
+
+// SID フォーマット: RFC 6265 cookie-octet に準拠した印字可能 ASCII
+const SID_MAX_LENGTH = 4096
+const SID_PATTERN = /^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/
+
+// PAT フォーマット: pat_ + 64桁小文字16進数
+const PAT_PATTERN = /^pat_[0-9a-f]{64}$/
+
+// SA Key フォーマット: cs_ + 64桁小文字16進数
+const SA_KEY_PATTERN = /^cs_[0-9a-f]{64}$/
+
+/** CredentialKind は認証方式の種別。 */
+export type CredentialKind = "sid" | "pat" | "sa"
+
+/**
+ * Credential は認証情報のタグ付きユニオン型。
+ *
+ * - sid: connect.sid Cookie。書き込み操作が可能な唯一の方式。defaultProject は省略可能。
+ * - pat: Personal Access Token。読み取り専用。defaultProject は省略可能。
+ * - sa: Service Account Key。読み取り専用。プロジェクト固有のため defaultProject は必須。
+ */
+export type Credential =
+  | { kind: "sid"; value: string; defaultProject?: string }
+  | { kind: "pat"; value: string; defaultProject?: string }
+  | { kind: "sa"; value: string; defaultProject: string }
+
+/** CredentialParseError は Credential の構築に失敗したことを表すエラー。 */
+export class CredentialParseError extends Error {
+  /** kind は失敗した検証の種別。 */
+  readonly kind: string
+  /** hint は修正方法を示すヒントメッセージ。 */
+  readonly hint: string
+
+  constructor(kind: string, message: string, hint: string) {
+    super(message)
+    this.name = "CredentialParseError"
+    this.kind = kind
+    this.hint = hint
+  }
+}
+
+/**
+ * detectCredentialKind は生の文字列値から認証方式の種別を判別する。
+ *
+ * プレフィックスのみで判別し、フォーマット検証は行わない。
+ * pat_/cs_ 以外はすべて SID とみなす。空文字は "unknown" を返す。
+ */
+export function detectCredentialKind(raw: string): CredentialKind | "unknown" {
+  if (raw.length === 0) return "unknown"
+  if (raw.startsWith("pat_")) return "pat"
+  if (raw.startsWith("cs_")) return "sa"
+  // pat_/cs_ 以外は SID として扱う (SID のフォーマットは多様なため正のマッチは使わない)
+  // ただし SID_PATTERN に合致しない値は parseCredential でエラーになる
+  return "sid"
+}
+
+/**
+ * parseCredential は生の文字列値を検証して Credential を構築する。
+ *
+ * @param raw - 認証情報の生の文字列値
+ * @param opts.defaultProject - プロジェクト名。SA Key では必須。SID/PAT では省略可能。
+ * @throws CredentialParseError フォーマット違反または SA Key で defaultProject 未指定の場合
+ */
+export function parseCredential(raw: string, opts?: { defaultProject?: string }): Credential {
+  const kind = detectCredentialKind(raw)
+
+  if (kind === "unknown") {
+    throw new CredentialParseError(
+      "UNKNOWN_KIND",
+      "認証情報のフォーマットが不正です",
+      "有効な SID、pat_ で始まる PAT、または cs_ で始まる SA Key を指定してください",
+    )
+  }
+
+  if (kind === "pat") {
+    if (!PAT_PATTERN.test(raw)) {
+      throw new CredentialParseError(
+        "INVALID_PAT",
+        "Personal Access Token のフォーマットが不正です",
+        "pat_ で始まる 68 文字 (pat_ + 64 桁小文字 16 進数) を指定してください",
+      )
+    }
+    const cred: { kind: "pat"; value: string; defaultProject?: string } = {
+      kind: "pat",
+      value: raw,
+    }
+    if (opts?.defaultProject !== undefined) cred.defaultProject = opts.defaultProject
+    return cred
+  }
+
+  if (kind === "sa") {
+    if (!SA_KEY_PATTERN.test(raw)) {
+      throw new CredentialParseError(
+        "INVALID_SA",
+        "Service Account キーのフォーマットが不正です",
+        "cs_ で始まる 67 文字 (cs_ + 64 桁小文字 16 進数) を指定してください",
+      )
+    }
+    const project = opts?.defaultProject
+    if (!project || project.length === 0) {
+      throw new CredentialParseError(
+        "SA_PROJECT_REQUIRED",
+        "Service Account Key にはプロジェクト名が必要です",
+        "--project フラグまたは COS_PROJECT 環境変数でプロジェクト名を指定してください",
+      )
+    }
+    return { kind: "sa", value: raw, defaultProject: project }
+  }
+
+  // kind === "sid"
+  if (raw.length === 0 || raw.length > SID_MAX_LENGTH || !SID_PATTERN.test(raw)) {
+    throw new CredentialParseError(
+      "INVALID_SID",
+      "SID のフォーマットが不正です",
+      "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
+    )
+  }
+  const cred: { kind: "sid"; value: string; defaultProject?: string } = { kind: "sid", value: raw }
+  if (opts?.defaultProject !== undefined) cred.defaultProject = opts.defaultProject
+  return cred
+}
+
+/**
+ * canWrite は Credential が書き込み操作を実行できるかを返す。
+ *
+ * SID のみ書き込み可能。PAT と SA Key は読み取り専用。
+ */
+export function canWrite(cred: Credential): boolean {
+  return cred.kind === "sid"
+}
+
+/**
+ * isValidSaKeyFormat は SA Key の文字列フォーマット (cs_ + 64桁小文字16進数) のみを検証する。
+ *
+ * `parseCredential` と異なり project 不要。`assertValidServiceAccountKey` の内部で使用する。
+ */
+export function isValidSaKeyFormat(key: string): boolean {
+  return SA_KEY_PATTERN.test(key)
+}
+
+/**
+ * displayKind は Credential の種別を人間が読みやすい文字列で返す。
+ */
+export function displayKind(cred: Credential): string {
+  switch (cred.kind) {
+    case "sid":
+      return "SID"
+    case "pat":
+      return "PAT"
+    case "sa":
+      return "Service Account"
+  }
+}

--- a/tests/unit/commands/_shared.resolve.test.ts
+++ b/tests/unit/commands/_shared.resolve.test.ts
@@ -1,0 +1,244 @@
+/**
+ * _shared.resolve.test.ts — resolveActiveCredential の単体テスト。
+ *
+ * 認証情報の解決優先順位 (環境変数 > プロファイル > デフォルト) を検証する。
+ * キーチェーン呼び出しは InMemoryCredentialStore で代替し、OS 依存を排除する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import type { CommonArgs } from "@/commands/_shared"
+import { resolveActiveCredential } from "@/commands/_shared"
+import type { Credential } from "@/core/auth/credential"
+import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+
+// テスト用フィクスチャ
+const VALID_SID = "s%3AabcDEF123456789012345678901234567890"
+const VALID_PAT = `pat_${"a".repeat(64)}`
+const VALID_SA_KEY = `cs_${"b".repeat(64)}`
+
+/** テスト用デフォルト CommonArgs を生成するヘルパー */
+function makeArgs(overrides: Partial<CommonArgs> = {}): CommonArgs {
+  return {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: false,
+    ...overrides,
+  }
+}
+
+describe("resolveActiveCredential — 環境変数 COS_PERSONAL_ACCESS_TOKEN", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  it("有効な PAT が設定されている場合 PAT Credential を返す", async () => {
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = VALID_PAT
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("pat")
+    expect(cred.value).toBe(VALID_PAT)
+  })
+
+  it("COS_PERSONAL_ACCESS_TOKEN が COS_SID より優先される", async () => {
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = VALID_PAT
+    process.env["COS_SID"] = VALID_SID
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("pat")
+  })
+
+  it("不正な PAT が設定されている場合は exit 5 で終了する", async () => {
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = "不正なPATフォーマット"
+    const store = new InMemoryCredentialStore()
+
+    try {
+      await resolveActiveCredential(makeArgs(), store)
+    } catch {
+      // exitWithError による throw は想定内
+    }
+
+    expect(exitMock).toHaveBeenCalledWith(5)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("INVALID_PERSONAL_ACCESS_TOKEN")
+  })
+})
+
+describe("resolveActiveCredential — 環境変数 COS_SERVICE_ACCOUNT_KEY", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_PROJECT")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+    Reflect.deleteProperty(process.env, "COS_PROJECT")
+  })
+
+  it("有効な SA Key + COS_PROJECT が設定されている場合 SA Credential を返す", async () => {
+    process.env["COS_SERVICE_ACCOUNT_KEY"] = VALID_SA_KEY
+    process.env["COS_PROJECT"] = "作業プロジェクト"
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("sa")
+    expect(cred.value).toBe(VALID_SA_KEY)
+  })
+
+  it("COS_SERVICE_ACCOUNT_KEY が COS_SID より優先される", async () => {
+    process.env["COS_SERVICE_ACCOUNT_KEY"] = VALID_SA_KEY
+    process.env["COS_PROJECT"] = "作業プロジェクト"
+    process.env["COS_SID"] = VALID_SID
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("sa")
+  })
+})
+
+describe("resolveActiveCredential — 環境変数 COS_SID", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+  let stderrMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    stderrMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  it("有効な SID が設定されている場合 SID Credential を返す", async () => {
+    process.env["COS_SID"] = VALID_SID
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("sid")
+    expect(cred.value).toBe(VALID_SID)
+  })
+
+  it("COS_SID に PAT を設定した場合は PAT Credential を返す (互換モード: stderr 警告あり)", async () => {
+    // COS_PERSONAL_ACCESS_TOKEN への移行を促すが、PAT として動作させる互換動作
+    process.env["COS_SID"] = VALID_PAT
+    const store = new InMemoryCredentialStore()
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    // 警告を出して PAT として処理 (Phase 6 で hard error に切り替え)
+    expect(cred.kind).toBe("pat")
+    const stderrOutput = (stderrMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stderrOutput).toContain("COS_PERSONAL_ACCESS_TOKEN")
+  })
+})
+
+describe("resolveActiveCredential — keychain (CredentialStore) からの解決", () => {
+  let exitMock: ReturnType<typeof spyOn>
+  let stdoutMock: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+    stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  afterEach(() => {
+    exitMock.mockRestore()
+    stdoutMock.mockRestore()
+    Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+    Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+    Reflect.deleteProperty(process.env, "COS_SID")
+  })
+
+  it("--profile で指定したプロファイルの Credential を取得できる", async () => {
+    const store = new InMemoryCredentialStore()
+    const sidCred: Credential = { kind: "sid", value: VALID_SID }
+    await store.save("仕事用", sidCred)
+
+    const cred = await resolveActiveCredential(makeArgs({ profile: "仕事用" }), store)
+
+    expect(cred.kind).toBe("sid")
+    expect(cred.value).toBe(VALID_SID)
+  })
+
+  it("プロファイル指定なしのとき default プロファイルを参照する", async () => {
+    const store = new InMemoryCredentialStore()
+    const patCred: Credential = { kind: "pat", value: VALID_PAT }
+    await store.save("default", patCred)
+
+    const cred = await resolveActiveCredential(makeArgs(), store)
+
+    expect(cred.kind).toBe("pat")
+    expect(cred.value).toBe(VALID_PAT)
+  })
+
+  it("keychain にも認証情報がない場合は exit 2 + AUTH_REQUIRED で終了する", async () => {
+    const store = new InMemoryCredentialStore()
+
+    try {
+      await resolveActiveCredential(makeArgs(), store)
+    } catch {
+      // exitWithError による throw は想定内
+    }
+
+    expect(exitMock).toHaveBeenCalledWith(2)
+    const stdoutOutput = (stdoutMock.mock.calls as Array<[string]>).map((c) => c[0]).join("")
+    expect(stdoutOutput).toContain("AUTH_REQUIRED")
+  })
+
+  it("PAT Credential が保存されたプロファイルを正しく読み出せる", async () => {
+    const store = new InMemoryCredentialStore()
+    const patCred: Credential = { kind: "pat", value: VALID_PAT }
+    await store.save("個人PAT", patCred)
+
+    const cred = await resolveActiveCredential(makeArgs({ profile: "個人PAT" }), store)
+
+    expect(cred.kind).toBe("pat")
+    expect(cred.value).toBe(VALID_PAT)
+  })
+})

--- a/tests/unit/commands/auth/whoami.pat.test.ts
+++ b/tests/unit/commands/auth/whoami.pat.test.ts
@@ -110,12 +110,17 @@ beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
   Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
 })
 
 afterEach(() => {
   exitMock.mockRestore()
   stdoutMock?.mockRestore()
   stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/commands/auth/whoami.test.ts
+++ b/tests/unit/commands/auth/whoami.test.ts
@@ -78,6 +78,8 @@ beforeEach(() => {
   exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
   stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
   Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
   Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
   Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
 })
@@ -86,6 +88,9 @@ afterEach(() => {
   exitMock.mockRestore()
   stdoutMock?.mockRestore()
   stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
   server.resetHandlers()
 })
 

--- a/tests/unit/core/auth/credential-store.test.ts
+++ b/tests/unit/core/auth/credential-store.test.ts
@@ -1,0 +1,197 @@
+/**
+ * credential-store.test.ts — CredentialStore interface とアダプタ実装のテスト。
+ *
+ * TokenStore を内部バックエンドに使いながら、Credential 型で CRUD できることを確認する。
+ * legacy 平文 SID/PAT 値 (JSON エンベロープ以前に保存されたもの) の互換読み出しも検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { Credential } from "@/core/auth/credential"
+import { InMemoryCredentialStore, TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
+import { InMemoryTokenStore } from "@/core/auth/store"
+
+// テスト用フィクスチャ
+const VALID_SID = "s%3AabcDEF123456789012345678901234567890"
+const VALID_PAT = `pat_${"a".repeat(64)}`
+const VALID_SA_KEY = `cs_${"b".repeat(64)}`
+
+describe("TokenStoreCredentialAdapter — SID Credential の保存と読み出し", () => {
+  it("SID Credential を保存して取得できる", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+    const cred: Credential = { kind: "sid", value: VALID_SID }
+
+    await store.save("個人用プロファイル", cred)
+    const loaded = await store.load("個人用プロファイル")
+
+    expect(loaded).not.toBeNull()
+    expect(loaded?.kind).toBe("sid")
+    expect(loaded?.value).toBe(VALID_SID)
+  })
+
+  it("SID Credential の defaultProject が保持される", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+    const cred: Credential = { kind: "sid", value: VALID_SID, defaultProject: "私のプロジェクト" }
+
+    await store.save("仕事用プロファイル", cred)
+    const loaded = await store.load("仕事用プロファイル")
+
+    expect(loaded?.defaultProject).toBe("私のプロジェクト")
+  })
+})
+
+describe("TokenStoreCredentialAdapter — PAT Credential の保存と読み出し", () => {
+  it("PAT Credential を保存して取得できる", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+    const cred: Credential = { kind: "pat", value: VALID_PAT }
+
+    await store.save("個人PAT", cred)
+    const loaded = await store.load("個人PAT")
+
+    expect(loaded?.kind).toBe("pat")
+    expect(loaded?.value).toBe(VALID_PAT)
+  })
+})
+
+describe("TokenStoreCredentialAdapter — SA Credential の保存と読み出し", () => {
+  it("SA Credential を保存して取得できる", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+    const cred: Credential = {
+      kind: "sa",
+      value: VALID_SA_KEY,
+      defaultProject: "チーム開発プロジェクト",
+    }
+
+    await store.save("チームSA", cred)
+    const loaded = await store.load("チームSA")
+
+    expect(loaded?.kind).toBe("sa")
+    expect(loaded?.value).toBe(VALID_SA_KEY)
+    expect(loaded?.defaultProject).toBe("チーム開発プロジェクト")
+  })
+})
+
+describe("TokenStoreCredentialAdapter — legacy 平文値の互換読み出し", () => {
+  it("legacy 平文 SID 値を SID Credential として読み出せる", async () => {
+    // 旧バージョンが保存した平文 SID 文字列を新アダプタで読める
+    const tokenStore = new InMemoryTokenStore()
+    await tokenStore.save("旧プロファイル", VALID_SID)
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+
+    const loaded = await store.load("旧プロファイル")
+
+    expect(loaded?.kind).toBe("sid")
+    expect(loaded?.value).toBe(VALID_SID)
+  })
+
+  it("legacy 平文 PAT 値を PAT Credential として読み出せる", async () => {
+    // 旧バージョンが保存した平文 PAT 文字列を新アダプタで読める
+    const tokenStore = new InMemoryTokenStore()
+    await tokenStore.save("旧PATプロファイル", VALID_PAT)
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+
+    const loaded = await store.load("旧PATプロファイル")
+
+    expect(loaded?.kind).toBe("pat")
+    expect(loaded?.value).toBe(VALID_PAT)
+  })
+})
+
+describe("TokenStoreCredentialAdapter — 削除操作", () => {
+  it("プロファイルを削除できる", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+    const cred: Credential = { kind: "sid", value: VALID_SID }
+
+    await store.save("削除対象プロファイル", cred)
+    await store.delete("削除対象プロファイル")
+
+    expect(await store.load("削除対象プロファイル")).toBeNull()
+  })
+
+  it("存在しないプロファイルを load すると null を返す", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+
+    expect(await store.load("存在しないプロファイル")).toBeNull()
+  })
+})
+
+describe("TokenStoreCredentialAdapter — list 操作", () => {
+  it("保存したプロファイルの一覧を kind 付きで返す", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+
+    await store.save("個人用SID", { kind: "sid", value: VALID_SID })
+    await store.save("個人PAT", { kind: "pat", value: VALID_PAT })
+    await store.save("チームSA", {
+      kind: "sa",
+      value: VALID_SA_KEY,
+      defaultProject: "team-project",
+    })
+
+    const list = await store.list()
+
+    expect(list).toHaveLength(3)
+    const sidEntry = list.find((e) => e.profile === "個人用SID")
+    expect(sidEntry?.kind).toBe("sid")
+    const patEntry = list.find((e) => e.profile === "個人PAT")
+    expect(patEntry?.kind).toBe("pat")
+    const saEntry = list.find((e) => e.profile === "チームSA")
+    expect(saEntry?.kind).toBe("sa")
+    expect(saEntry?.defaultProject).toBe("team-project")
+  })
+
+  it("SA Credential の list エントリには defaultProject が含まれる", async () => {
+    const tokenStore = new InMemoryTokenStore()
+    const store = new TokenStoreCredentialAdapter(tokenStore)
+
+    await store.save("SAプロファイル", {
+      kind: "sa",
+      value: VALID_SA_KEY,
+      defaultProject: "開発チームプロジェクト",
+    })
+
+    const list = await store.list()
+    expect(list[0]?.defaultProject).toBe("開発チームプロジェクト")
+  })
+})
+
+describe("InMemoryCredentialStore — テスト用インメモリ実装", () => {
+  it("SID Credential を保存して取得できる", async () => {
+    const store = new InMemoryCredentialStore()
+    const cred: Credential = { kind: "sid", value: VALID_SID }
+
+    await store.save("default", cred)
+    const loaded = await store.load("default")
+
+    expect(loaded?.kind).toBe("sid")
+    expect(loaded?.value).toBe(VALID_SID)
+  })
+
+  it("存在しないプロファイルは null を返す", async () => {
+    const store = new InMemoryCredentialStore()
+    expect(await store.load("nonexistent")).toBeNull()
+  })
+
+  it("プロファイルを削除できる", async () => {
+    const store = new InMemoryCredentialStore()
+    await store.save("削除テスト", { kind: "pat", value: VALID_PAT })
+    await store.delete("削除テスト")
+    expect(await store.load("削除テスト")).toBeNull()
+  })
+
+  it("list が kind/profile/defaultProject を含む配列を返す", async () => {
+    const store = new InMemoryCredentialStore()
+    await store.save("personalSID", { kind: "sid", value: VALID_SID })
+    await store.save("teamSA", { kind: "sa", value: VALID_SA_KEY, defaultProject: "team-proj" })
+
+    const list = await store.list()
+    expect(list).toHaveLength(2)
+    expect(list.some((e) => e.profile === "personalSID" && e.kind === "sid")).toBe(true)
+    expect(list.some((e) => e.profile === "teamSA" && e.kind === "sa")).toBe(true)
+  })
+})

--- a/tests/unit/core/auth/credential.test.ts
+++ b/tests/unit/core/auth/credential.test.ts
@@ -1,0 +1,183 @@
+/**
+ * credential.test.ts — Credential ドメイン型と判別関数のテスト。
+ *
+ * 認証方式 (SID / PAT / SA Key) を統一的に扱う Credential 型の
+ * 構築・判別・能力チェックを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  CredentialParseError,
+  canWrite,
+  detectCredentialKind,
+  displayKind,
+  parseCredential,
+} from "@/core/auth/credential"
+
+// テスト用フィクスチャ
+const VALID_SID = "s%3AabcDEF123456789012345678901234567890"
+const VALID_PAT = `pat_${"a".repeat(64)}`
+const VALID_SA_KEY = `cs_${"b".repeat(64)}`
+const DEFAULT_PROJECT = "my-cosense-project"
+
+describe("detectCredentialKind", () => {
+  it("pat_ プレフィックスは PAT と判別できる", () => {
+    expect(detectCredentialKind(VALID_PAT)).toBe("pat")
+  })
+
+  it("cs_ プレフィックスは SA と判別できる", () => {
+    expect(detectCredentialKind(VALID_SA_KEY)).toBe("sa")
+  })
+
+  it("s%3A で始まる SID は SID と判別できる", () => {
+    // SID はエンコードされた cookie 値なので pat_/cs_ 以外は SID とみなす
+    expect(detectCredentialKind(VALID_SID)).toBe("sid")
+  })
+
+  it("空文字は unknown と判別できる", () => {
+    expect(detectCredentialKind("")).toBe("unknown")
+  })
+
+  it("pat_/cs_ 以外のプレフィックスは SID として判別できる", () => {
+    // SID のフォーマットは多様 (例: s%3A<random>, 英数字の組み合わせ等) なため
+    // pat_/cs_ 以外はすべて SID とみなす
+    expect(detectCredentialKind("xyz_unknown")).toBe("sid")
+  })
+})
+
+describe("parseCredential — SID", () => {
+  it("有効な SID から SID Credential を構築できる", () => {
+    const cred = parseCredential(VALID_SID)
+    expect(cred.kind).toBe("sid")
+    expect(cred.value).toBe(VALID_SID)
+  })
+
+  it("SID に省略可能な defaultProject を付与できる", () => {
+    const cred = parseCredential(VALID_SID, { defaultProject: DEFAULT_PROJECT })
+    expect(cred.kind).toBe("sid")
+    expect(cred.defaultProject).toBe(DEFAULT_PROJECT)
+  })
+
+  it("空文字の SID は CredentialParseError をスローする", () => {
+    expect(() => parseCredential("")).toThrow(CredentialParseError)
+  })
+
+  it("制御文字を含む SID は CredentialParseError をスローする", () => {
+    expect(() => parseCredential("sid\x00value")).toThrow(CredentialParseError)
+  })
+
+  it("PAT 文字列を渡すと PAT Credential として自動判別される", () => {
+    // detectCredentialKind が pat_ を PAT と判別するため PAT Credential を返す
+    const cred = parseCredential(VALID_PAT)
+    expect(cred.kind).toBe("pat")
+  })
+})
+
+describe("parseCredential — PAT", () => {
+  it("有効な PAT から PAT Credential を構築できる", () => {
+    const cred = parseCredential(VALID_PAT)
+    expect(cred.kind).toBe("pat")
+    expect(cred.value).toBe(VALID_PAT)
+  })
+
+  it("PAT に省略可能な defaultProject を付与できる", () => {
+    const cred = parseCredential(VALID_PAT, { defaultProject: DEFAULT_PROJECT })
+    expect(cred.defaultProject).toBe(DEFAULT_PROJECT)
+  })
+
+  it("pat_ プレフィックスが正しくない PAT は CredentialParseError をスローする", () => {
+    // 64桁ではなく63桁
+    const shortPat = `pat_${"a".repeat(63)}`
+    expect(() => parseCredential(shortPat)).toThrow(CredentialParseError)
+  })
+
+  it("大文字を含む PAT は CredentialParseError をスローする", () => {
+    const upperPat = `pat_${"A".repeat(64)}`
+    expect(() => parseCredential(upperPat)).toThrow(CredentialParseError)
+  })
+})
+
+describe("parseCredential — SA Key", () => {
+  it("有効な SA Key と defaultProject から SA Credential を構築できる", () => {
+    const cred = parseCredential(VALID_SA_KEY, { defaultProject: DEFAULT_PROJECT })
+    expect(cred.kind).toBe("sa")
+    expect(cred.value).toBe(VALID_SA_KEY)
+    expect(cred.defaultProject).toBe(DEFAULT_PROJECT)
+  })
+
+  it("SA Key に defaultProject を渡さないと CredentialParseError をスローする", () => {
+    // SA Credential は defaultProject が必須
+    expect(() => parseCredential(VALID_SA_KEY)).toThrow(CredentialParseError)
+  })
+
+  it("SA Key に空文字の defaultProject を渡すと CredentialParseError をスローする", () => {
+    expect(() => parseCredential(VALID_SA_KEY, { defaultProject: "" })).toThrow(
+      CredentialParseError,
+    )
+  })
+
+  it("cs_ プレフィックスが正しくない SA Key は CredentialParseError をスローする", () => {
+    const shortKey = `cs_${"b".repeat(63)}`
+    expect(() => parseCredential(shortKey, { defaultProject: DEFAULT_PROJECT })).toThrow(
+      CredentialParseError,
+    )
+  })
+})
+
+describe("CredentialParseError", () => {
+  it("kind フィールドを持つ", () => {
+    try {
+      parseCredential("")
+    } catch (e) {
+      expect(e).toBeInstanceOf(CredentialParseError)
+      if (e instanceof CredentialParseError) {
+        expect(typeof e.kind).toBe("string")
+      }
+    }
+  })
+
+  it("hint フィールドを持つ", () => {
+    try {
+      parseCredential("")
+    } catch (e) {
+      if (e instanceof CredentialParseError) {
+        expect(typeof e.hint).toBe("string")
+        expect(e.hint.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe("canWrite", () => {
+  it("SID Credential は書き込み可能", () => {
+    const cred = parseCredential(VALID_SID)
+    expect(canWrite(cred)).toBe(true)
+  })
+
+  it("PAT Credential は書き込み不可", () => {
+    const cred = parseCredential(VALID_PAT)
+    expect(canWrite(cred)).toBe(false)
+  })
+
+  it("SA Credential は書き込み不可", () => {
+    const cred = parseCredential(VALID_SA_KEY, { defaultProject: DEFAULT_PROJECT })
+    expect(canWrite(cred)).toBe(false)
+  })
+})
+
+describe("displayKind", () => {
+  it("SID Credential の表示文字列は 'SID'", () => {
+    const cred = parseCredential(VALID_SID)
+    expect(displayKind(cred)).toBe("SID")
+  })
+
+  it("PAT Credential の表示文字列は 'PAT'", () => {
+    const cred = parseCredential(VALID_PAT)
+    expect(displayKind(cred)).toBe("PAT")
+  })
+
+  it("SA Credential の表示文字列は 'Service Account'", () => {
+    const cred = parseCredential(VALID_SA_KEY, { defaultProject: DEFAULT_PROJECT })
+    expect(displayKind(cred)).toBe("Service Account")
+  })
+})


### PR DESCRIPTION
## Summary

coscli 認証再設計プランの Phase 1〜3 を実装する。

- **Phase 1**: `Credential` タグ付きユニオン型と判別関数を `src/core/auth/credential.ts` に集約し、`pat_/cs_` プレフィックス検出ロジックを 1 ファイルに閉じ込めた
- **Phase 2**: `CredentialStore` interface と `TokenStoreCredentialAdapter` を新設し、keychain を JSON エンベロープ形式で読み書きできる抽象層を提供した (legacy 平文値の後方互換あり)
- **Phase 3**: `resolveActiveCredential` 関数を実装し、`buildRestClient`・`requireSid`・`whoami.ts` から `pat_` 文字列マッチ分岐を除去した

### 解決優先順位 (resolveActiveCredential)

1. `COS_PERSONAL_ACCESS_TOKEN` env → 匿名 PAT Credential
2. `COS_SERVICE_ACCOUNT_KEY` env → 匿名 SA Credential
3. `COS_SID` env (profile 未指定時) → SID Credential (PAT 値は互換 + stderr 警告)
4–7. CredentialStore (--profile → "default" プロファイル)

### 後方互換

- keychain の legacy 平文 SID/PAT 値は自動判別して読み出し可能
- `buildRestClient` の `config.serviceAccounts` フォールバックは Phase 4 まで保持
- `COS_SID` への PAT 混入は Phase 6 まで stderr 警告で受理

## Test plan

- [ ] `bun test` 全 1504 件 pass を確認
- [ ] `bunx biome check src tests` エラーゼロを確認
- [ ] `bun run typecheck` エラーゼロを確認
- [ ] 既存の `_shared.test.ts`・`_shared.pat.test.ts`・`whoami.test.ts`・`whoami.pat.test.ts` が外形挙動を維持していることを確認

Refs #auth-redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * サービスアカウントキー認証への対応を追加しました。

* **Bug Fixes**
  * 認証情報の検証とフォーマット判定の精度を向上させました。
  * 複数の認証方式を使用する場合の優先順位を明確化しました。

* **Tests**
  * 認証情報の解決と検証に関する包括的なテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->