### PR TITLE
feat(auth): auth list / status / doctor / use コマンドを新設する (Phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ cos search          全文検索 (--vector でベクトル検索、--infobox で
 cos auth login     認証ログイン (--sid / --pat でクレデンシャルを直接渡す)
 cos auth logout    ログアウト
 cos auth whoami    現在のログインユーザーを表示
+cos auth list      登録済みプロファイルを一覧表示する (alias: ls)
+cos auth status    現在のアクティブ認証情報と解決経路を表示する
+cos auth doctor    全プロファイルの健全性を検査する
+cos auth use       デフォルトプロファイルを切り替える (--unset で削除)
 cos auth migrate   旧 config.serviceAccounts の SA キーを keychain に移行する
 
 cos config get    設定値を取得

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -442,6 +442,110 @@ export async function resolveActiveCredential(
 }
 
 /**
+ * CredentialSource は resolveActiveCredentialWithSource が返す解決経路を表す。
+ *
+ * 形式:
+ * - `"env:COS_PERSONAL_ACCESS_TOKEN"` — 環境変数 COS_PERSONAL_ACCESS_TOKEN
+ * - `"env:COS_SERVICE_ACCOUNT_KEY"` — 環境変数 COS_SERVICE_ACCOUNT_KEY
+ * - `"env:COS_SID"` — 環境変数 COS_SID
+ * - `"profile:<name>"` — keychain のプロファイル名
+ */
+export type CredentialSource =
+  | "env:COS_PERSONAL_ACCESS_TOKEN"
+  | "env:COS_SERVICE_ACCOUNT_KEY"
+  | "env:COS_SID"
+  | `profile:${string}`
+
+/** CredentialWithSource は Credential と解決経路をまとめた型。 */
+export interface CredentialWithSource {
+  credential: Credential
+  source: CredentialSource
+}
+
+/**
+ * resolveActiveCredentialWithSource は resolveActiveCredential と同じ解決ロジックを実行し、
+ * Credential と解決経路 (CredentialSource) の両方を返す。
+ *
+ * auth status コマンド専用の内部 API。
+ */
+export async function resolveActiveCredentialWithSource(
+  args: CommonArgs,
+  store: CredentialStore,
+): Promise<CredentialWithSource> {
+  // 1. COS_PERSONAL_ACCESS_TOKEN
+  const envPat = process.env["COS_PERSONAL_ACCESS_TOKEN"]
+  if (envPat !== undefined) {
+    try {
+      const cred = parseCredential(envPat)
+      if (cred.kind !== "pat") throw new Error("PAT 形式でありません")
+      return { credential: cred, source: "env:COS_PERSONAL_ACCESS_TOKEN" }
+    } catch {
+      writeErrorJson(
+        "INVALID_PERSONAL_ACCESS_TOKEN",
+        "COS_PERSONAL_ACCESS_TOKEN のフォーマットが不正です",
+        "pat_ で始まる 68 文字の Personal Access Token を指定してください",
+      )
+      exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+    }
+  }
+
+  // 2. COS_SERVICE_ACCOUNT_KEY
+  const envKey = process.env["COS_SERVICE_ACCOUNT_KEY"]
+  if (envKey !== undefined) {
+    if (!isValidSaKeyFormat(envKey)) {
+      writeErrorJson(
+        "INVALID_SERVICE_ACCOUNT_KEY",
+        "COS_SERVICE_ACCOUNT_KEY のフォーマットが不正です",
+        "cs_ で始まる 67 文字のキーを指定してください",
+      )
+      exitWithError(5, "INVALID_SERVICE_ACCOUNT_KEY")
+    }
+    const project = args.project ?? process.env["COS_PROJECT"]
+    const credSa: { kind: "sa"; value: string; defaultProject?: string } = {
+      kind: "sa",
+      value: envKey,
+    }
+    if (project !== undefined) credSa.defaultProject = project
+    return { credential: credSa, source: "env:COS_SERVICE_ACCOUNT_KEY" }
+  }
+
+  // 3. COS_SID env (profile 未指定時のみ)
+  if (!args.profile) {
+    const envSid = process.env["COS_SID"]
+    if (envSid !== undefined) {
+      if (detectCredentialKind(envSid) === "pat") {
+        process.stderr.write(
+          "警告: COS_SID に Personal Access Token が設定されています。COS_PERSONAL_ACCESS_TOKEN 環境変数の使用を推奨します。\n",
+        )
+        try {
+          return { credential: parseCredential(envSid), source: "env:COS_SID" }
+        } catch {
+          exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
+        }
+      }
+      try {
+        return { credential: parseCredential(envSid), source: "env:COS_SID" }
+      } catch {
+        exitWithError(5, "INVALID_SID")
+      }
+    }
+  }
+
+  // 4-7. CredentialStore からプロファイルを解決
+  const profile = args.profile ?? "default"
+  const cred = await store.load(profile)
+  if (cred === null) {
+    writeErrorJson(
+      "AUTH_REQUIRED",
+      "認証情報が見つかりません",
+      "`cos auth login` を実行してログインしてください",
+    )
+    exitWithError(2, "AUTH_REQUIRED")
+  }
+  return { credential: cred, source: `profile:${profile}` }
+}
+
+/**
  * requireSid はセッション ID を取得し、未認証または書き込み不可の場合はエラーで終了する。
  *
  * 認証解決は resolveActiveCredential に委譲し、canWrite で書き込み可否を判定する。

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -520,12 +520,22 @@ export async function resolveActiveCredentialWithSource(
         try {
           return { credential: parseCredential(envSid), source: "env:COS_SID" }
         } catch {
+          writeErrorJson(
+            "INVALID_PERSONAL_ACCESS_TOKEN",
+            "COS_SID に設定された Personal Access Token のフォーマットが不正です",
+            "pat_ で始まる 68 文字の Personal Access Token を COS_PERSONAL_ACCESS_TOKEN 環境変数で指定してください",
+          )
           exitWithError(5, "INVALID_PERSONAL_ACCESS_TOKEN")
         }
       }
       try {
         return { credential: parseCredential(envSid), source: "env:COS_SID" }
       } catch {
+        writeErrorJson(
+          "INVALID_SID",
+          "COS_SID のフォーマットが不正です",
+          "改行・制御文字・空白を含まない印字可能 ASCII 文字列を指定してください",
+        )
         exitWithError(5, "INVALID_SID")
       }
     }

--- a/src/commands/auth/doctor.ts
+++ b/src/commands/auth/doctor.ts
@@ -1,0 +1,107 @@
+/**
+ * auth/doctor.ts — `cos auth doctor` コマンド。
+ *
+ * 全プロファイルに対してフォーマット検証を行い、問題があれば修復方法を提示する。
+ * exit code: 1 件でも fail があれば exit 1。
+ */
+
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
+import { displayKind } from "@/core/auth/credential"
+import type { CredentialStore } from "@/core/auth/credential-store"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** DoctorResult は doctor コマンドがプロファイルごとに生成する検査結果。 */
+interface DoctorResult {
+  profile: string
+  kind: string
+  status: "ok" | "warn"
+  message?: string
+}
+
+/** AuthDoctorCommandDeps は createAuthDoctorCommand に注入できる依存。テスト専用。 */
+export interface AuthDoctorCommandDeps {
+  /** createCredStore は CredentialStore を生成する関数。未指定時は OS keychain を使用する。 */
+  createCredStore?: () => CredentialStore
+}
+
+/** createAuthDoctorCommand は依存を注入して doctor コマンドを生成する。 */
+export function createAuthDoctorCommand(deps: AuthDoctorCommandDeps = {}) {
+  const getCredStore = () =>
+    deps.createCredStore
+      ? deps.createCredStore()
+      : new TokenStoreCredentialAdapter(createTokenStore())
+
+  return defineCommand({
+    meta: { name: "doctor", description: "全プロファイルの健全性を検査する" },
+    args: { ...commonArgs },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.doctor", a)
+      const startTime = Date.now()
+
+      const credStore = getCredStore()
+      const entries = await credStore.list()
+      const results: DoctorResult[] = []
+
+      for (const entry of entries) {
+        const cred = await credStore.load(entry.profile)
+        if (cred === null) {
+          results.push({
+            profile: entry.profile,
+            kind: entry.kind,
+            status: "warn",
+            message: "プロファイルが keychain から読み取れませんでした",
+          })
+          continue
+        }
+
+        // SA Credential は defaultProject 必須
+        if (cred.kind === "sa" && !cred.defaultProject) {
+          results.push({
+            profile: entry.profile,
+            kind: entry.kind,
+            status: "warn",
+            message:
+              "SA Credential に defaultProject が設定されていません。`cos auth migrate` で再移行するか、プロファイルを削除して再登録してください",
+          })
+          continue
+        }
+
+        results.push({
+          profile: entry.profile,
+          kind: displayKind(cred),
+          status: "ok",
+        })
+      }
+
+      const hasWarn = results.some((r) => r.status === "warn")
+
+      if (a.json) {
+        writeJson({ profiles: results }, { command: "auth.doctor", startTime }, buildJsonOpts(a))
+        if (hasWarn) process.exit(1)
+        return
+      }
+
+      if (entries.length === 0) {
+        process.stdout.write("登録済みのプロファイルはありません\n")
+        return
+      }
+
+      for (const r of results) {
+        const icon = r.status === "ok" ? "✓" : "✗"
+        process.stdout.write(`${icon} ${r.profile} (${r.kind})\n`)
+        if (r.message) {
+          process.stdout.write(`  → ${r.message}\n`)
+        }
+      }
+
+      if (hasWarn) process.exit(1)
+    },
+  })
+}
+
+/** authDoctorCommand は OS keychain を使うデフォルト実装。 */
+export const authDoctorCommand = createAuthDoctorCommand()

--- a/src/commands/auth/list.ts
+++ b/src/commands/auth/list.ts
@@ -1,0 +1,64 @@
+/**
+ * auth/list.ts — `cos auth list` コマンド。
+ *
+ * keychain に登録された全プロファイルを kind・defaultProject 付きで一覧表示する。
+ * alias: `cos auth ls`
+ */
+
+import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
+import type { CredentialStore } from "@/core/auth/credential-store"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+/** AuthListCommandDeps は createAuthListCommand に注入できる依存。テスト専用。 */
+export interface AuthListCommandDeps {
+  /** createCredStore は CredentialStore を生成する関数。未指定時は OS keychain を使用する。 */
+  createCredStore?: () => CredentialStore
+}
+
+/** createAuthListCommand は依存を注入して list コマンドを生成する。 */
+export function createAuthListCommand(deps: AuthListCommandDeps = {}) {
+  const getCredStore = () =>
+    deps.createCredStore
+      ? deps.createCredStore()
+      : new TokenStoreCredentialAdapter(createTokenStore())
+
+  return defineCommand({
+    meta: { name: "list", description: "登録済み認証プロファイルを一覧表示する" },
+    args: { ...commonArgs },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.list", a)
+      const startTime = Date.now()
+
+      const credStore = getCredStore()
+      const entries = await credStore.list()
+
+      if (a.json || !a.plain) {
+        const profiles = entries.map((e) => ({
+          profile: e.profile,
+          kind: e.kind,
+          ...(e.defaultProject !== undefined ? { defaultProject: e.defaultProject } : {}),
+        }))
+        writeJson({ profiles }, { command: "auth.list", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      if (entries.length === 0) {
+        process.stdout.write("登録済みのプロファイルはありません\n")
+        return
+      }
+
+      writePlainTable(
+        ["プロファイル", "kind", "defaultProject"],
+        entries.map((e) => [e.profile, e.kind, e.defaultProject ?? ""]),
+      )
+    },
+  })
+}
+
+/** authListCommand は OS keychain を使うデフォルト実装。 */
+export const authListCommand = createAuthListCommand()

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,0 +1,86 @@
+/**
+ * auth/status.ts — `cos auth status` コマンド。
+ *
+ * 現在アクティブな認証情報と解決経路 (7 段優先順位のどれにヒットしたか) を表示する。
+ */
+
+import {
+  type CommonArgs,
+  type CredentialSource,
+  buildJsonOpts,
+  checkSandbox,
+  commonArgs,
+  resolveActiveCredentialWithSource,
+} from "@/commands/_shared"
+import type { CredentialStore } from "@/core/auth/credential-store"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable } from "@/presenter/plain"
+import { defineCommand } from "citty"
+
+/** AuthStatusCommandDeps は createAuthStatusCommand に注入できる依存。テスト専用。 */
+export interface AuthStatusCommandDeps {
+  /** createCredStore は CredentialStore を生成する関数。未指定時は OS keychain を使用する。 */
+  createCredStore?: () => CredentialStore
+}
+
+/** createAuthStatusCommand は依存を注入して status コマンドを生成する。 */
+export function createAuthStatusCommand(deps: AuthStatusCommandDeps = {}) {
+  const getCredStore = () =>
+    deps.createCredStore
+      ? deps.createCredStore()
+      : new TokenStoreCredentialAdapter(createTokenStore())
+
+  return defineCommand({
+    meta: { name: "status", description: "現在のアクティブ認証情報と解決経路を表示する" },
+    args: { ...commonArgs },
+    async run({ args }) {
+      const a = args as CommonArgs
+      checkSandbox("auth.status", a)
+      const startTime = Date.now()
+
+      const credStore = getCredStore()
+      const { credential: cred, source } = await resolveActiveCredentialWithSource(a, credStore)
+
+      const sourceLabel = formatSource(source)
+
+      if (a.json || !a.plain) {
+        writeJson(
+          {
+            kind: cred.kind,
+            source,
+            ...(cred.defaultProject !== undefined ? { defaultProject: cred.defaultProject } : {}),
+          },
+          { command: "auth.status", startTime },
+          buildJsonOpts(a),
+        )
+        return
+      }
+
+      writePlainTable(
+        ["フィールド", "値"],
+        [
+          ["認証種別", cred.kind],
+          ["解決経路", sourceLabel],
+          ...(cred.defaultProject !== undefined
+            ? ([["デフォルトプロジェクト", cred.defaultProject]] as [string, string][])
+            : []),
+        ],
+      )
+    },
+  })
+}
+
+/** formatSource は CredentialSource を人が読みやすい形式に変換する。 */
+function formatSource(source: CredentialSource): string {
+  if (source === "env:COS_PERSONAL_ACCESS_TOKEN") return "環境変数 COS_PERSONAL_ACCESS_TOKEN"
+  if (source === "env:COS_SERVICE_ACCOUNT_KEY") return "環境変数 COS_SERVICE_ACCOUNT_KEY"
+  if (source === "env:COS_SID") return "環境変数 COS_SID"
+  // "profile:<name>" 形式
+  const profileName = source.slice("profile:".length)
+  return `キーチェーン プロファイル "${profileName}"`
+}
+
+/** authStatusCommand は OS keychain を使うデフォルト実装。 */
+export const authStatusCommand = createAuthStatusCommand()

--- a/src/commands/auth/use.ts
+++ b/src/commands/auth/use.ts
@@ -1,0 +1,111 @@
+/**
+ * auth/use.ts — `cos auth use` コマンド。
+ *
+ * config.defaultProfile を更新してデフォルト認証プロファイルを切り替える。
+ * 存在しないプロファイル指定は exit 4 + PROFILE_NOT_FOUND。
+ * --unset で defaultProfile を削除する。
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildLogger,
+  checkSandbox,
+  commonArgs,
+  exitWithError,
+} from "@/commands/_shared"
+import type { CredentialStore } from "@/core/auth/credential-store"
+import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
+import { defaultConfigPath, loadConfig, saveConfig } from "@/infra/config"
+import { createTokenStore } from "@/infra/keychain/index"
+import { writeErrorJson, writeJson } from "@/presenter/json"
+import { defineCommand } from "citty"
+
+/** AuthUseCommandDeps は createAuthUseCommand に注入できる依存。テスト専用。 */
+export interface AuthUseCommandDeps {
+  /** configPath は設定ファイルパスの上書き。未指定時はデフォルトパスを使用する。 */
+  configPath?: string
+  /** createCredStore は CredentialStore を生成する関数。未指定時は OS keychain を使用する。 */
+  createCredStore?: () => CredentialStore
+}
+
+/** createAuthUseCommand は依存を注入して use コマンドを生成する。 */
+export function createAuthUseCommand(deps: AuthUseCommandDeps = {}) {
+  const getConfigPath = () => deps.configPath ?? defaultConfigPath()
+  const getCredStore = () =>
+    deps.createCredStore
+      ? deps.createCredStore()
+      : new TokenStoreCredentialAdapter(createTokenStore())
+
+  return defineCommand({
+    meta: {
+      name: "use",
+      description: "デフォルト認証プロファイルを切り替える",
+    },
+    args: {
+      ...commonArgs,
+      unset: {
+        type: "boolean",
+        description: "defaultProfile を削除する",
+        default: false,
+      },
+    },
+    async run({ args }) {
+      type UseArgs = CommonArgs & { unset: boolean }
+      const a = args as UseArgs
+      checkSandbox("auth.use", a)
+      const logger = buildLogger(a)
+      const startTime = Date.now()
+
+      const configPath = getConfigPath()
+      const config = loadConfig(configPath)
+
+      if (a.unset) {
+        // defaultProfile を削除する
+        const { defaultProfile: _removed, ...rest } = config
+        saveConfig(rest, configPath)
+        logger.success("defaultProfile を削除しました")
+        if (a.json) {
+          writeJson({ defaultProfile: null }, { command: "auth.use", startTime }, buildJsonOpts(a))
+        }
+        return
+      }
+
+      const profileName = a.profile
+      if (!profileName) {
+        writeErrorJson(
+          "PROFILE_REQUIRED",
+          "プロファイル名が指定されていません",
+          "--profile (-p) フラグでプロファイル名を指定してください",
+        )
+        exitWithError(5, "VALIDATION_ERROR")
+      }
+
+      // プロファイルの存在確認
+      const credStore = getCredStore()
+      const cred = await credStore.load(profileName)
+      if (cred === null) {
+        writeErrorJson(
+          "PROFILE_NOT_FOUND",
+          `プロファイル "${profileName}" は登録されていません`,
+          "`cos auth list` で登録済みプロファイルを確認してください",
+        )
+        exitWithError(4, "PROFILE_NOT_FOUND")
+      }
+
+      saveConfig({ ...config, defaultProfile: profileName }, configPath)
+      logger.success(`デフォルトプロファイルを "${profileName}" に設定しました`)
+
+      if (a.json) {
+        writeJson(
+          { defaultProfile: profileName },
+          { command: "auth.use", startTime },
+          buildJsonOpts(a),
+        )
+      }
+    },
+  })
+}
+
+/** authUseCommand は OS keychain を使うデフォルト実装。 */
+export const authUseCommand = createAuthUseCommand()

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -45,9 +45,13 @@ import { projectStreamCommand } from "@/commands/project/stream"
 import { searchCommand } from "@/commands/search"
 
 // 認証コマンド
+import { authDoctorCommand } from "@/commands/auth/doctor"
+import { authListCommand } from "@/commands/auth/list"
 import { authLoginCommand } from "@/commands/auth/login"
 import { authLogoutCommand } from "@/commands/auth/logout"
 import { authMigrateCommand } from "@/commands/auth/migrate"
+import { authStatusCommand } from "@/commands/auth/status"
+import { authUseCommand } from "@/commands/auth/use"
 import { authWhoamiCommand } from "@/commands/auth/whoami"
 
 // 設定コマンド
@@ -162,6 +166,11 @@ export const authCommand = defineCommand({
     whoami: authWhoamiCommand,
     me: authWhoamiCommand,
     migrate: authMigrateCommand,
+    list: authListCommand,
+    ls: authListCommand,
+    status: authStatusCommand,
+    doctor: authDoctorCommand,
+    use: authUseCommand,
   },
   run: showUsageIfNoSubCommand,
 })

--- a/tests/unit/commands/auth/doctor.test.ts
+++ b/tests/unit/commands/auth/doctor.test.ts
@@ -98,7 +98,7 @@ describe("authDoctorCommand — プロファイルなし", () => {
     const output = getPlain()
 
     expect(exitMock).not.toHaveBeenCalled()
-    expect(output.length).toBeGreaterThanOrEqual(0)
+    expect(output).toContain("登録済みのプロファイルはありません")
   })
 })
 

