### PR TITLE
feat(page): cos page get に --format ai フラグを追加してエージェント向け Markdown 出力を実現する

### DIFF
--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -58,9 +58,12 @@ cos exit-codes --json               # 終了コード一覧 (単一ソース)
 cos page list --project <name> --json --results-only --select 'pages[].title' --limit 50 --sort updated
 # sort: updated|created|accessed|pageRank|links|views|title
 
-# ページ全データ
+# ページ全データ (JSON)
 cos page get "タイトル" --project <name> --json --results-only
 # data: { id, title, lines: [{ text, ... }], commitId, persistent, ... }
+
+# AI 向け Markdown (メタデータ・テロメア・本文・1-hop 関連ページをワンショット出力)
+cos page get "タイトル" --project <name> --format ai
 
 # 本文テキスト
 cos page text "タイトル" --project <name>

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cos page new --project myproject --title "新しいページ" --body "本文"
 
 ```
 cos page list           ページ一覧を取得 (--pinned でピン留めページのみ表示、--icon <name> でアイコンフィルタ)
-cos page get            ページ本文を取得
+cos page get            ページ本文を取得 (--format ai でエージェント向け Markdown 出力)
 cos page text           ページのテキスト (コードブロックなし) を取得
 cos page context        ページ起点の Smart Context (リンク先本文) を取得
 cos page infobox        LLM 生成 infobox データを取得

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -2,6 +2,8 @@
  * page/get.ts — `cos page get <title>` コマンド。
  *
  * 指定したタイトルのページ詳細 (行データ、メタ情報) を取得して出力する。
+ * --format ai を指定すると、メタデータ・テロメア・本文・1-hop 関連ページを
+ * エージェントが読みやすい Markdown 形式でワンショット出力する。
  */
 
 import {
@@ -10,11 +12,16 @@ import {
   buildRestClient,
   checkSandbox,
   commonArgs,
+  exitWithError,
   requireProject,
 } from "@/commands/_shared"
+import { formatAiPage } from "@/core/format/ai-page"
 import { getPage } from "@/core/pages"
-import { writeJson } from "@/presenter/json"
+import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
+
+/** --format に指定できる有効な値 */
+const VALID_FORMATS = ["ai"] as const
 
 export const pageGetCommand = defineCommand({
   meta: { name: "get", description: "ページ詳細を取得する" },
@@ -25,14 +32,50 @@ export const pageGetCommand = defineCommand({
       description: "ページタイトル",
       required: true,
     },
+    format: {
+      type: "string",
+      description: "出力フォーマット (ai)。ai はエージェント向け Markdown 形式で出力する",
+    },
   },
   async run({ args }) {
-    const a = args as CommonArgs & { title: string }
+    const a = args as CommonArgs & { title: string; format?: string }
     checkSandbox("page.get", a)
     const project = requireProject(a)
     const startTime = Date.now()
 
+    // --format バリデーション
+    if (a.format !== undefined && !(VALID_FORMATS as readonly string[]).includes(a.format)) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--format=${a.format} は無効な値です`,
+        `有効な値: ${VALID_FORMATS.join(", ")}`,
+      )
+      exitWithError(5, "VALIDATION_ERROR")
+    }
+
+    // --format ai と --json の排他制御
+    if (a.format === "ai" && a.json) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        "--format=ai と --json は同時に指定できません",
+        "--format=ai は Markdown 形式で出力するため JSON envelope は不要です",
+      )
+      exitWithError(5, "VALIDATION_ERROR")
+    }
+
     const client = await buildRestClient(a)
