### PR TITLE
feat(page/history): --page-id と --since フラグを追加してリネーム後も変更履歴を追跡できるようにする

### DIFF
--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -82,6 +82,8 @@ cos page snapshot get "タイトル" <timestampId> --project <name> --json --res
 
 # コミット履歴
 cos page history "タイトル" --project <name> -n 10 --json --results-only
+cos page history --page-id <pageId> --project <name> --json --results-only  # リネーム後も追跡可能
+cos page history "タイトル" --project <name> --since <commitId> --json --results-only  # 差分のみ取得
 
 # 行・範囲取得
 cos page line get "タイトル" --line 3 --project <name> --json --results-only

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ cos page update-links   プロジェクト内のリンクを一括置換する
 cos page pin            ページをピン留め
 cos page unpin          ページのピン留めを解除
 cos page watch          ページ更新をリアルタイム監視 (WebSocket)
-cos page history        コミット履歴を取得
+cos page history        コミット履歴を取得 (--page-id でリネーム後も追跡、--since で差分取得)
 cos page delete         ページを削除
 
 cos page line get       指定行または範囲を取得

--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -1,8 +1,11 @@
 /**
- * page/history.ts — `cos page history <title>` コマンド。
+ * page/history.ts — `cos page history` コマンド。
  *
  * ページのコミット履歴 (GET /api/commits/:project/:pageid) を取得して出力する。
- * まず getPage でタイトルから pageId を解決し、getPageCommits で履歴を取得する。
+ * - `<title>` を指定した場合: getPage でタイトルから pageId を解決してから getPageCommits を呼ぶ
+ * - `--page-id <pageId>` を指定した場合: title → pageId 解決をスキップして直接 getPageCommits を呼ぶ
+ *   リネーム後も変更履歴を追跡できる。
+ * - `--since <commitId>` を指定した場合: その commitId より後（新しい）のコミットのみを返す
  */
 
 import {
@@ -27,8 +30,16 @@ export const pageHistoryCommand = defineCommand({
     ...commonArgs,
     title: {
       type: "positional",
-      description: "ページタイトル",
-      required: true,
+      description: "ページタイトル (--page-id を指定した場合は省略可)",
+      required: false,
+    },
+    "page-id": {
+      type: "string",
+      description: "ページ ID (指定するとタイトル解決をスキップしてリネーム後も追跡できる)",
+    },
+    since: {
+      type: "string",
+      description: "この commitId より後（新しい）のコミットのみを返す",
     },
     limit: {
       type: "string",
@@ -41,17 +52,24 @@ export const pageHistoryCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string; limit?: string; head?: string }
+    const a = args as CommonArgs & {
+      title?: string
+      "page-id"?: string
+      since?: string
+      limit?: string
+      head?: string
+    }
     checkSandbox("page.history", a)
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // title の空文字チェック (positional は required でも空文字が来うる)
-    if (!a.title) {
+    // title か --page-id のどちらかが必須
+    const pageId = a["page-id"]
+    if (!pageId && !a.title) {
       writeErrorJson(
         "VALIDATION_ERROR",
-        "title が指定されていません",
-        "ページタイトルを指定してください",
+        "title または --page-id が指定されていません",
+        "ページタイトルまたは --page-id を指定してください",
       )
       exitWithError(5, "VALIDATION_ERROR")
     }
@@ -74,21 +92,41 @@ export const pageHistoryCommand = defineCommand({
     try {
       const client = await buildRestClient(a)
 
-      // title → pageId 解決
-      const page = await getPage(client, { project, title: a.title })
+      let resolvedPageId: string
+      if (pageId) {
+        // --page-id 指定時は title → pageId 解決をスキップ
+        resolvedPageId = pageId
+      } else {
+        // title → pageId 解決
+        const page = await getPage(client, { project, title: a.title as string })
+        resolvedPageId = page.id
+      }
 
       // コミット履歴取得
       const opts: { project: string; pageId: string; head?: string } = {
         project,
-        pageId: page.id,
+        pageId: resolvedPageId,
       }
       if (a.head !== undefined) opts.head = a.head
 
       const commitsResponse = await getPageCommits(client, opts)
 
+      // --since によるフィルタリング: 指定 commitId より後（新しい）のコミットのみ返す
+      // commits は新しい順（最新→古い）で並んでいるため、
+      // 指定 commitId のインデックスより前（配列の先頭側）を返す
+      let commits = commitsResponse.commits
+      if (a.since !== undefined) {
+        const sinceIndex = commits.findIndex((c) => c.id === a.since)
+        if (sinceIndex >= 0) {
+          commits = commits.slice(0, sinceIndex)
+        }
+        // sinceIndex が -1 の場合（見つからない）は全件返す
+      }
+
       // --limit によるスライス
-      const commits =
-        limit !== undefined ? commitsResponse.commits.slice(0, limit) : commitsResponse.commits
+      if (limit !== undefined) {
+        commits = commits.slice(0, limit)
+      }
 
       if (a.json || !a.plain) {
         writeJson({ commits }, { command: "page.history", startTime }, buildJsonOpts(a))
@@ -106,7 +144,7 @@ export const pageHistoryCommand = defineCommand({
         ]),
       )
     } catch (err) {
-      handleRestError(err, { resourceKind: "page", resourceName: a.title })
+      handleRestError(err, { resourceKind: "page", resourceName: pageId ?? a.title ?? "" })
       throw err
     }
   },

--- a/src/commands/page/history.ts
+++ b/src/commands/page/history.ts
@@ -112,13 +112,12 @@ export const pageHistoryCommand = defineCommand({
       const commitsResponse = await getPageCommits(client, opts)
 
       // --since によるフィルタリング: 指定 commitId より後（新しい）のコミットのみ返す
-      // commits は新しい順（最新→古い）で並んでいるため、
-      // 指定 commitId のインデックスより前（配列の先頭側）を返す
+      // API は古い順（最古→最新）で返すため、指定 commitId のインデックスより後ろ（配列の末尾側）を返す
       let commits = commitsResponse.commits
       if (a.since !== undefined) {
         const sinceIndex = commits.findIndex((c) => c.id === a.since)
         if (sinceIndex >= 0) {
-          commits = commits.slice(0, sinceIndex)
+          commits = commits.slice(sinceIndex + 1)
         }
         // sinceIndex が -1 の場合（見つからない）は全件返す
       }

--- a/tests/fixtures/commits/page-history.json
+++ b/tests/fixtures/commits/page-history.json
@@ -1,22 +1,21 @@
 {
   "commits": [
     {
-      "id": "commit-id-2",
-      "parentId": "commit-id-1",
+      "id": "commit-id-0",
       "pageId": "page-id-hello",
       "userId": "user-id-1",
-      "created": 1700200000,
+      "created": 1700000000,
       "kind": "page",
       "changes": [
         {
-          "type": "update",
+          "type": "insert",
           "lines": [
             {
-              "id": "line-id-1",
-              "text": "更新した行",
+              "id": "line-id-title",
+              "text": "Hello World",
               "userId": "user-id-1",
-              "created": 1700200000,
-              "updated": 1700200000
+              "created": 1700000000,
+              "updated": 1700000000
             }
           ]
         }
@@ -45,21 +44,22 @@
       ]
     },
     {
-      "id": "commit-id-0",
+      "id": "commit-id-2",
+      "parentId": "commit-id-1",
       "pageId": "page-id-hello",
       "userId": "user-id-1",
-      "created": 1700000000,
+      "created": 1700200000,
       "kind": "page",
       "changes": [
         {
-          "type": "insert",
+          "type": "update",
           "lines": [
             {
-              "id": "line-id-title",
-              "text": "Hello World",
+              "id": "line-id-1",
+              "text": "更新した行",
               "userId": "user-id-1",
-              "created": 1700000000,
-              "updated": 1700000000
+              "created": 1700200000,
+              "updated": 1700200000
             }
           ]
         }

--- a/tests/unit/commands/page/history.test.ts
+++ b/tests/unit/commands/page/history.test.ts
@@ -100,7 +100,8 @@ describe("pageHistoryCommand", () => {
       const json = JSON.parse(output)
       // writeJson の envelope 形式: { data: { commits: [...] }, meta: { ... } }
       expect(json.data.commits).toHaveLength(3)
-      expect(json.data.commits[0].id).toBe("commit-id-2")
+      // APIは古い順（最古が先頭）で返す
+      expect(json.data.commits[0].id).toBe("commit-id-0")
     })
 
     it("title に対応するページの pageId を使って getPageCommits が呼ばれる", async () => {
@@ -221,8 +222,8 @@ describe("pageHistoryCommand", () => {
       expect(writtenLines).toHaveLength(4)
       // ヘッダー行はタブ区切りの列名
       expect(writtenLines[0]).toBe("id\tcreated\tuserId\tchanges\n")
-      // データ行はタブ区切りの id、ISO 8601 日時、userId、changes 数
-      expect(writtenLines[1]).toMatch(/^commit-id-2\t20\d{2}-/)
+      // データ行はタブ区切りの id、ISO 8601 日時、userId、changes 数（古い順で先頭は commit-id-0）
+      expect(writtenLines[1]).toMatch(/^commit-id-0\t20\d{2}-/)
     })
   })
 
@@ -258,8 +259,8 @@ describe("pageHistoryCommand", () => {
 
   describe("--since フラグ", () => {
     it("--since commit-id-1 を指定すると commit-id-1 より新しいコミットのみ返る", async () => {
-      // フィクスチャの順序: [commit-id-2, commit-id-1, commit-id-0]
-      // commit-id-1 のインデックス = 1 → インデックス 0 (commit-id-2) のみを返す
+      // フィクスチャの順序（APIと同じ古い順）: [commit-id-0, commit-id-1, commit-id-2]
+      // commit-id-1 のインデックス = 1 → インデックス 2 (commit-id-2) のみを返す
       try {
         await runHistory({ ...defaultArgs, since: "commit-id-1" })
       } catch {
@@ -273,8 +274,8 @@ describe("pageHistoryCommand", () => {
       expect(json.data.commits[0].id).toBe("commit-id-2")
     })
 
-    it("--since commit-id-0 を指定すると commit-id-2 と commit-id-1 が返る", async () => {
-      // commit-id-0 のインデックス = 2 → インデックス 0,1 (commit-id-2, commit-id-1) を返す
+    it("--since commit-id-0 を指定すると commit-id-1 と commit-id-2 が返る", async () => {
+      // commit-id-0 のインデックス = 0 → インデックス 1,2 (commit-id-1, commit-id-2) を返す
       try {
         await runHistory({ ...defaultArgs, since: "commit-id-0" })
       } catch {
@@ -285,8 +286,8 @@ describe("pageHistoryCommand", () => {
       const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
       const json = JSON.parse(output)
       expect(json.data.commits).toHaveLength(2)
-      expect(json.data.commits[0].id).toBe("commit-id-2")
-      expect(json.data.commits[1].id).toBe("commit-id-1")
+      expect(json.data.commits[0].id).toBe("commit-id-1")
+      expect(json.data.commits[1].id).toBe("commit-id-2")
     })
 
     it("--since に存在しない commitId を指定した場合は全件返る", async () => {
@@ -303,7 +304,7 @@ describe("pageHistoryCommand", () => {
     })
 
     it("--since が最新 commitId の場合は空配列が返る", async () => {
-      // commit-id-2 が最新 (index=0) → それより新しいコミットはない → 空
+      // commit-id-2 が最新 (index=2, 末尾) → それより後ろのコミットはない → 空
       try {
         await runHistory({ ...defaultArgs, since: "commit-id-2" })
       } catch {
@@ -317,7 +318,7 @@ describe("pageHistoryCommand", () => {
     })
 
     it("--since と --limit を組み合わせた場合は --since 適用後に --limit でスライスされる", async () => {
-      // --since commit-id-0 → [commit-id-2, commit-id-1] → --limit 1 → [commit-id-2]
+      // --since commit-id-0 → [commit-id-1, commit-id-2] → --limit 1 → [commit-id-1]
       try {
         await runHistory({ ...defaultArgs, since: "commit-id-0", limit: "1" })
       } catch {
@@ -328,7 +329,7 @@ describe("pageHistoryCommand", () => {
       const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
       const json = JSON.parse(output)
       expect(json.data.commits).toHaveLength(1)
-      expect(json.data.commits[0].id).toBe("commit-id-2")
+      expect(json.data.commits[0].id).toBe("commit-id-1")
     })
   })
 

--- a/tests/unit/commands/page/history.test.ts
+++ b/tests/unit/commands/page/history.test.ts
@@ -1,13 +1,16 @@
 /**
- * page/history.test.ts — `cos page history <title>` コマンドのテスト。
+ * page/history.test.ts — `cos page history` コマンドのテスト。
  *
  * Scrapbox commits API を叩いてページのコミット履歴を返すコマンドを検証する。
  * - 正常系: コミット一覧が JSON で取れる
  * - --limit によるスライス動作
  * - --head がクエリパラメータに乗ること
+ * - --page-id 指定で title → pageId 解決をスキップする
+ * - --since 指定で指定 commitId より後のコミットのみ返す
  * - 認証エラー → exit 2
  * - 404 (ページ未存在) → exit 4
  * - project 未指定 → exit 5
+ * - title と --page-id の両方未指定 → exit 5
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
@@ -37,6 +40,8 @@ async function runHistory(args: Record<string, unknown>) {
 const defaultArgs = {
   project: "テストプロジェクト",
   title: "Hello World",
+  "page-id": undefined,
+  since: undefined,
   limit: undefined,
   head: undefined,
   json: true,
@@ -221,6 +226,112 @@ describe("pageHistoryCommand", () => {
     })
   })
 
+  describe("--page-id フラグ", () => {
+    it("--page-id を指定すると title なしで getPageCommits が呼ばれる", async () => {
+      try {
+        await runHistory({ ...defaultArgs, title: "", "page-id": "page-id-hello" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      // --page-id 指定時は getPage をスキップするので呼ばれない
+      expect(getPageSpy).not.toHaveBeenCalled()
+      // getPageCommits は --page-id の値で呼ばれる
+      const callArgs = getPageCommitsSpy.mock.calls[0]
+      expect(callArgs?.[1]).toMatchObject({ pageId: "page-id-hello" })
+    })
+
+    it("--page-id 指定時は JSON でコミット一覧が返る", async () => {
+      try {
+        await runHistory({ ...defaultArgs, title: "", "page-id": "page-id-hello" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(3)
+    })
+  })
+
+  describe("--since フラグ", () => {
+    it("--since commit-id-1 を指定すると commit-id-1 より新しいコミットのみ返る", async () => {
+      // フィクスチャの順序: [commit-id-2, commit-id-1, commit-id-0]
+      // commit-id-1 のインデックス = 1 → インデックス 0 (commit-id-2) のみを返す
+      try {
+        await runHistory({ ...defaultArgs, since: "commit-id-1" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(1)
+      expect(json.data.commits[0].id).toBe("commit-id-2")
+    })
+
+    it("--since commit-id-0 を指定すると commit-id-2 と commit-id-1 が返る", async () => {
+      // commit-id-0 のインデックス = 2 → インデックス 0,1 (commit-id-2, commit-id-1) を返す
+      try {
+        await runHistory({ ...defaultArgs, since: "commit-id-0" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(2)
+      expect(json.data.commits[0].id).toBe("commit-id-2")
+      expect(json.data.commits[1].id).toBe("commit-id-1")
+    })
+
+    it("--since に存在しない commitId を指定した場合は全件返る", async () => {
+      try {
+        await runHistory({ ...defaultArgs, since: "commit-id-999" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(3)
+    })
+
+    it("--since が最新 commitId の場合は空配列が返る", async () => {
+      // commit-id-2 が最新 (index=0) → それより新しいコミットはない → 空
+      try {
+        await runHistory({ ...defaultArgs, since: "commit-id-2" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(0)
+    })
+
+    it("--since と --limit を組み合わせた場合は --since 適用後に --limit でスライスされる", async () => {
+      // --since commit-id-0 → [commit-id-2, commit-id-1] → --limit 1 → [commit-id-2]
+      try {
+        await runHistory({ ...defaultArgs, since: "commit-id-0", limit: "1" })
+      } catch {
+        // 想定内
+      }
+
+      expect(exitMock).not.toHaveBeenCalled()
+      const output = (stdoutMock.mock.calls[0]?.[0] as string) ?? ""
+      const json = JSON.parse(output)
+      expect(json.data.commits).toHaveLength(1)
+      expect(json.data.commits[0].id).toBe("commit-id-2")
+    })
+  })
+
   describe("エラー系", () => {
     it("project 未指定は PROJECT_REQUIRED で exit 5 になる", async () => {
       try {
@@ -236,11 +347,12 @@ describe("pageHistoryCommand", () => {
       expect(stdoutMock).toHaveBeenCalledWith(expect.stringContaining("PROJECT_REQUIRED"))
     })
 
-    it("title 未指定は VALIDATION_ERROR で exit 5 になる", async () => {
+    it("title と --page-id の両方未指定は VALIDATION_ERROR で exit 5 になる", async () => {
       try {
         await runHistory({
           ...defaultArgs,
           title: "",
+          "page-id": undefined,
         })
       } catch {
         // 想定内


### PR DESCRIPTION
## Summary

- `--page-id <pageId>` フラグを追加。タイトル→pageId解決をスキップして直接コミット履歴を取得できる。タイトルがリネームされた後も同一ページの変更履歴を追跡可能
- `--since <commitId>` フラグを追加。指定した commitId より後（新しい）のコミットのみを返す。エージェントが commitId を記憶しておき次回実行時に渡すことで差分のみを効率よく処理できる
- `title` を optional に変更し、`--page-id` との排他的代替として受け入れる

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/commands/page/history.ts` | `--page-id`・`--since` フラグ追加、title を optional 化、slice 方向を API の古い順に合わせて修正 |
| `tests/unit/commands/page/history.test.ts` | `--page-id`・`--since` の新テストケース追加、フィクスチャ順序修正に伴う既存テスト更新 |
| `tests/fixtures/commits/page-history.json` | APIの実際の返却順（古い順）に合わせてフィクスチャを修正 |
| `README.md` / `.agents/skills/coscli/SKILL.md` | コマンド説明・使用例を更新 |

## 動作確認（mtane0412-sandbox）

```bash
# --page-id でタイトル解決をスキップして取得
cos page history --page-id 6a0e7690ef399f9bd9b415b1 --project mtane0412-sandbox --json --results-only
# → 18件取得 ✅

# --since で差分のみ取得
cos page history "update links test" --project mtane0412-sandbox \
  --since 6a0e76e961a126b64d37af85 --json --results-only
# → 2件取得（期待通り）✅
```

## Test plan

- [x] `bun test` — 1610 tests pass
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check` — Lint 警告ゼロ
- [x] sandbox (`mtane0412-sandbox`) での実機動作確認

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)