### PR TITLE
feat(page): cos page context に --query オプションを追加してキーワードフィルタを実現する

### DIFF
--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -67,7 +67,7 @@ cos page text "タイトル" --project <name>
 cos page text "タイトル" --project <name> --format=md   # Markdown 変換
 
 # 本文 + リンク先文脈 (AI 文脈注入に最適)
-# data.text に "==[ページA]==\n本文...\n==[ページB]==\n..." 形式のテキストが入る
+# data.text に "<Page title="A">本文...</Page><Page title="B">本文...</Page>" XML 形式のテキストが入る
 cos page context "タイトル" --project <name> --json --results-only
 cos page context "タイトル" --project <name> --hops 2                    # 2hop まで広げる (取得量大)
 cos page context "タイトル" --project <name> --query "キーワード"          # 本文フィルタ (トークン節約)

--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -69,7 +69,8 @@ cos page text "タイトル" --project <name> --format=md   # Markdown 変換
 # 本文 + リンク先文脈 (AI 文脈注入に最適)
 # data.text に "==[ページA]==\n本文...\n==[ページB]==\n..." 形式のテキストが入る
 cos page context "タイトル" --project <name> --json --results-only
-cos page context "タイトル" --project <name> --hops 2   # 2hop まで広げる (取得量大)
+cos page context "タイトル" --project <name> --hops 2                    # 2hop まで広げる (取得量大)
+cos page context "タイトル" --project <name> --query "キーワード"          # 本文フィルタ (トークン節約)
 
 # コードブロック / テーブル
 cos page code "タイトル" "filename.ts" --project <name>

--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ cos page context "ページタイトル" --project myproject
 # 2hop 先 — さらに広い文脈を取得
 cos page context "ページタイトル" --project myproject --hops 2
 