+
+    if (a.format === "ai") {
+      // getPage と getProjectMembers を並列フェッチして遅延を抑える
+      const [page, members] = await Promise.all([
+        getPage(client, { project, title: a.title }),
+        client.getProjectMembers(project).catch(() => null),
+      ])
+      const markdown = formatAiPage(page, members)
+      process.stdout.write(markdown)
+      return
+    }
+
     const page = await getPage(client, { project, title: a.title })
 
     if (a.json || !a.plain) {

--- a/src/core/format/ai-page.ts
+++ b/src/core/format/ai-page.ts
@@ -24,7 +24,7 @@ function formatTimestamp(unixSec: number): string {
 }
 
 /**
- * formatAiPage は Page と ProjectMembersResponse からエージェント向け Markdown を生成する。
+ * formatAiPage は Page と ProjectMembersResponse からエージェント向け Markdown を生成して返す。
  *
  * @param page - Cosense ページ詳細
  * @param members - プロジェクトメンバー情報。null の場合はユーザーID をそのまま使用する

--- a/src/core/format/ai-page.ts
+++ b/src/core/format/ai-page.ts
@@ -1,0 +1,116 @@
+/**
+ * ai-page.ts — ページ情報をエージェント向け Markdown に整形するフォーマッター。
+ *
+ * Page + ProjectMembersResponse から、メタデータ・アイコン・テロメア・本文・
+ * 1-hop 関連ページを 1 度に出力する Markdown 文字列を生成する。
+ * `cos page get --format ai` 専用。
+ */
+
+import { buildTelomere } from "@/core/telomere"
+import type { Page } from "@/schemas/page"
+import type { ProjectMembersResponse } from "@/schemas/project"
+
+/** unix タイムスタンプ（秒）を "YYYY-MM-DD HH:mm:ss" の JST 文字列に変換する */
+function formatTimestamp(unixSec: number): string {
+  return new Date(unixSec * 1000).toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}
+
+/**
+ * formatAiPage は Page と ProjectMembersResponse からエージェント向け Markdown を生成する。
+ *
+ * @param page - Cosense ページ詳細
+ * @param members - プロジェクトメンバー情報。null の場合はユーザーID をそのまま使用する
+ */
+export function formatAiPage(page: Page, members: ProjectMembersResponse | null): string {
+  // userId → { displayName, name } のマップを構築する
+  const memberMap = new Map<string, string>()
+  const nameMap = new Map<string, string>()
+  if (members) {
+    for (const u of members.users) {
+      memberMap.set(u.id, u.displayName)
+      nameMap.set(u.id, u.name)
+    }
+  }
+
+  const lines: string[] = []
+
+  // タイトル
+  lines.push(`# ${page.title}`, "")
+
+  // メタデータセクション
+  lines.push("## メタデータ", "")
+  lines.push("| 項目 | 値 |")
+  lines.push("|------|-----|")
+  lines.push(`| ID | ${page.id} |`)
+  if (page.commitId) lines.push(`| commitId | ${page.commitId} |`)
+  lines.push(`| 作成日時 | ${formatTimestamp(page.created)} |`)
+  lines.push(`| 最終更新 | ${formatTimestamp(page.updated)} |`)
+  if (page.linked !== undefined) lines.push(`| 被リンク数 | ${page.linked} |`)
+  if (page.views !== undefined) lines.push(`| views | ${page.views} |`)
+  // lines[0] はタイトル行なので除いた行数・文字数を計算する
+  const bodyLines = page.lines.slice(1)
+  lines.push(`| 行数 | ${bodyLines.length} |`)
+  const charCount = bodyLines.reduce((sum, l) => sum + l.text.length, 0)
+  lines.push(`| 文字数 | ${charCount} |`)
+  if (page.user) {
+    const creatorName = memberMap.get(page.user.id) ?? page.user.displayName ?? page.user.id
+    lines.push(`| 作成者 | ${creatorName} |`)
+  }
+  lines.push("")
+
+  // テロメア集計（lines[0] タイトル行は除外）
+  const telomere = buildTelomere(bodyLines, memberMap)
+
+  // 編集メンバーセクション（テロメアに登場したユーザーのアイコン記法）
+  if (telomere.length > 0) {
+    lines.push("## 編集メンバー", "")
+    const icons = telomere
+      .map(({ userId }) => {
+        const name = nameMap.get(userId) ?? userId
+        return `[${name}.icon]`
+      })
+      .join(" ")
+    lines.push(icons, "")
+  }
+
+  // テロメアセクション
+  if (telomere.length > 0) {
+    lines.push("## テロメア", "")
+    lines.push("| 更新者 | 行数 | 最終更新 |")
+    lines.push("|--------|------|----------|")
+    for (const entry of telomere) {
+      lines.push(
+        `| ${entry.displayName} | ${entry.lineCount} | ${formatTimestamp(entry.latestUpdated)} |`,
+      )
+    }
+    lines.push("")
+  }
+
+  // 本文セクション（lines[0] タイトル行を除く）
+  lines.push("## 本文", "")
+  for (const line of bodyLines) {
+    lines.push(line.text)
+  }
+  lines.push("")
+
+  // 1-hop 関連ページセクション
+  const links1hop = page.relatedPages?.links1hop
+  if (links1hop && links1hop.length > 0) {
+    lines.push("---", "")
+    lines.push("## 関連ページ（1-hop）", "")
+    for (const rel of links1hop) {
+      lines.push(`- ${rel.title}`)
+    }
+    lines.push("")
+  }
+
+  return lines.join("\n")
+}

--- a/src/core/telomere.ts
+++ b/src/core/telomere.ts
@@ -1,0 +1,49 @@
+/**
+ * telomere.ts — ページ行配列からテロメア情報を集計するコアロジック。
+ *
+ * テロメアとは、各行の最終更新者を集計した「誰が何行、いつ更新したか」の一覧。
+ * エージェントが編集履歴の概要を把握するために使用する。
+ */
+
+import type { Line } from "@/schemas/page"
+
+/** TelomereEntry は 1 ユーザー分のテロメア集計結果。 */
+export type TelomereEntry = {
+  userId: string
+  /** memberMap にない場合は userId をそのまま使用する */
+  displayName: string
+  lineCount: number
+  /** ユーザーが書いた行の中で最も新しい updated タイムスタンプ (unix ms) */
+  latestUpdated: number
+}
+
+/**
+ * buildTelomere は行配列をユーザー単位で集計し、行数降順のテロメア一覧を返す。
+ *
+ * @param lines - ページ行配列
+ * @param memberMap - userId → displayName のマッピング
+ */
+export function buildTelomere(lines: Line[], memberMap: Map<string, string>): TelomereEntry[] {
+  const accum = new Map<string, { lineCount: number; latestUpdated: number }>()
+
+  for (const line of lines) {
+    const existing = accum.get(line.userId)
+    if (existing) {
+      existing.lineCount += 1
+      if (line.updated > existing.latestUpdated) {
+        existing.latestUpdated = line.updated
+      }
+    } else {
+      accum.set(line.userId, { lineCount: 1, latestUpdated: line.updated })
+    }
+  }
+
+  return [...accum.entries()]
+    .map(([userId, { lineCount, latestUpdated }]) => ({
+      userId,
+      displayName: memberMap.get(userId) ?? userId,
+      lineCount,
+      latestUpdated,
+    }))
+    .sort((a, b) => b.lineCount - a.lineCount)
+}

--- a/src/core/telomere.ts
+++ b/src/core/telomere.ts
@@ -13,7 +13,7 @@ export type TelomereEntry = {
   /** memberMap にない場合は userId をそのまま使用する */
   displayName: string
   lineCount: number
-  /** ユーザーが書いた行の中で最も新しい updated タイムスタンプ (unix ms) */
+  /** ユーザーが書いた行の中で最も新しい updated タイムスタンプ (unix 秒) */
   latestUpdated: number
 }
 

--- a/tests/unit/commands/page/get.test.ts
+++ b/tests/unit/commands/page/get.test.ts
@@ -1,0 +1,199 @@
+/**
+ * page/get.test.ts — `cos page get <title>` コマンドのテスト。
+ *
+ * --format ai オプションによる AI 向け Markdown 出力と、
+ * バリデーション（無効な --format 値）を検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { pageGetCommand } from "@/commands/page/get"
+import { http, HttpResponse } from "msw"
+import { useMswServer } from "../../../helpers/msw"
+
+const BASE_URL = "https://scrapbox.io"
+const TEST_PROJECT = "テストプロジェクト"
+const TEST_TITLE = "テストページ"
+
+/** テスト用ページAPIレスポンス */
+const PAGE_RESPONSE = {
+  id: "page-id-001",
+  title: TEST_TITLE,
+  created: 1700000000,
+  updated: 1700100000,
+  views: 10,
+  linked: 3,
+  commitId: "commit-abc",
+  lines: [
+    { id: "l0", text: TEST_TITLE, userId: "uid-山田", created: 1700000000, updated: 1700000000 },
+    { id: "l1", text: "本文1行目", userId: "uid-山田", created: 1700000000, updated: 1700050000 },
+    { id: "l2", text: "本文2行目", userId: "uid-鈴木", created: 1700000000, updated: 1700100000 },
+  ],
+  user: { id: "uid-山田", name: "yamada", displayName: "山田太郎" },
+  relatedPages: {
+    links1hop: [{ id: "rel1", title: "リンク先ページ", created: 1700000000, updated: 1700000000 }],
+  },
+}
+
+/** テスト用メンバーAPIレスポンス */
+const MEMBERS_RESPONSE = {
+  users: [
+    { id: "uid-山田", name: "yamada", displayName: "山田太郎", created: 0, updated: 0 },
+    { id: "uid-鈴木", name: "suzuki", displayName: "鈴木次郎", created: 0, updated: 0 },
+  ],
+}
+
+useMswServer([
+  http.get(`${BASE_URL}/api/pages/:project/:title`, ({ params }) => {
+    if (
+      decodeURIComponent(params["project"] as string) === TEST_PROJECT &&
+      decodeURIComponent(params["title"] as string) === TEST_TITLE
+    ) {
+      return HttpResponse.json(PAGE_RESPONSE)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+  http.get(`${BASE_URL}/api/projects/:project/users`, ({ params }) => {
+    if (decodeURIComponent(params["project"] as string) === TEST_PROJECT) {
+      return HttpResponse.json(MEMBERS_RESPONSE)
+    }
+    return HttpResponse.json({ message: "Not found" }, { status: 404 })
+  }),
+  http.get(`${BASE_URL}/api/users/me`, () => {
+    return HttpResponse.json({ id: "uid-山田", name: "yamada" })
+  }),
+])
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+
+async function runGet(args: Record<string, unknown>) {
+  await (
+    pageGetCommand.run as (ctx: { args: unknown; cmd: never; rawArgs: string[] }) => Promise<void>
+  )({
+    args,
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_ENABLE_COMMANDS")
+  Reflect.deleteProperty(process.env, "COS_DISABLE_COMMANDS")
+  process.env["COS_SID"] = "s%3Atest-session-id"
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  Reflect.deleteProperty(process.env, "COS_SID")
+})
+
+describe("pageGetCommand", () => {
+  describe("--format ai", () => {
+    it("出力に # ページタイトルの見出しが含まれる", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "ai",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {
+        // REST クライアント初期化中の throw は想定内
+      }
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain(`# ${TEST_TITLE}`)
+    })
+
+    it("出力にメタデータセクションの pageId が含まれる", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "ai",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {}
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("page-id-001")
+    })
+
+    it("出力に本文行が含まれる", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "ai",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {}
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("本文1行目")
+      expect(output).toContain("本文2行目")
+    })
+
+    it("出力に 1-hop 関連ページが含まれる", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "ai",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {}
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("リンク先ページ")
+    })
+
+    it("--format ai --json を同時指定すると VALIDATION_ERROR で exit 5", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "ai",
+          json: true,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {}
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("VALIDATION_ERROR")
+    })
+  })
+
+  describe("バリデーション", () => {
+    it("--format に無効値を指定すると VALIDATION_ERROR で exit 5", async () => {
+      try {
+        await runGet({
+          title: TEST_TITLE,
+          project: TEST_PROJECT,
+          format: "xml",
+          json: false,
+          plain: false,
+          "results-only": false,
+          quiet: false,
+        })
+      } catch {}
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("VALIDATION_ERROR")
+    })
+  })
+})