--- a/tests/unit/commands/auth/doctor.test.ts
+++ b/tests/unit/commands/auth/doctor.test.ts
@@ -1,0 +1,116 @@
+/**
+ * doctor.test.ts — `cos auth doctor` コマンドのユニットテスト。
+ *
+ * 全プロファイルのフォーマット検証を行う動作を検証する。
+ * (API ping は --check オプションのオプトインであり、ここではフォーマット検証のみテストする)
+ * keychain は InMemoryCredentialStore で代替する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthDoctorCommand } from "@/commands/auth/doctor"
+import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock.mockRestore()
+})
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+function capturePlainOutput(): () => string {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => chunks.join("")
+}
+
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => JSON.parse(chunks.join(""))
+}
+
+async function runDoctor(args: Record<string, unknown>, credStore: InMemoryCredentialStore) {
+  const command = createAuthDoctorCommand({ createCredStore: () => credStore })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+const defaultArgs = {
+  json: false,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: undefined,
+  "results-only": false,
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authDoctorCommand — 全プロファイル正常", () => {
+  it("全プロファイルが OK の場合は exit しないこと", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
+    await credStore.save("work", { kind: "pat", value: `pat_${"a".repeat(64)}` })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore)
+    const output = getPlain()
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(output).toContain("default")
+    expect(output).toContain("work")
+  })
+})
+
+describe("authDoctorCommand — プロファイルなし", () => {
+  it("プロファイルが空の場合は正常終了すること", async () => {
+    const credStore = new InMemoryCredentialStore()
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore)
+    const output = getPlain()
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(output.length).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe("authDoctorCommand — --json 出力", () => {
+  it("JSON 出力に profiles 配列が含まれること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
+
+    const getJson = captureJsonOutput()
+    await runDoctor({ ...defaultArgs, json: true }, credStore)
+    const output = getJson() as { data?: { profiles: unknown[] } }
+
+    expect(output.data?.profiles).toHaveLength(1)
+  })
+})

--- a/tests/unit/commands/auth/list.test.ts
+++ b/tests/unit/commands/auth/list.test.ts
@@ -1,0 +1,130 @@
+/**
+ * list.test.ts — `cos auth list` コマンドのユニットテスト。
+ *
+ * keychain に登録された全プロファイルを kind 付きで一覧表示する動作を検証する。
+ * keychain は InMemoryCredentialStore で代替する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthListCommand } from "@/commands/auth/list"
+import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+})
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => JSON.parse(chunks.join(""))
+}
+
+function capturePlainOutput(): () => string {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => chunks.join("")
+}
+
+async function runList(args: Record<string, unknown>, credStore: InMemoryCredentialStore) {
+  const command = createAuthListCommand({ createCredStore: () => credStore })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+const defaultArgs = {
+  json: false,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: undefined,
+  "results-only": false,
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authListCommand — --json 出力", () => {
+  it("登録済みプロファイルが kind・defaultProject 付きで返ること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid-abc" })
+    await credStore.save("work-pat", { kind: "pat", value: `pat_${"a".repeat(64)}` })
+    await credStore.save("cs_仕事プロジェクト", {
+      kind: "sa",
+      value: "cs_cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      defaultProject: "仕事プロジェクト",
+    })
+
+    const getJson = captureJsonOutput()
+    await runList({ ...defaultArgs, json: true }, credStore)
+    const output = getJson() as { data?: { profiles: Array<Record<string, unknown>> } }
+
+    expect(output.data?.profiles).toHaveLength(3)
+    const sidEntry = output.data?.profiles.find((p) => p["profile"] === "default")
+    expect(sidEntry?.["kind"]).toBe("sid")
+    const patEntry = output.data?.profiles.find((p) => p["profile"] === "work-pat")
+    expect(patEntry?.["kind"]).toBe("pat")
+    const saEntry = output.data?.profiles.find((p) => p["profile"] === "cs_仕事プロジェクト")
+    expect(saEntry?.["kind"]).toBe("sa")
+    expect(saEntry?.["defaultProject"]).toBe("仕事プロジェクト")
+  })
+
+  it("プロファイルが空の場合は空配列を返すこと", async () => {
+    const credStore = new InMemoryCredentialStore()
+    const getJson = captureJsonOutput()
+    await runList({ ...defaultArgs, json: true }, credStore)
+    const output = getJson() as { data?: { profiles: unknown[] } }
+    expect(output.data?.profiles).toHaveLength(0)
+  })
+})
+
+describe("authListCommand — プレーン出力", () => {
+  it("プロファイル名と kind が表示されること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid-abc" })
+    await credStore.save("work-pat", { kind: "pat", value: `pat_${"a".repeat(64)}` })
+
+    const getPlain = capturePlainOutput()
+    await runList(defaultArgs, credStore)
+    const output = getPlain()
+
+    expect(output).toContain("default")
+    expect(output).toContain("sid")
+    expect(output).toContain("work-pat")
+    expect(output).toContain("pat")
+  })
+})

--- a/tests/unit/commands/auth/list.test.ts
+++ b/tests/unit/commands/auth/list.test.ts
@@ -119,7 +119,7 @@ describe("authListCommand — プレーン出力", () => {
     await credStore.save("work-pat", { kind: "pat", value: `pat_${"a".repeat(64)}` })
 
     const getPlain = capturePlainOutput()
-    await runList(defaultArgs, credStore)
+    await runList({ ...defaultArgs, plain: true }, credStore)
     const output = getPlain()
 
     expect(output).toContain("default")

--- a/tests/unit/commands/auth/status.test.ts
+++ b/tests/unit/commands/auth/status.test.ts
@@ -1,0 +1,173 @@
+/**
+ * status.test.ts — `cos auth status` コマンドのユニットテスト。
+ *
+ * アクティブな認証情報と解決経路を表示する動作を検証する。
+ * keychain は InMemoryCredentialStore で代替し、環境変数は各テストで制御する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { createAuthStatusCommand } from "@/commands/auth/status"
+import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  Reflect.deleteProperty(process.env, "COS_PROFILE")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock?.mockRestore()
+  stderrMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+  Reflect.deleteProperty(process.env, "COS_SERVICE_ACCOUNT_KEY")
+  Reflect.deleteProperty(process.env, "COS_PROFILE")
+})
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+function captureJsonOutput(): () => unknown {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => JSON.parse(chunks.join(""))
+}
+
+function capturePlainOutput(): () => string {
+  const chunks: string[] = []
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => chunks.join("")
+}
+
+async function runStatus(args: Record<string, unknown>, credStore: InMemoryCredentialStore) {
+  const command = createAuthStatusCommand({ createCredStore: () => credStore })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+const jsonArgs = {
+  json: true,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: undefined,
+  "results-only": false,
+}
+
+const plainArgs = {
+  json: false,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: undefined,
+  "results-only": false,
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authStatusCommand — 環境変数 COS_PERSONAL_ACCESS_TOKEN", () => {
+  it("JSON 出力に kind: 'pat' と source: 'env:COS_PERSONAL_ACCESS_TOKEN' が含まれること", async () => {
+    process.env["COS_PERSONAL_ACCESS_TOKEN"] = `pat_${"a".repeat(64)}`
+    const credStore = new InMemoryCredentialStore()
+
+    const getJson = captureJsonOutput()
+    await runStatus(jsonArgs, credStore)
+    const output = getJson() as { data?: Record<string, unknown> }
+
+    expect(output.data?.["kind"]).toBe("pat")
+    expect(output.data?.["source"]).toBe("env:COS_PERSONAL_ACCESS_TOKEN")
+  })
+})
+
+describe("authStatusCommand — COS_SID 環境変数", () => {
+  it("JSON 出力に kind: 'sid' と source: 'env:COS_SID' が含まれること", async () => {
+    process.env["COS_SID"] = "s%3Atest-sid-xyz"
+    const credStore = new InMemoryCredentialStore()
+
+    const getJson = captureJsonOutput()
+    await runStatus(jsonArgs, credStore)
+    const output = getJson() as { data?: Record<string, unknown> }
+
+    expect(output.data?.["kind"]).toBe("sid")
+    expect(output.data?.["source"]).toBe("env:COS_SID")
+  })
+})
+
+describe("authStatusCommand — keychain プロファイル", () => {
+  it("keychain の default プロファイルから解決した場合に source: 'profile:default' が含まれること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Akeychain-sid" })
+
+    const getJson = captureJsonOutput()
+    await runStatus(jsonArgs, credStore)
+    const output = getJson() as { data?: Record<string, unknown> }
+
+    expect(output.data?.["kind"]).toBe("sid")
+    expect(output.data?.["source"]).toBe("profile:default")
+  })
+
+  it("--profile work を指定した場合に source: 'profile:work' が含まれること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("work", { kind: "pat", value: `pat_${"b".repeat(64)}` })
+
+    const getJson = captureJsonOutput()
+    await runStatus({ ...jsonArgs, profile: "work" }, credStore)
+    const output = getJson() as { data?: Record<string, unknown> }
+
+    expect(output.data?.["kind"]).toBe("pat")
+    expect(output.data?.["source"]).toBe("profile:work")
+  })
+})
+
+describe("authStatusCommand — プレーン出力", () => {
+  it("プレーン出力に kind と source が含まれること", async () => {
+    process.env["COS_SID"] = "s%3Atest-plain-sid"
+    const credStore = new InMemoryCredentialStore()
+
+    const getPlain = capturePlainOutput()
+    await runStatus(plainArgs, credStore)
+    const output = getPlain()
+
+    expect(output).toContain("sid")
+    expect(output).toContain("COS_SID")
+  })
+})
+
+describe("authStatusCommand — 認証情報なし", () => {
+  it("認証情報が解決できない場合は exit 2 になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    // 環境変数なし・keychain 空
+
+    try {
+      await runStatus(jsonArgs, credStore)
+    } catch {
+      // exitWithError による throw は想定内
+    }
+
+    expect(exitMock).toHaveBeenCalledWith(2)
+  })
+})

--- a/tests/unit/commands/auth/status.test.ts
+++ b/tests/unit/commands/auth/status.test.ts
@@ -78,7 +78,7 @@ const jsonArgs = {
 
 const plainArgs = {
   json: false,
-  plain: false,
+  plain: true,
   quiet: false,
   verbose: false,
   profile: undefined,

--- a/tests/unit/commands/auth/use.test.ts
+++ b/tests/unit/commands/auth/use.test.ts
@@ -1,0 +1,119 @@
+/**
+ * use.test.ts — `cos auth use` コマンドのユニットテスト。
+ *
+ * config.defaultProfile を更新する動作を検証する。
+ * 設定ファイル操作は一時ディレクトリで代替し、keychain は InMemoryCredentialStore で代替する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createAuthUseCommand } from "@/commands/auth/use"
+import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+import { loadConfig } from "@/infra/config"
+
+// ---------------------------------------------------------------------------
+// 一時設定ファイル管理
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+let configPath: string
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `coscli-use-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(tmpDir, { recursive: true })
+  configPath = join(tmpDir, "config.json5")
+  writeFileSync(configPath, JSON.stringify({ defaultProject: "テスト" }))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// テスト前後処理
+// ---------------------------------------------------------------------------
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+})
+
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
+
+async function runUse(args: Record<string, unknown>, credStore: InMemoryCredentialStore) {
+  const command = createAuthUseCommand({ configPath, createCredStore: () => credStore })
+  await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+const baseArgs = {
+  json: false,
+  plain: false,
+  quiet: false,
+  verbose: false,
+  profile: undefined,
+  "results-only": false,
+  unset: false,
+}
+
+// ---------------------------------------------------------------------------
+// テストケース
+// ---------------------------------------------------------------------------
+
+describe("authUseCommand — 基本動作", () => {
+  it("存在するプロファイルを指定すると config.defaultProfile が更新されること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("work", { kind: "sid", value: "s%3Awork-sid-abc" })
+
+    await runUse({ ...baseArgs, profile: "work" }, credStore)
+
+    const config = loadConfig(configPath)
+    expect(config.defaultProfile).toBe("work")
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+
+  it("存在しないプロファイルを指定すると exit 4 (PROFILE_NOT_FOUND) になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    // work プロファイルは登録していない
+
+    try {
+      await runUse({ ...baseArgs, profile: "存在しないプロファイル" }, credStore)
+    } catch {
+      // exitWithError による throw は想定内
+    }
+
+    expect(exitMock).toHaveBeenCalledWith(4)
+  })
+})
+
+describe("authUseCommand — --unset", () => {
+  it("--unset で config.defaultProfile が削除されること", async () => {
+    // 事前に defaultProfile を設定しておく
+    writeFileSync(configPath, JSON.stringify({ defaultProject: "テスト", defaultProfile: "work" }))
+    const credStore = new InMemoryCredentialStore()
+
+    await runUse({ ...baseArgs, unset: true }, credStore)
+
+    const config = loadConfig(configPath)
+    expect(config.defaultProfile).toBeUndefined()
+    expect(exitMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- `cos auth list` (alias `ls`): keychain の全プロファイルを kind・defaultProject 付きで一覧表示
- `cos auth status`: 現在のアクティブ認証情報と解決経路 (7 段優先順位のどれにヒットしたか) を表示。`--json` 対応
- `cos auth doctor`: 全プロファイルのフォーマット検証。問題があれば修復方法を提示。1 件でも fail なら exit 1
- `cos auth use`: `config.defaultProfile` を更新してデフォルトプロファイルを切り替え。存在しないプロファイルは exit 4 + `PROFILE_NOT_FOUND`。`--unset` で削除
- `_shared.ts` に `resolveActiveCredentialWithSource` を追加し、Credential と解決経路を同時返す内部 API を提供

## Test plan

- [ ] `bun test` 全件 pass (1514 tests)
- [ ] `bunx biome check src tests` 警告ゼロ
- [ ] `bun run typecheck` エラーゼロ
- [ ] `cos auth list` が登録済みプロファイルを一覧表示する
- [ ] `cos auth status` が現在の認証種別と解決経路を表示する
- [ ] `cos auth use work` が `config.defaultProfile` を `work` に更新する
- [ ] `cos auth use --unset` が `config.defaultProfile` を削除する
- [ ] 存在しないプロファイルで `cos auth use` すると exit 4 になる
- [ ] `cos auth doctor` が全プロファイル OK 時に exit 0 で終了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `cos auth list`（別名: `ls`）：登録済みの認証プロファイルを一覧表示
  * `cos auth status`：現在の認証情報と解決経路を表示
  * `cos auth doctor`：全プロファイルの健全性検査を実行（警告で非0終了）
  * `cos auth use`：デフォルトプロファイルを切り替え／`--unset`で削除

* **ドキュメント**
  * README に上記コマンドの説明を追加

* **テスト**
  * それぞれの認証コマンドのユニットテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->