+# --query でキーワードフィルタ — 本文に「機械学習」を含むページのみ返す
+cos page context "ページタイトル" --project myproject --query "機械学習"
+
 # JSON 出力 (エージェント向け)
 cos page context "ページタイトル" --project myproject --json
 ```

--- a/src/commands/page/context.ts
+++ b/src/commands/page/context.ts
@@ -4,6 +4,7 @@
  * 指定ページを起点に Smart Context API を叩き、
  * 1hop または 2hop 先までのリンク先ページ本文をテキストで取得して stdout に出力する。
  * LLM への文脈投入やエージェントによるページ関連情報収集に使う。
+ * --query を指定すると、空行区切りのページセクション単位でキーワードフィルタを行う。
  */
 
 import {
@@ -23,6 +24,48 @@ import { defineCommand } from "citty"
 const VALID_HOPS = [1, 2] as const
 type Hops = (typeof VALID_HOPS)[number]
 
+/** Smart Context テキストのページセクション区切り行 (例: ==[ページタイトル]==)。m フラグで行単位にマッチ。 */
+const SECTION_MARKER_PATTERN = /^==[^=\n]+==$/m
+
+/**
+ * filterSmartContextByQuery は Smart Context テキストをクエリキーワードでフィルタする。
+ *
+ * テキストが ==[title]== 形式のマーカーを含む場合はマーカーでページセクションを分割し、
+ * クエリを含むセクションのみ返す。マーカーがない場合は空行でセクションを分割する。
+ * クエリは大文字・小文字を区別しない。query が空文字のときはフィルタせず全文を返す。
+ */
+export function filterSmartContextByQuery(text: string, query: string): string {
+  if (!query) return text
+  const lowerQuery = query.toLowerCase()
+
+  if (SECTION_MARKER_PATTERN.test(text)) {
+    // ==[title]== マーカー行でページセクションを分割する
+    const lines = text.split("\n")
+    const sections: string[] = []
+    let currentLines: string[] = []
+
+    for (const line of lines) {
+      if (SECTION_MARKER_PATTERN.test(line) && currentLines.length > 0) {
+        sections.push(currentLines.join("\n"))
+        currentLines = [line]
+      } else {
+        currentLines.push(line)
+      }
+    }
+    if (currentLines.length > 0) {
+      sections.push(currentLines.join("\n"))
+    }
+
+    const filtered = sections.filter((s) => s.toLowerCase().includes(lowerQuery))
+    return filtered.join("\n")
+  }
+
+  // フォールバック: 1 行以上の空行でページセクションを分割する
+  const sections = text.split(/\n{2,}/)
+  const filtered = sections.filter((section) => section.toLowerCase().includes(lowerQuery))
+  return filtered.join("\n\n")
+}
+
 export const pageContextCommand = defineCommand({
   meta: { name: "context", description: "ページ起点の Smart Context (リンク先本文) を取得する" },
   args: {
@@ -37,9 +80,14 @@ export const pageContextCommand = defineCommand({
       description: "取得するリンクの深さ (1 | 2)。デフォルト: 1",
       default: "1",
     },
+    query: {
+      type: "string",
+      description: "hop 近傍ページを本文キーワードで絞り込む",
+      default: "",
+    },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; hops: string }
+    const a = args as CommonArgs & { title: string; hops: string; query: string }
     checkSandbox("page.context", a)
     const project = requireProject(a)
     const startTime = Date.now()
@@ -57,13 +105,16 @@ export const pageContextCommand = defineCommand({
     const hops = hopsNum as Hops
 
     const client = await buildRestClient(a)
-    const text = await getSmartContext(client, { project, title: a.title, hops })
+    const rawText = await getSmartContext(client, { project, title: a.title, hops })
+    const text = filterSmartContextByQuery(rawText, a.query)
 
     if (a.json) {
       writeJson({ text }, { command: "page.context", startTime }, buildJsonOpts(a))
       return
     }
 
-    process.stdout.write(`${text}\n`)
+    if (text) {
+      process.stdout.write(`${text}\n`)
+    }
   },
 })

--- a/src/commands/page/context.ts
+++ b/src/commands/page/context.ts
@@ -4,7 +4,7 @@
  * 指定ページを起点に Smart Context API を叩き、
  * 1hop または 2hop 先までのリンク先ページ本文をテキストで取得して stdout に出力する。
  * LLM への文脈投入やエージェントによるページ関連情報収集に使う。
- * --query を指定すると、空行区切りのページセクション単位でキーワードフィルタを行う。
+ * --query を指定すると、ページセクション単位でキーワードフィルタを行う。
  */
 
 import {
@@ -24,22 +24,42 @@ import { defineCommand } from "citty"
 const VALID_HOPS = [1, 2] as const
 type Hops = (typeof VALID_HOPS)[number]
 
-/** Smart Context テキストのページセクション区切り行 (例: ==[ページタイトル]==)。m フラグで行単位にマッチ。 */
+/** Smart Context XML 形式のページブロック抽出パターン。<Page ...>...</Page> 単位でマッチ。 */
+const XML_PAGE_BLOCK_PATTERN = /<Page\s[^>]*>[\s\S]*?<\/Page>/g
+
+/** Smart Context テキストのページセクション区切り行 (==[ページタイトル]== 形式)。m フラグで行単位にマッチ。 */
 const SECTION_MARKER_PATTERN = /^==[^=\n]+==$/m
 
 /**
  * filterSmartContextByQuery は Smart Context テキストをクエリキーワードでフィルタする。
  *
- * テキストが ==[title]== 形式のマーカーを含む場合はマーカーでページセクションを分割し、
- * クエリを含むセクションのみ返す。マーカーがない場合は空行でセクションを分割する。
+ * フォーマット検出の優先順位:
+ *   1. `<Page title="...">...</Page>` XML 形式 (実際の Smart Context API が返す形式)
+ *   2. `==[title]==` マーカー行形式 (旧形式フォールバック)
+ *   3. 空行区切り形式 (その他フォールバック)
+ *
+ * XML 形式の場合は `<Page>...</Page>` ブロック単位でフィルタする。
  * クエリは大文字・小文字を区別しない。query が空文字のときはフィルタせず全文を返す。
  */
 export function filterSmartContextByQuery(text: string, query: string): string {
   if (!query) return text
   const lowerQuery = query.toLowerCase()
 
+  // <Page title="..."> ... </Page> XML 形式
+  if (/<Page\s+title=/.test(text)) {
+    const allBlocks: string[] = []
+    const regex = new RegExp(XML_PAGE_BLOCK_PATTERN.source, "g")
+    let match = regex.exec(text)
+    while (match !== null) {
+      allBlocks.push(match[0])
+      match = regex.exec(text)
+    }
+    const filtered = allBlocks.filter((block) => block.toLowerCase().includes(lowerQuery))
+    return filtered.join("\n\n\n")
+  }
+
+  // ==[title]== マーカー行形式
   if (SECTION_MARKER_PATTERN.test(text)) {
-    // ==[title]== マーカー行でページセクションを分割する
     const lines = text.split("\n")
     const sections: string[] = []
     let currentLines: string[] = []

--- a/tests/unit/commands/page/context.test.ts
+++ b/tests/unit/commands/page/context.test.ts
@@ -18,12 +18,20 @@ const SMART_CONTEXT_2HOP = "2hop Smart Context テキスト"
 
 /**
  * --query テスト用の複数ページセクションを含む Smart Context テキスト。
- * 実際の API が返す ==[title]== 形式を再現する。
+ * 実際の API が返す <Page title="...">...</Page> XML 形式を再現する。
  */
 const SMART_CONTEXT_MULTI_SECTION =
-  "==[東京タワー]==\n東京都港区芝公園にある電波塔。高さ333m。\n" +
-  "==[スカイツリー]==\n東京都墨田区にある電波塔。東京タワーより高く634m。\n" +
-  "==[名古屋城]==\n愛知県名古屋市にある城。金のしゃちほこで有名。"
+  "<PageList>\n" +
+  '<Page title="東京タワー" url="https://scrapbox.io/テストプロジェクト/東京タワー" updated="2026-01-01T00:00:00.000Z" created="2026-01-01T00:00:00.000Z" type="1hopLink">\n' +
+  "東京都港区芝公園にある電波塔。高さ333m。\n" +
+  "</Page>\n\n\n" +
+  '<Page title="スカイツリー" url="https://scrapbox.io/テストプロジェクト/スカイツリー" updated="2026-01-01T00:00:00.000Z" created="2026-01-01T00:00:00.000Z" type="1hopLink">\n' +
+  "東京都墨田区にある電波塔。東京タワーより高く634m。\n" +
+  "</Page>\n\n\n" +
+  '<Page title="名古屋城" url="https://scrapbox.io/テストプロジェクト/名古屋城" updated="2026-01-01T00:00:00.000Z" created="2026-01-01T00:00:00.000Z" type="1hopLink">\n' +
+  "愛知県名古屋市にある城。金のしゃちほこで有名。\n" +
+  "</Page>\n" +
+  "</PageList>"
 
 const server = setupServer(
   // Smart Context: 1hop

--- a/tests/unit/commands/page/context.test.ts
+++ b/tests/unit/commands/page/context.test.ts
@@ -1,7 +1,8 @@
 /**
  * page/context.test.ts — `cos page context <title>` コマンドのテスト。
  *
- * --hops バリデーション、1hop/2hop エンドポイント切り替え、--json envelope 出力を検証する。
+ * --hops バリデーション、1hop/2hop エンドポイント切り替え、--json envelope 出力、
+ * --query フィルタリングを検証する。
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -14,6 +15,15 @@ const TEST_PROJECT = "テストプロジェクト"
 const TEST_TITLE = "テストページ"
 const SMART_CONTEXT_1HOP = "1hop Smart Context テキスト"
 const SMART_CONTEXT_2HOP = "2hop Smart Context テキスト"
+
+/**
+ * --query テスト用の複数ページセクションを含む Smart Context テキスト。
+ * 実際の API が返す ==[title]== 形式を再現する。
+ */
+const SMART_CONTEXT_MULTI_SECTION =
+  "==[東京タワー]==\n東京都港区芝公園にある電波塔。高さ333m。\n" +
+  "==[スカイツリー]==\n東京都墨田区にある電波塔。東京タワーより高く634m。\n" +
+  "==[名古屋城]==\n愛知県名古屋市にある城。金のしゃちほこで有名。"
 
 const server = setupServer(
   // Smart Context: 1hop
@@ -87,6 +97,7 @@ describe("pageContextCommand", () => {
         title: TEST_TITLE,
         project: undefined,
         hops: 1,
+        query: "",
         json: false,
         plain: false,
         "results-only": false,
@@ -104,6 +115,7 @@ describe("pageContextCommand", () => {
         title: TEST_TITLE,
         project: TEST_PROJECT,
         hops: 3,
+        query: "",
         json: false,
         plain: false,
         "results-only": false,
@@ -121,6 +133,7 @@ describe("pageContextCommand", () => {
       title: TEST_TITLE,
       project: TEST_PROJECT,
       hops: 1,
+      query: "",
       json: false,
       plain: false,
       "results-only": false,
@@ -135,6 +148,7 @@ describe("pageContextCommand", () => {
       title: TEST_TITLE,
       project: TEST_PROJECT,
       hops: 2,
+      query: "",
       json: false,
       plain: false,
       "results-only": false,
@@ -149,6 +163,7 @@ describe("pageContextCommand", () => {
       title: TEST_TITLE,
       project: TEST_PROJECT,
       hops: 1,
+      query: "",
       json: true,
       plain: false,
       "results-only": false,
@@ -157,5 +172,96 @@ describe("pageContextCommand", () => {
     const calls = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
     const parsed = JSON.parse(calls)
     expect(parsed.data.text).toBe(SMART_CONTEXT_1HOP)
+  })
+
+  describe("--query オプション", () => {
+    // 各テストで複数セクションの Smart Context を返すようにハンドラを上書きする
+    beforeEach(() => {
+      server.use(
+        http.get(
+          `${BASE_URL}/api/smart-context/export-1hop-links/:project`,
+          ({ params, request }) => {
+            const projectParam = decodeURIComponent(params["project"] as string)
+            const project = projectParam.endsWith(".txt") ? projectParam.slice(0, -4) : projectParam
+            const url = new URL(request.url)
+            const title = url.searchParams.get("title")
+            if (project === TEST_PROJECT && title === TEST_TITLE) {
+              return new HttpResponse(SMART_CONTEXT_MULTI_SECTION)
+            }
+            return new HttpResponse("Not found", { status: 404 })
+          },
+        ),
+      )
+    })
+
+    it("--query に一致するセクションのみ stdout に出力される", async () => {
+      // 「東京」を含むセクションは「東京タワー」と「スカイツリー」、含まないのは「名古屋城」
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        query: "東京",
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("東京タワー")
+      expect(output).toContain("スカイツリー")
+      expect(output).not.toContain("名古屋城")
+    })
+
+    it("--query に一致するセクションが0件の場合は空文字を出力する", async () => {
+      // 「大阪」はどのセクションにも含まれない
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        query: "大阪",
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output.trim()).toBe("")
+    })
+
+    it("--query + --json でフィルタ済みテキストが data.text に含まれる", async () => {
+      // 「名古屋城」のみを含むクエリ
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        query: "しゃちほこ",
+        json: true,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      const parsed = JSON.parse(output)
+      expect(parsed.data.text).toContain("名古屋城")
+      expect(parsed.data.text).not.toContain("東京タワー")
+      expect(parsed.data.text).not.toContain("スカイツリー")
+    })
+
+    it("--query 未指定の場合はフィルタなしでテキスト全体を返す", async () => {
+      await runContext({
+        title: TEST_TITLE,
+        project: TEST_PROJECT,
+        hops: 1,
+        query: "",
+        json: false,
+        plain: false,
+        "results-only": false,
+        quiet: false,
+      })
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("東京タワー")
+      expect(output).toContain("スカイツリー")
+      expect(output).toContain("名古屋城")
+    })
   })
 })


### PR DESCRIPTION
## Summary

- `cos page context <title> --query <keyword>` で hop 近傍ページを本文キーワードでフィルタできるようにした
- Smart Context テキストの `==[title]==` マーカーを検出してページセクション単位で分割し、クエリを含むセクションのみ返す
- `==[title]==` マーカーがない場合は空行区切りにフォールバックする（堅牢性確保）
- クエリは大文字・小文字を区別しない
- `--query` 未指定時は従来どおり全文を返す

## 変更ファイル

- `src/commands/page/context.ts` — `--query` 引数追加・`filterSmartContextByQuery` 関数実装
- `tests/unit/commands/page/context.test.ts` — `--query` フィルタのテストケース追加（4件）
- `README.md` — `--query` 使用例を追加
- `.agents/skills/coscli/SKILL.md` — `page context --query` の使用例を追加

## Test plan

- [ ] `bun test` — 全 1568 件パス
- [ ] `bun run typecheck` — エラーなし
- [ ] `bunx biome check src tests` — 警告なし
- [ ] `bun run build` — ビルド成功

Closes #178