### PR TITLE
feat(auth): auth doctor に API 疎通確認を追加して SID の有効性をチェックする

### DIFF
--- a/src/commands/auth/doctor.ts
+++ b/src/commands/auth/doctor.ts
@@ -40,9 +40,18 @@ export interface AuthDoctorCommandDeps {
 }
 
 function defaultCreateClient(cred: Credential): DoctorApiClient {
-  if (cred.kind === "pat") return new CosenseRestClient({ personalAccessToken: cred.value })
-  if (cred.kind === "sa") return new CosenseRestClient({ serviceAccountKey: cred.value })
-  return new CosenseRestClient({ sid: cred.value })
+  switch (cred.kind) {
+    case "pat":
+      return new CosenseRestClient({ personalAccessToken: cred.value })
+    case "sa":
+      return new CosenseRestClient({ serviceAccountKey: cred.value })
+    case "sid":
+      return new CosenseRestClient({ sid: cred.value })
+    default: {
+      const _exhaustive: never = cred
+      throw new Error("未対応の Credential kind です")
+    }
+  }
 }
 
 /** createAuthDoctorCommand は依存を注入して doctor コマンドを生成する。 */

--- a/src/commands/auth/doctor.ts
+++ b/src/commands/auth/doctor.ts
@@ -1,17 +1,22 @@
 /**
  * auth/doctor.ts — `cos auth doctor` コマンド。
  *
- * 全プロファイルに対してフォーマット検証を行い、問題があれば修復方法を提示する。
+ * 全プロファイルに対してフォーマット検証と API 疎通確認を行い、問題があれば修復方法を提示する。
  * exit code: 1 件でも fail があれば exit 1。
+ *
+ * デフォルトで /api/users/me に疎通確認を行う。
+ * --offline を指定した場合はフォーマット検証のみ実行する。
  */
 
 import { type CommonArgs, buildJsonOpts, checkSandbox, commonArgs } from "@/commands/_shared"