--- a/tests/unit/core/format/ai-page.test.ts
+++ b/tests/unit/core/format/ai-page.test.ts
@@ -1,0 +1,134 @@
+/**
+ * ai-page.test.ts — AI向けページMarkdown生成のテスト。
+ *
+ * formatAiPage 関数が Page + ProjectMembersResponse から
+ * エージェントが読みやすい Markdown を正しく生成することを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { formatAiPage } from "@/core/format/ai-page"
+import type { Page } from "@/schemas/page"
+import type { ProjectMembersResponse } from "@/schemas/project"
+
+/** テスト用の最小 Page オブジェクト */
+const BASE_PAGE: Page = {
+  id: "page-id-abc123",
+  title: "テストページ",
+  created: 1700000000,
+  updated: 1700100000,
+  views: 42,
+  linked: 5,
+  commitId: "commit-xyz",
+  lines: [
+    // lines[0] はタイトル行（本文出力から除外される）
+    {
+      id: "line0",
+      text: "テストページ",
+      userId: "user-山田",
+      created: 1700000000,
+      updated: 1700000000,
+    },
+    {
+      id: "line1",
+      text: "本文の1行目です",
+      userId: "user-山田",
+      created: 1700000000,
+      updated: 1700050000,
+    },
+    {
+      id: "line2",
+      text: "本文の2行目です",
+      userId: "user-鈴木",
+      created: 1700000000,
+      updated: 1700100000,
+    },
+  ],
+  user: { id: "user-山田", name: "yamada", displayName: "山田太郎" },
+  relatedPages: {
+    links1hop: [
+      { id: "rel1", title: "関連ページA", created: 1700000000, updated: 1700000000 },
+      { id: "rel2", title: "関連ページB", created: 1700000000, updated: 1700000000 },
+    ],
+  },
+}
+
+/** テスト用のメンバーレスポンス */
+const MEMBERS: ProjectMembersResponse = {
+  users: [
+    { id: "user-山田", name: "yamada", displayName: "山田太郎", created: 0, updated: 0 },
+    { id: "user-鈴木", name: "suzuki", displayName: "鈴木次郎", created: 0, updated: 0 },
+  ],
+}
+
+describe("formatAiPage", () => {
+  it("出力の先頭がページタイトルの # 見出しになる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toMatch(/^# テストページ\n/)
+  })
+
+  it("メタデータセクションに pageId が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("page-id-abc123")
+  })
+
+  it("メタデータセクションに commitId が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("commit-xyz")
+  })
+
+  it("メタデータセクションに views が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("42")
+  })
+
+  it("メタデータセクションに被リンク数が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("5")
+  })
+
+  it("編集メンバーセクションにアイコン記法が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    // テロメアに登場した山田・鈴木のアイコン記法が出力される
+    expect(output).toContain("[yamada.icon]")
+    expect(output).toContain("[suzuki.icon]")
+  })
+
+  it("テロメアセクションにユーザー名・行数が含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("山田太郎")
+    expect(output).toContain("鈴木次郎")
+  })
+
+  it("本文セクションに lines[1] 以降のテキストが含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("本文の1行目です")
+    expect(output).toContain("本文の2行目です")
+  })
+
+  it("本文セクションに lines[0]（タイトル行）は含まれない", () => {
+    // タイトル行のテキストは # 見出しとして既出のため本文ブロックには含まない
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    // 本文セクション (## 本文) 以降のテキスト部分にタイトル行が重複しない
+    const bodySection = output.split("## 本文")[1] ?? ""
+    const firstLine = bodySection.trimStart().split("\n")[0]
+    expect(firstLine).not.toBe("テストページ")
+  })
+
+  it("1-hop関連ページセクションにページタイトルが含まれる", () => {
+    const output = formatAiPage(BASE_PAGE, MEMBERS)
+    expect(output).toContain("関連ページA")
+    expect(output).toContain("関連ページB")
+  })
+
+  it("1-hop関連ページがない場合、関連ページセクションは出力されない", () => {
+    const page: Page = { ...BASE_PAGE, relatedPages: undefined }
+    const output = formatAiPage(page, MEMBERS)
+    expect(output).not.toContain("関連ページ")
+  })
+
+  it("メンバー情報が null の場合もエラーなく出力できる", () => {
+    expect(() => formatAiPage(BASE_PAGE, null)).not.toThrow()
+    const output = formatAiPage(BASE_PAGE, null)
+    expect(output).toContain("# テストページ")
+  })
+})

