### PR TITLE
feat(project): cos project members コマンドを追加してプロジェクトメンバー一覧を取得する

### DIFF
--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -96,6 +96,7 @@ cos search "キーワード" --project <name> --json --results-only --select 'pa
 # プロジェクト情報・フィード・横断検索
 cos project list --json --results-only
 cos project info --project <name> --json --results-only
+cos project members --project <name> --json --results-only
 cos project stream --project <name> --limit 20 --json --results-only
 cos project search "キーワード" --json --results-only
 ```
@@ -166,7 +167,7 @@ cos page rename "旧タイトル" "新タイトル" --project <name>
 # 読み取り専用に制限
 cos --enable-commands "page.list,page.get,page.text,page.code,page.url,page.icon,\
 page.history,page.table,page.snapshot.list,page.snapshot.get,page.line.get,\
-page.context,page.watch,project.list,project.info,project.graph,\
+page.context,page.watch,project.list,project.info,project.members,project.graph,\
 project.stream,project.search,search,auth.whoami,schema,exit-codes" \
     page list --project <name> --json
 
@@ -190,7 +191,7 @@ COS_ENABLE_COMMANDS="page.list,page.get,search" cos page list --project <name>
 | `page.line.get` | 行・範囲取得 |
 | `page.context` | Smart Context (リンク先本文取得、読み取り) |
 | `page.watch` | リアルタイム監視 (読み取りのみ) |
-| `project.list` / `project.info` / `project.graph` | プロジェクト情報 |
+| `project.list` / `project.info` / `project.members` / `project.graph` | プロジェクト情報 |
 | `project.stream` / `project.search` | フィード・横断検索 (読み取り) |
 | `search` | プロジェクト内ページ検索 |
 | `auth.whoami` / `auth.list` | 認証状態確認 |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ cos page snapshot get   特定スナップショットを取得
 
 cos project list    参加プロジェクト一覧を取得
 cos project info    プロジェクト情報を取得
+cos project members プロジェクトメンバー一覧を取得
 cos project stream  プロジェクトの最近更新フィードを取得 (--watch でポーリング監視)
 cos project graph   ページ間リンクをグラフとして export する (DOT / JSON / TSV)
 cos project search  参加プロジェクト全体を横断してプロジェクトを検索する (--watch-list でウォッチリスト絞り込み、--joined で参加プロジェクト全体を明示)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -38,6 +38,7 @@ import { projectGraphCommand } from "@/commands/project/graph"
 import { projectInfoCommand } from "@/commands/project/info"
 // プロジェクトコマンド
 import { projectListCommand } from "@/commands/project/list"
+import { projectMembersCommand } from "@/commands/project/members"
 import { projectSearchCommand } from "@/commands/project/search"
 import { projectStreamCommand } from "@/commands/project/stream"
 
@@ -151,6 +152,7 @@ export const projectCommand = defineCommand({
     list: projectListCommand,
     ls: projectListCommand,
     info: projectInfoCommand,
+    members: projectMembersCommand,
     graph: projectGraphCommand,
     stream: projectStreamCommand,
     search: projectSearchCommand,

--- a/src/commands/project/members.ts
+++ b/src/commands/project/members.ts
@@ -43,12 +43,7 @@ export interface ProjectMembersDeps {
   restClient?: ProjectMembersRestClient
 }
 
-/**
- * makeProjectMembersCommand は ProjectMembersDeps を受け取り、citty コマンドを返すファクトリ。
- *
- * deps を省略すると本番実装 (実際の REST API 呼び出し) を使用する。
- * テスト時は deps にモックを渡してフローを検証する。
- */
+/** makeProjectMembersCommand は ProjectMembersDeps を受け取り、citty コマンドを返す。 */
 export function makeProjectMembersCommand(deps: ProjectMembersDeps = {}) {
   return defineCommand({
     meta: {
@@ -82,19 +77,27 @@ export function makeProjectMembersCommand(deps: ProjectMembersDeps = {}) {
         throw err
       }
 
-      if (a.json || !a.plain) {
+      if (a.json) {
         writeJson(result, { command: "project.members", startTime }, buildJsonOpts(a))
         return
       }
 
-      if (result.users.length === 0) {
+      const rows = [
+        ...result.users.map((u) => [u.id, u.name, u.displayName, u.provider ?? "", "在籍中"]),
+        ...(result.memberSnapshots ?? []).map((s) => [
+          s.id,
+          String((s.data as { name?: string } | undefined)?.name ?? ""),
+          String((s.data as { displayName?: string } | undefined)?.displayName ?? ""),
+          "",
+          `退去 (${s.reason ?? ""})`,
+        ]),
+      ]
+
+      if (rows.length === 0) {
         return
       }
 
-      writePlainTable(
-        ["ID", "ユーザー名", "表示名", "プロバイダ"],
-        result.users.map((u) => [u.id, u.name, u.displayName, u.provider ?? ""]),
-      )
+      writePlainTable(["ID", "ユーザー名", "表示名", "プロバイダ", "状態"], rows)
     },
   })
 }

--- a/src/commands/project/members.ts
+++ b/src/commands/project/members.ts
@@ -1,0 +1,103 @@
+/**
+ * project/members.ts — `cos project members [<name>]` コマンド。
+ *
+ * /api/projects/:project/users を叩いてプロジェクトメンバー一覧を取得する。
+ * 現メンバー (users) と退去済みメンバー (memberSnapshots) を出力する。
+ *
+ * 終了コード:
+ *   0   正常終了
+ *   2   認証エラー
+ *   3   権限エラー
+ *   4   プロジェクト未発見
+ *   5   バリデーションエラー
+ *   7   sandbox 違反
+ */
+
+import {
+  type CommonArgs,
+  buildJsonOpts,
+  buildRestClient,
+  checkSandbox,
+  commonArgs,
+  handleRestError,
+  requireProject,
+} from "@/commands/_shared"
+import { writeJson } from "@/presenter/json"
+import { writePlainTable } from "@/presenter/plain"
+import type { ProjectMembersResponse } from "@/schemas/project"
+import { defineCommand } from "citty"
+
+/** ProjectMembersRestClient は members コマンドが REST 呼び出しに使用する最小 interface。 */
+export interface ProjectMembersRestClient {
+  getProjectMembers(project: string): Promise<ProjectMembersResponse>
+}
+
+/**
+ * ProjectMembersDeps は makeProjectMembersCommand に渡す依存オブジェクト。
+ *
+ * テスト時にモックを注入できるようにするための DI interface。
+ * 指定しないフィールドは本番実装にフォールバックする。
+ */
+export interface ProjectMembersDeps {
+  /** REST クライアント (省略時: buildRestClient で生成) */
+  restClient?: ProjectMembersRestClient
+}
+
+/**
+ * makeProjectMembersCommand は ProjectMembersDeps を受け取り、citty コマンドを返すファクトリ。
+ *
+ * deps を省略すると本番実装 (実際の REST API 呼び出し) を使用する。
+ * テスト時は deps にモックを渡してフローを検証する。
+ */
+export function makeProjectMembersCommand(deps: ProjectMembersDeps = {}) {
+  return defineCommand({
+    meta: {
+      name: "members",
+      description: "プロジェクトメンバー一覧を取得する",
+    },
+    args: {
+      ...commonArgs,
+      name: {
+        type: "positional",
+        description: "プロジェクト名 (省略時は --project フラグを使用)",
+        required: false,
+      },
+    },
+    async run({ args }) {
+      const a = args as CommonArgs & { name?: string }
+      const startTime = Date.now()
+
+      checkSandbox("project.members", a)
+
+      const project = a.name ?? requireProject(a)
+
+      const client: ProjectMembersRestClient =
+        deps.restClient !== undefined ? deps.restClient : await buildRestClient(a)
+
+      let result: ProjectMembersResponse
+      try {
+        result = await client.getProjectMembers(project)
+      } catch (err) {
+        handleRestError(err, { resourceKind: "project", resourceName: project })
+        throw err
+      }
+
+      if (a.json || !a.plain) {
+        writeJson(result, { command: "project.members", startTime }, buildJsonOpts(a))
+        return
+      }
+
+      if (result.users.length === 0) {
+        return
+      }
+
+      writePlainTable(
+        ["ID", "ユーザー名", "表示名", "プロバイダ"],
+        result.users.map((u) => [u.id, u.name, u.displayName, u.provider ?? ""]),
+      )
+    },
+  })
+}
+
+/** projectMembersCommand は deps なしの本番実装コマンド。 */
+export const projectMembersCommand = makeProjectMembersCommand()

--- a/src/core/api/rest.ts
+++ b/src/core/api/rest.ts
@@ -24,10 +24,16 @@ import type {
 } from "@/schemas/page"
 import {
   ProjectListResponseSchema,
+  ProjectMembersResponseSchema,
   ProjectSchema,
   ProjectSearchResultSchema,
 } from "@/schemas/project"
-import type { Project, ProjectListResponse, ProjectSearchResult } from "@/schemas/project"
+import type {
+  Project,
+  ProjectListResponse,
+  ProjectMembersResponse,
+  ProjectSearchResult,
+} from "@/schemas/project"
 import { PageSnapshotListSchema, PageSnapshotResultSchema } from "@/schemas/snapshot"
 import type { PageSnapshotList, PageSnapshotResult } from "@/schemas/snapshot"
 import { StreamResponseSchema } from "@/schemas/stream"
@@ -260,6 +266,14 @@ export class CosenseRestClient {
   async listProjects(): Promise<ProjectListResponse> {
     const data = await this.fetchJson(`${BASE_URL}/api/projects`)
     return ProjectListResponseSchema.parse(data)
+  }
+
+  /** getProjectMembers は /api/projects/:project/users を叩いてプロジェクトメンバー一覧を返す。 */
+  async getProjectMembers(project: string): Promise<ProjectMembersResponse> {
+    const data = await this.fetchJson(
+      `${BASE_URL}/api/projects/${encodeURIComponent(project)}/users`,
+    )
+    return ProjectMembersResponseSchema.parse(data)
   }
 
   /**

--- a/src/core/command-classification.ts
+++ b/src/core/command-classification.ts
@@ -35,6 +35,7 @@ export const READ_COMMANDS: readonly string[] = [
   "project.graph",
   "project.info",
   "project.list",
+  "project.members",
   "project.search",
   "project.stream",
   "schema",

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -67,3 +67,32 @@ export const ProjectSearchResultSchema = z.object({
   projects: z.array(FoundProjectSchema),
 })
 export type ProjectSearchResult = z.infer<typeof ProjectSearchResultSchema>
+
+/** ProjectMemberSchema は /api/projects/:project/users のレスポンス内の各メンバー要素。 */
+export const ProjectMemberSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  displayName: z.string(),
+  email: z.string().optional(),
+  provider: z.string().optional(),
+  created: z.number(),
+  updated: z.number(),
+})
+export type ProjectMember = z.infer<typeof ProjectMemberSchema>
+
+/** MemberSnapshotSchema は退去済みメンバーの記録。 */
+export const MemberSnapshotSchema = z.object({
+  id: z.string(),
+  reason: z.string().optional(),
+  created: z.number(),
+  updated: z.number(),
+  data: z.record(z.unknown()).optional(),
+})
+export type MemberSnapshot = z.infer<typeof MemberSnapshotSchema>
+
+/** ProjectMembersResponseSchema は /api/projects/:project/users のレスポンス全体。 */
+export const ProjectMembersResponseSchema = z.object({
+  users: z.array(ProjectMemberSchema),
+  memberSnapshots: z.array(MemberSnapshotSchema),
+})
+export type ProjectMembersResponse = z.infer<typeof ProjectMembersResponseSchema>

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -93,6 +93,7 @@ export type MemberSnapshot = z.infer<typeof MemberSnapshotSchema>
 /** ProjectMembersResponseSchema は /api/projects/:project/users のレスポンス全体。 */
 export const ProjectMembersResponseSchema = z.object({
   users: z.array(ProjectMemberSchema),
-  memberSnapshots: z.array(MemberSnapshotSchema),
+  // プロジェクトによっては返らない場合がある
+  memberSnapshots: z.array(MemberSnapshotSchema).optional(),
 })
 export type ProjectMembersResponse = z.infer<typeof ProjectMembersResponseSchema>

--- a/tests/unit/commands/project/members.test.ts
+++ b/tests/unit/commands/project/members.test.ts
@@ -1,0 +1,275 @@
+/**
+ * project/members.test.ts — `cos project members` コマンドのテスト。
+ *
+ * DI (deps) を使って REST クライアントをモック注入し、
+ * 正常系・エラー系・sandbox 違反・バリデーションを検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import {
+  type ProjectMembersDeps,
+  type ProjectMembersRestClient,
+  makeProjectMembersCommand,
+} from "@/commands/project/members"
+import { AuthError, ForbiddenError, NotFoundError } from "@/core/api/rest"
+import type { ProjectMembersResponse } from "@/schemas/project"
+
+// ----- モックデータ -----
+
+/** 基本 ProjectMembersResponse */
+const mockMembersResponse: ProjectMembersResponse = {
+  users: [
+    {
+      id: "ユーザーID-001",
+      name: "yamada-taro",
+      displayName: "山田太郎",
+      email: "yamada@example.co.jp",
+      provider: "google",
+      created: 1700000000,
+      updated: 1700100000,
+    },
+    {
+      id: "ユーザーID-002",
+      name: "suzuki-hanako",
+      displayName: "鈴木花子",
+      email: "suzuki@example.co.jp",
+      provider: "github",
+      created: 1700050000,
+      updated: 1700150000,
+    },
+  ],
+  memberSnapshots: [
+    {
+      id: "スナップショットID-001",
+      reason: "left",
+      created: 1699000000,
+      updated: 1699100000,
+      data: { displayName: "退去ユーザー", name: "retired-user" },
+    },
+  ],
+}
+
+/** メンバーなし・スナップショットなしの空レスポンス */
+const mockEmptyResponse: ProjectMembersResponse = {
+  users: [],
+  memberSnapshots: [],
+}
+
+// ----- モックファクトリ -----
+
+/** createMockRestClient はモック REST クライアントを生成する。 */
+function createMockRestClient(
+  response: ProjectMembersResponse = mockMembersResponse,
+  opts: { throwError?: Error } = {},
+): ProjectMembersRestClient {
+  return {
+    async getProjectMembers() {
+      if (opts.throwError) throw opts.throwError
+      return response
+    },
+  }
+}
+
+/** defaultArgs は全テストで共通の基本引数。 */
+const defaultArgs: Record<string, unknown> = {
+  name: "テストプロジェクト",
+  project: undefined,
+  json: false,
+  plain: false,
+  "results-only": false,
+  select: undefined,
+  "enable-commands": undefined,
+  "disable-commands": undefined,
+  verbose: undefined,
+  quiet: false,
+  profile: undefined,
+}
+
+/** createMockDeps はモック依存を生成する。個別フィールドを上書き可能。 */
+function createMockDeps(overrides: Partial<ProjectMembersDeps> = {}): ProjectMembersDeps {
+  return {
+    restClient: createMockRestClient(),
+    ...overrides,
+  }
+}
+
+/** runMembers は makeProjectMembersCommand の run を呼び出すヘルパー。 */
+async function runMembers(args: Record<string, unknown>, deps?: ProjectMembersDeps): Promise<void> {
+  const cmd = makeProjectMembersCommand(deps)
+  await (cmd.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>)({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+/** process.exit のモック後に継続実行で throw される例外を握り潰してコマンドを実行する */
+async function runAndIgnoreExit(
+  args: Record<string, unknown>,
+  deps?: ProjectMembersDeps,
+): Promise<void> {
+  try {
+    await runMembers(args, deps)
+  } catch {
+    // process.exit モック後の継続による throw は想定内
+  }
+}
+
+// ----- セットアップ -----
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+const writtenChunks: string[] = []
+
+beforeEach(() => {
+  writtenChunks.length = 0
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writtenChunks.push(String(chunk))
+    return true
+  })
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+})
+
+/** captureStdout は書き出された全出力を結合して返す。 */
+function captureStdout(): string {
+  return writtenChunks.join("")
+}
+
+// ----- テスト -----
+
+describe("makeProjectMembersCommand", () => {
+  describe("バリデーション", () => {
+    it("プロジェクト名未指定 (name も --project も環境変数もなし) の場合は exit 5 で終了する", async () => {
+      await runAndIgnoreExit(
+        { ...defaultArgs, name: undefined, project: undefined },
+        createMockDeps(),
+      )
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+
+    it("COS_PROJECT 環境変数でプロジェクト名を指定できる", async () => {
+      process.env["COS_PROJECT"] = "テストプロジェクト"
+      await runAndIgnoreExit({ ...defaultArgs, name: undefined }, createMockDeps())
+      // exit 5 (PROJECT_REQUIRED) は呼ばれない
+      expect(exitMock).not.toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("sandbox 違反", () => {
+    it("--disable-commands=project.members の場合は exit 7 で終了する", async () => {
+      await runAndIgnoreExit(
+        { ...defaultArgs, "disable-commands": "project.members" },
+        createMockDeps(),
+      )
+      expect(exitMock).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe("正常系 (プレーンテキスト出力)", () => {
+    it("デフォルトでメンバー情報を含む整列テキストを出力する", async () => {
+      await runAndIgnoreExit(defaultArgs, createMockDeps())
+
+      const out = captureStdout()
+      expect(out).toContain("山田太郎")
+      expect(out).toContain("suzuki-hanako")
+    })
+
+    it("メンバーが0件の場合は何も出力しない", async () => {
+      await runAndIgnoreExit(
+        defaultArgs,
+        createMockDeps({ restClient: createMockRestClient(mockEmptyResponse) }),
+      )
+
+      const out = captureStdout()
+      // エラーなしで完了し、出力は空か見出しのみ
+      expect(exitMock).not.toHaveBeenCalledWith(2)
+      expect(exitMock).not.toHaveBeenCalledWith(4)
+      expect(out).not.toContain("山田太郎")
+    })
+  })
+
+  describe("正常系 (JSON 出力)", () => {
+    it("--json の場合は envelope 形式で users/memberSnapshots を含む JSON を出力する", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, json: true }, createMockDeps())
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as {
+        data: ProjectMembersResponse
+        meta: { command: string }
+      }
+      expect(parsed.meta.command).toBe("project.members")
+      expect(Array.isArray(parsed.data.users)).toBe(true)
+      expect(parsed.data.users).toHaveLength(2)
+      expect(parsed.data.users[0]?.displayName).toBe("山田太郎")
+      expect(Array.isArray(parsed.data.memberSnapshots)).toBe(true)
+    })
+
+    it("--results-only の場合は data のみ出力する (meta なし)", async () => {
+      await runAndIgnoreExit({ ...defaultArgs, json: true, "results-only": true }, createMockDeps())
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as ProjectMembersResponse
+      expect(Array.isArray(parsed.users)).toBe(true)
+      expect("meta" in parsed).toBe(false)
+    })
+
+    it("--select=users[].name の場合は name 配列のみ出力する", async () => {
+      await runAndIgnoreExit(
+        {
+          ...defaultArgs,
+          json: true,
+          "results-only": true,
+          select: "users[].name",
+        },
+        createMockDeps(),
+      )
+
+      const out = captureStdout()
+      const parsed = JSON.parse(out) as string[]
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed).toContain("yamada-taro")
+      expect(parsed).toContain("suzuki-hanako")
+    })
+  })
+
+  describe("エラー系", () => {
+    it("NotFoundError の場合は exit 4 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient(mockMembersResponse, {
+          throwError: new NotFoundError("/api/projects/存在しないプロジェクト/users"),
+        }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(4)
+    })
+
+    it("AuthError の場合は exit 2 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient(mockMembersResponse, {
+          throwError: new AuthError(),
+        }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(2)
+    })
+
+    it("ForbiddenError の場合は exit 3 で終了する", async () => {
+      const deps = createMockDeps({
+        restClient: createMockRestClient(mockMembersResponse, {
+          throwError: new ForbiddenError(),
+        }),
+      })
+      await runAndIgnoreExit(defaultArgs, deps)
+      expect(exitMock).toHaveBeenCalledWith(3)
+    })
+  })
+})

--- a/tests/unit/commands/project/members.test.ts
+++ b/tests/unit/commands/project/members.test.ts
@@ -70,12 +70,12 @@ function createMockRestClient(
   }
 }
 
-/** defaultArgs は全テストで共通の基本引数。 */
-const defaultArgs: Record<string, unknown> = {
+/** plainArgs はプレーンテキスト出力を期待するテストで使う基本引数。 */
+const plainArgs: Record<string, unknown> = {
   name: "テストプロジェクト",
   project: undefined,
   json: false,
-  plain: false,
+  plain: true,
   "results-only": false,
   select: undefined,
   "enable-commands": undefined,
@@ -84,6 +84,16 @@ const defaultArgs: Record<string, unknown> = {
   quiet: false,
   profile: undefined,
 }
+
+/** jsonArgs は JSON 出力を期待するテストで使う基本引数。 */
+const jsonArgs: Record<string, unknown> = {
+  ...plainArgs,
+  json: true,
+  plain: false,
+}
+
+/** defaultArgs は後方互換のエイリアス (バリデーション系テストで使用)。 */
+const defaultArgs = plainArgs
 
 /** createMockDeps はモック依存を生成する。個別フィールドを上書き可能。 */
 function createMockDeps(overrides: Partial<ProjectMembersDeps> = {}): ProjectMembersDeps {
@@ -110,8 +120,21 @@ async function runAndIgnoreExit(
 ): Promise<void> {
   try {
     await runMembers(args, deps)
-  } catch {
-    // process.exit モック後の継続による throw は想定内
+  } catch (err) {
+    // process.exit モック後に exitWithError が throw する Error のみ無視する
+    // exitWithError は process.exit 直後に throw new Error(code) を呼ぶため、
+    // 既知の終了コード文字列を持つ Error は想定内として握り潰す
+    const knownExitCodes = [
+      "PROJECT_REQUIRED",
+      "POLICY_DENIED",
+      "AUTH_ERROR",
+      "AUTH_REQUIRED",
+      "FORBIDDEN",
+      "NOT_FOUND",
+      "VALIDATION_ERROR",
+    ]
+    if (err instanceof Error && knownExitCodes.some((c) => err.message.includes(c))) return
+    throw err
   }
 }
 
@@ -162,6 +185,21 @@ describe("makeProjectMembersCommand", () => {
       // exit 5 (PROJECT_REQUIRED) は呼ばれない
       expect(exitMock).not.toHaveBeenCalledWith(5)
     })
+
+    it("--project フラグは COS_PROJECT 環境変数より優先される", async () => {
+      process.env["COS_PROJECT"] = "env-project"
+      let capturedProject: string | undefined
+      const deps = createMockDeps({
+        restClient: {
+          async getProjectMembers(project) {
+            capturedProject = project
+            return mockMembersResponse
+          },
+        },
+      })
+      await runAndIgnoreExit({ ...plainArgs, name: undefined, project: "cli-project" }, deps)
+      expect(capturedProject).toBe("cli-project")
+    })
   })
 
   describe("sandbox 違反", () => {
@@ -175,17 +213,25 @@ describe("makeProjectMembersCommand", () => {
   })
 
   describe("正常系 (プレーンテキスト出力)", () => {
-    it("デフォルトでメンバー情報を含む整列テキストを出力する", async () => {
-      await runAndIgnoreExit(defaultArgs, createMockDeps())
+    it("--plain でメンバー情報を含む整列テキストを出力する", async () => {
+      await runAndIgnoreExit(plainArgs, createMockDeps())
 
       const out = captureStdout()
       expect(out).toContain("山田太郎")
       expect(out).toContain("suzuki-hanako")
     })
 
-    it("メンバーが0件の場合は何も出力しない", async () => {
+    it("--plain で退去済みメンバー (memberSnapshots) も出力する", async () => {
+      await runAndIgnoreExit(plainArgs, createMockDeps())
+
+      const out = captureStdout()
+      // memberSnapshots にある退去ユーザーが出力に含まれること
+      expect(out).toContain("退去")
+    })
+
+    it("メンバーが0件・スナップショットも0件の場合は何も出力しない", async () => {
       await runAndIgnoreExit(
-        defaultArgs,
+        plainArgs,
         createMockDeps({ restClient: createMockRestClient(mockEmptyResponse) }),
       )
 
@@ -199,7 +245,7 @@ describe("makeProjectMembersCommand", () => {
 
   describe("正常系 (JSON 出力)", () => {
     it("--json の場合は envelope 形式で users/memberSnapshots を含む JSON を出力する", async () => {
-      await runAndIgnoreExit({ ...defaultArgs, json: true }, createMockDeps())
+      await runAndIgnoreExit(jsonArgs, createMockDeps())
 
       const out = captureStdout()
       const parsed = JSON.parse(out) as {
@@ -214,7 +260,7 @@ describe("makeProjectMembersCommand", () => {
     })
 
     it("--results-only の場合は data のみ出力する (meta なし)", async () => {
-      await runAndIgnoreExit({ ...defaultArgs, json: true, "results-only": true }, createMockDeps())
+      await runAndIgnoreExit({ ...jsonArgs, "results-only": true }, createMockDeps())
 
       const out = captureStdout()
       const parsed = JSON.parse(out) as ProjectMembersResponse
@@ -225,8 +271,7 @@ describe("makeProjectMembersCommand", () => {
     it("--select=users[].name の場合は name 配列のみ出力する", async () => {
       await runAndIgnoreExit(
         {
-          ...defaultArgs,
-          json: true,
+          ...jsonArgs,
           "results-only": true,
           select: "users[].name",
         },


### PR DESCRIPTION
## Summary

- `GET /api/projects/:project/users` エンドポイントから現メンバー (`users`) と退去済みメンバー (`memberSnapshots`) を取得する `cos project members` コマンドを追加
- `ProjectMember` / `MemberSnapshot` zod スキーマを `src/schemas/project.ts` に追加
- `CosenseRestClient` に `getProjectMembers` メソッドを追加
- DI パターン (`makeProjectMembersCommand`) でテスタブルに実装
- `project.members` を `READ_COMMANDS` に追加（PAT/SA/SID すべてで動作）
- `README.md` と `.agents/skills/coscli/SKILL.md` のコマンド一覧を更新

## Test plan

- [x] `bun test tests/unit/commands/project/members.test.ts` — 11 テスト全通過
- [x] `bunx biome check src tests` — Lint 警告ゼロ
- [x] `bun run typecheck` — 型エラーゼロ
- [x] `bun test` — 全 1562 テスト通過

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プロジェクトメンバー一覧を取得するコマンドが追加されました。プロジェクト内のメンバーと退去済みメンバーの情報を確認できます。

* **Documentation**
  * コマンド一覧とスキル設定ドキュメントが更新されました。

* **Tests**
  * 新機能の単体テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->