-import { displayKind } from "@/core/auth/credential"
+import { AuthError, CosenseRestClient } from "@/core/api/rest"
+import { type Credential, displayKind } from "@/core/auth/credential"
 import type { CredentialStore } from "@/core/auth/credential-store"
 import { TokenStoreCredentialAdapter } from "@/core/auth/credential-store"
 import { createTokenStore } from "@/infra/keychain/index"
 import { writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
+import { ZodError } from "zod"
 
 /** DoctorResult は doctor コマンドがプロファイルごとに生成する検査結果。 */
 interface DoctorResult {
@@ -21,10 +26,23 @@ interface DoctorResult {
   message?: string
 }
 
+/** DoctorApiClient は API 疎通確認に使用するクライアントの最小インターフェース。 */
+interface DoctorApiClient {
+  getMe(): Promise<unknown>
+}
+
 /** AuthDoctorCommandDeps は createAuthDoctorCommand に注入できる依存。テスト専用。 */
 export interface AuthDoctorCommandDeps {
   /** createCredStore は CredentialStore を生成する関数。未指定時は OS keychain を使用する。 */
   createCredStore?: () => CredentialStore
+  /** createClient は API 疎通確認用クライアントを生成する関数。未指定時は CosenseRestClient を使用する。 */
+  createClient?: (cred: Credential) => DoctorApiClient
+}
+
+function defaultCreateClient(cred: Credential): DoctorApiClient {
+  if (cred.kind === "pat") return new CosenseRestClient({ personalAccessToken: cred.value })
+  if (cred.kind === "sa") return new CosenseRestClient({ serviceAccountKey: cred.value })
+  return new CosenseRestClient({ sid: cred.value })
 }
 
 /** createAuthDoctorCommand は依存を注入して doctor コマンドを生成する。 */
@@ -33,12 +51,20 @@ export function createAuthDoctorCommand(deps: AuthDoctorCommandDeps = {}) {
     deps.createCredStore
       ? deps.createCredStore()
       : new TokenStoreCredentialAdapter(createTokenStore())
+  const getClient = deps.createClient ?? defaultCreateClient
 
   return defineCommand({
     meta: { name: "doctor", description: "全プロファイルの健全性を検査する" },
-    args: { ...commonArgs },
+    args: {
+      ...commonArgs,
+      offline: {
+        type: "boolean" as const,
+        description: "API 疎通確認をスキップする（オフライン環境向け）",
+        default: false,
+      },
+    },
     async run({ args }) {
-      const a = args as CommonArgs
+      const a = args as CommonArgs & { offline: boolean }
       checkSandbox("auth.doctor", a)
       const startTime = Date.now()
 
@@ -70,11 +96,44 @@ export function createAuthDoctorCommand(deps: AuthDoctorCommandDeps = {}) {
           continue
         }
 
-        results.push({
-          profile: entry.profile,
-          kind: displayKind(cred),
-          status: "ok",
-        })
+        // --offline が指定された場合は API 疎通確認をスキップする
+        if (a.offline) {
+          results.push({
+            profile: entry.profile,
+            kind: displayKind(cred),
+            status: "ok",
+          })
+          continue
+        }
+
+        // API 疎通確認: /api/users/me を呼び出して認証の有効性を確認する
+        try {
+          const client = getClient(cred)
+          await client.getMe()
+          results.push({
+            profile: entry.profile,
+            kind: displayKind(cred),
+            status: "ok",
+          })
+        } catch (err) {
+          if (err instanceof AuthError || err instanceof ZodError) {
+            // ZodError: Cosense は無効なセッションで 401 でなく 200 + ゲストレスポンスを返すことがある
+            // その場合 MeSchema のパースが失敗するため、セッション無効として扱う
+            results.push({
+              profile: entry.profile,
+              kind: displayKind(cred),
+              status: "warn",
+              message: `セッションが無効です。\`cos auth login --profile ${entry.profile}\` で再ログインしてください`,
+            })
+          } else {
+            results.push({
+              profile: entry.profile,
+              kind: displayKind(cred),
+              status: "warn",
+              message: `API 疎通確認に失敗しました: ${err instanceof Error ? err.message : String(err)}`,
+            })
+          }
+        }
       }
 
       const hasWarn = results.some((r) => r.status === "warn")

--- a/tests/unit/commands/auth/doctor.test.ts
+++ b/tests/unit/commands/auth/doctor.test.ts
@@ -1,14 +1,16 @@
 /**
  * doctor.test.ts — `cos auth doctor` コマンドのユニットテスト。
  *
- * 全プロファイルのフォーマット検証を行う動作を検証する。
- * (API ping は --check オプションのオプトインであり、ここではフォーマット検証のみテストする)
- * keychain は InMemoryCredentialStore で代替する。
+ * 全プロファイルのフォーマット検証と API 疎通確認の動作を検証する。
+ * keychain は InMemoryCredentialStore で代替し、API クライアントはモック関数を注入する。
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { createAuthDoctorCommand } from "@/commands/auth/doctor"
+import { AuthError } from "@/core/api/rest"
+import type { Credential } from "@/core/auth/credential"
 import { InMemoryCredentialStore } from "@/core/auth/credential-store"
+import { ZodError, ZodIssueCode } from "zod"
 
 // ---------------------------------------------------------------------------
 // テスト前後処理
@@ -51,8 +53,38 @@ function captureJsonOutput(): () => unknown {
   return () => JSON.parse(chunks.join(""))
 }
 
-async function runDoctor(args: Record<string, unknown>, credStore: InMemoryCredentialStore) {
-  const command = createAuthDoctorCommand({ createCredStore: () => credStore })
+/** 常に成功する API クライアントを返す。 */
+function successClient() {
+  return { getMe: async () => ({ id: "user123", name: "テストユーザー" }) }
+}
+
+/** 常に AuthError を返す API クライアントを返す。 */
+function unauthorizedClient() {
+  return {
+    getMe: async (): Promise<never> => {
+      throw new AuthError()
+    },
+  }
+}
+
+/** 常にネットワークエラーを返す API クライアントを返す。 */
+function networkErrorClient() {
+  return {
+    getMe: async (): Promise<never> => {
+      throw new Error("fetch failed: network error")
+    },
+  }
+}
+
+async function runDoctor(
+  args: Record<string, unknown>,
+  credStore: InMemoryCredentialStore,
+  createClient?: (_cred: Credential) => { getMe: () => Promise<unknown> },
+) {
+  const command = createAuthDoctorCommand({
+    createCredStore: () => credStore,
+    ...(createClient !== undefined && { createClient }),
+  })
   await (command.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
     args,
     cmd: {} as never,
@@ -67,10 +99,11 @@ const defaultArgs = {
   verbose: false,
   profile: undefined,
   "results-only": false,
+  offline: false,
 }
 
 // ---------------------------------------------------------------------------
-// テストケース
+// テストケース: フォーマット検証（既存の挙動）
 // ---------------------------------------------------------------------------
 
 describe("authDoctorCommand — 全プロファイル正常", () => {
@@ -80,7 +113,8 @@ describe("authDoctorCommand — 全プロファイル正常", () => {
     await credStore.save("work", { kind: "pat", value: `pat_${"a".repeat(64)}` })
 
     const getPlain = capturePlainOutput()
-    await runDoctor(defaultArgs, credStore)
+    // API ping は successClient で必ず成功させる
+    await runDoctor(defaultArgs, credStore, () => successClient())
     const output = getPlain()
 
     expect(exitMock).not.toHaveBeenCalled()
@@ -94,7 +128,7 @@ describe("authDoctorCommand — プロファイルなし", () => {
     const credStore = new InMemoryCredentialStore()
 
     const getPlain = capturePlainOutput()
-    await runDoctor(defaultArgs, credStore)
+    await runDoctor(defaultArgs, credStore, () => successClient())
     const output = getPlain()
 
     expect(exitMock).not.toHaveBeenCalled()
@@ -108,9 +142,151 @@ describe("authDoctorCommand — --json 出力", () => {
     await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
 
     const getJson = captureJsonOutput()
-    await runDoctor({ ...defaultArgs, json: true }, credStore)
+    await runDoctor({ ...defaultArgs, json: true }, credStore, () => successClient())
     const output = getJson() as { data?: { profiles: unknown[] } }
 
     expect(output.data?.profiles).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// テストケース: API 疎通確認（新機能）
+// ---------------------------------------------------------------------------
+
+describe("authDoctorCommand — API ping 成功", () => {
+  it("getMe が成功した場合はプロファイルが ok になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, () => successClient())
+    const output = getPlain()
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(output).toContain("✓ default")
+  })
+
+  it("PAT プロファイルの getMe が成功した場合も ok になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("readonly", { kind: "pat", value: `pat_${"b".repeat(64)}` })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, () => successClient())
+    const output = getPlain()
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(output).toContain("✓ readonly")
+  })
+})
+
+describe("authDoctorCommand — API ping 失敗 (401 認証エラー)", () => {
+  it("getMe が AuthError を throw した場合は warn になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("仕事用", { kind: "sid", value: "s%3Ainvalid-sid" })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, () => unauthorizedClient())
+    const output = getPlain()
+
+    // 認証エラーは exit 1
+    expect(exitMock).toHaveBeenCalledWith(1)
+    expect(output).toContain("✗ 仕事用")
+    expect(output).toContain("セッションが無効")
+  })
+
+  it("エラーメッセージに再ログインコマンドが含まれること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("仕事用", { kind: "sid", value: "s%3Ainvalid-sid" })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, () => unauthorizedClient())
+    const output = getPlain()
+
+    expect(output).toContain("cos auth login --profile 仕事用")
+  })
+})
+
+describe("authDoctorCommand — API ping 失敗 (200 + ゲストレスポンス = ZodError)", () => {
+  it("getMe が ZodError を throw した場合はセッション無効として warn になること", async () => {
+    // Cosense は無効なセッションで 401 でなく 200 + ゲストレスポンスを返すことがある
+    // その場合 MeSchema のパースが失敗して ZodError が throw される
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("期限切れ", { kind: "sid", value: "s%3Aexpired-sid" })
+
+    const zodError = new ZodError([
+      {
+        code: ZodIssueCode.invalid_type,
+        path: ["id"],
+        message: "Required",
+        expected: "string",
+        received: "undefined",
+      },
+    ])
+    const zodErrorClient = () => ({
+      getMe: async (): Promise<never> => {
+        throw zodError
+      },
+    })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, zodErrorClient)
+    const output = getPlain()
+
+    expect(exitMock).toHaveBeenCalledWith(1)
+    expect(output).toContain("✗ 期限切れ")
+    expect(output).toContain("セッションが無効")
+    expect(output).toContain("cos auth login --profile 期限切れ")
+  })
+})
+
+describe("authDoctorCommand — API ping ネットワークエラー", () => {
+  it("getMe がネットワークエラーを throw した場合は warn になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
+
+    const getPlain = capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, () => networkErrorClient())
+    const output = getPlain()
+
+    expect(exitMock).toHaveBeenCalledWith(1)
+    expect(output).toContain("✗ default")
+    expect(output).toContain("API 疎通確認に失敗しました")
+  })
+})
+
+describe("authDoctorCommand — --offline フラグ", () => {
+  it("--offline を指定した場合は API ping をスキップして ok になること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    await credStore.save("default", { kind: "sid", value: "s%3Atest-sid" })
+
+    // getMe が呼ばれたら失敗するクライアントを渡しても ok になるはず
+    const getPlain = capturePlainOutput()
+    await runDoctor({ ...defaultArgs, offline: true }, credStore, () => networkErrorClient())
+    const output = getPlain()
+
+    expect(exitMock).not.toHaveBeenCalled()
+    expect(output).toContain("✓ default")
+  })
+})
+
+describe("authDoctorCommand — createClient に Credential が渡されること", () => {
+  it("createClient に正しい Credential が渡されること", async () => {
+    const credStore = new InMemoryCredentialStore()
+    const cred: Credential = { kind: "sid", value: "s%3Atest-sid" }
+    await credStore.save("default", cred)
+
+    // TypeScript はクロージャ内の代入を追跡できないため配列で受け取る
+    const capturedCredentials: Credential[] = []
+    const createClient = (c: Credential) => {
+      capturedCredentials.push(c)
+      return successClient()
+    }
+
+    capturePlainOutput()
+    await runDoctor(defaultArgs, credStore, createClient)
+
+    expect(capturedCredentials).toHaveLength(1)
+    expect(capturedCredentials[0]?.kind).toBe("sid")
+    expect(capturedCredentials[0]?.value).toBe("s%3Atest-sid")
   })
 })

--- a/tests/unit/commands/auth/doctor.test.ts
+++ b/tests/unit/commands/auth/doctor.test.ts
@@ -124,14 +124,22 @@ describe("authDoctorCommand — 全プロファイル正常", () => {
 })
 
 describe("authDoctorCommand — プロファイルなし", () => {
-  it("プロファイルが空の場合は正常終了すること", async () => {
+  it("プロファイルが空の場合は正常終了し createClient が呼ばれないこと", async () => {
     const credStore = new InMemoryCredentialStore()
 
+    // プロファイルが空の場合は API 疎通確認が一切実行されないことを検証する
+    let createClientCallCount = 0
+    const createClient = (_c: Credential) => {
+      createClientCallCount++
+      return successClient()
+    }
+
     const getPlain = capturePlainOutput()
-    await runDoctor(defaultArgs, credStore, () => successClient())
+    await runDoctor(defaultArgs, credStore, createClient)
     const output = getPlain()
 
     expect(exitMock).not.toHaveBeenCalled()
+    expect(createClientCallCount).toBe(0)
     expect(output).toContain("登録済みのプロファイルはありません")
   })
 })


### PR DESCRIPTION
## Summary

- `auth doctor` の各プロファイルチェックに `/api/users/me` 呼び出しを追加し、セッションの有効性を確認する
- `AuthError` (401) および `ZodError`（Cosense が無効 SID で 200 + ゲストレスポンスを返す場合）をセッション無効として検出する
- `--offline` フラグを追加して、オフライン環境では API 疎通確認をスキップできるようにする
- `AuthDoctorCommandDeps` に `createClient` 注入ポイントを追加してテスト容易性を向上する

## 出力イメージ

```
✗ テストプロファイル (SID)
  → セッションが無効です。`cos auth login --profile テストプロファイル` で再ログインしてください
✓ default (SID)
```

## 技術メモ

Cosense は無効な SID に対して 401 でなく 200 + ゲストレスポンス（`id`/`name`/`displayName` 欠落）を返す仕様のため、`ZodError` もセッション無効として扱う。

## Test plan

- [x] `bun test` 全件 pass（1544 tests）
- [x] `bun run typecheck` エラーなし
- [x] `bunx biome check src tests` エラーなし
- [x] `bun run build` 成功
- [x] 実機動作確認: `cos auth doctor` でセッション無効な SID が正しく `✗` 表示される
- [x] 実機動作確認: `cos auth doctor --offline` で API ping をスキップして `✓` 表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `cos auth doctor` コマンドが全プロファイルの API 疎通確認に対応しました
  * `--offline` オプションを追加し、API 確認をスキップできるようになりました

* **改善**
  * 認証エラー時に再ログインコマンドの案内を表示するようになりました
  * API 疎通確認失敗時の詳細なエラーメッセージを提供するようになりました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mtane0412/coscli/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->