--- a/tests/unit/core/telomere.test.ts
+++ b/tests/unit/core/telomere.test.ts
@@ -1,0 +1,93 @@
+/**
+ * telomere.test.ts — テロメア集計ロジックのテスト。
+ *
+ * ページ行配列（Line[]）をユーザーID単位で集計し、
+ * 「誰が何行、いつ最後に更新したか」を返す buildTelomere 関数を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { buildTelomere } from "@/core/telomere"
+import type { Line } from "@/schemas/page"
+
+/** テスト用の行データを生成するヘルパー */
+function makeLine(id: string, userId: string, updated: number, text = "テスト行"): Line {
+  return { id, text, userId, created: 0, updated }
+}
+
+describe("buildTelomere", () => {
+  it("空の行配列を渡すと空配列を返す", () => {
+    const result = buildTelomere([], new Map())
+    expect(result).toEqual([])
+  })
+
+  it("1人が書いた行のみの場合、そのユーザーの1エントリを返す", () => {
+    const lines: Line[] = [
+      makeLine("line1", "user-山田", 1000),
+      makeLine("line2", "user-山田", 2000),
+      makeLine("line3", "user-山田", 3000),
+    ]
+    const memberMap = new Map([["user-山田", "山田太郎"]])
+
+    const result = buildTelomere(lines, memberMap)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      userId: "user-山田",
+      displayName: "山田太郎",
+      lineCount: 3,
+      latestUpdated: 3000,
+    })
+  })
+
+  it("複数ユーザーの行を正しく集計し、行数降順でソートして返す", () => {
+    const lines: Line[] = [
+      makeLine("line1", "user-山田", 1000),
+      makeLine("line2", "user-鈴木", 2000),
+      makeLine("line3", "user-山田", 3000),
+      makeLine("line4", "user-鈴木", 4000),
+      makeLine("line5", "user-鈴木", 5000),
+    ]
+    const memberMap = new Map([
+      ["user-山田", "山田太郎"],
+      ["user-鈴木", "鈴木次郎"],
+    ])
+
+    const result = buildTelomere(lines, memberMap)
+
+    // 行数降順: 鈴木(3行) > 山田(2行)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      userId: "user-鈴木",
+      displayName: "鈴木次郎",
+      lineCount: 3,
+      latestUpdated: 5000,
+    })
+    expect(result[1]).toEqual({
+      userId: "user-山田",
+      displayName: "山田太郎",
+      lineCount: 2,
+      latestUpdated: 3000,
+    })
+  })
+
+  it("memberMap にないユーザーIDは displayName にユーザーID自体をセットする", () => {
+    const lines: Line[] = [makeLine("line1", "unknown-user-id", 1000)]
+
+    const result = buildTelomere(lines, new Map())
+
+    expect(result[0]?.displayName).toBe("unknown-user-id")
+  })
+
+  it("latestUpdated は同一ユーザーの行の中で最も大きい updated を返す", () => {
+    const lines: Line[] = [
+      makeLine("line1", "user-山田", 5000),
+      makeLine("line2", "user-山田", 1000),
+      makeLine("line3", "user-山田", 3000),
+    ]
+    const memberMap = new Map([["user-山田", "山田太郎"]])
+
+    const result = buildTelomere(lines, memberMap)
+
+    expect(result[0]?.latestUpdated).toBe(5000)
+  })
+})


### PR DESCRIPTION
## Summary

- `cos page get <title> --format ai` でメタデータ・テロメア・本文・1-hop 関連ページをワンショット Markdown 出力できるようにする
- `getPage()` と `getProjectMembers()` を並列フェッチしてレイテンシを抑制する
- `--format ai --json` の同時指定は VALIDATION_ERROR (exit 5) で排他制御
- テロメア集計ロジック (`src/core/telomere.ts`) を独立したコア層として分離する

## 出力例

```
# ページタイトル

## メタデータ

| 項目 | 値 |
|------|-----|
| ID | ... |
| commitId | ... |
...

## 編集メンバー

[yamada.icon] [suzuki.icon]

## テロメア

| 更新者 | 行数 | 最終更新 |
|--------|------|----------|
| 山田太郎 | 30 | 2026/01/01 12:00:00 |

## 本文

（ページ本文）

---

## 関連ページ（1-hop）

- 関連ページA
- 関連ページB
```

## Test plan

- [x] `bun test` — 1617 pass / 0 fail
- [x] `bunx biome check src tests` — エラーなし
- [x] `bun run typecheck` — エラーなし
- [x] `cos page get "mtane0412" -p mtane0412 --format ai` で実動作確認
- [x] `--format ai --json` の排他制御を確認 (exit 5)
- [x] `--format xml` (無効値) の VALIDATION_ERROR を確認 (exit 5)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `cos page get` コマンドに `--format ai` オプションを追加。AI エージェント向けの Markdown 形式でページを出力でき、メタデータ、編集メンバー、関連ページ情報を含みます。

* **ドキュメント**
  * README.md と SKILL.md に新しい `--format ai` オプションの説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->