### PR TITLE
feat(schema): CLI 体系再編の基盤 — schema/envelope/auth-capabilities 拡張 (PR 0/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,9 +157,11 @@ type Credential =
 
 ### PAT 制約
 
-PAT (`pat_` + 64桁小文字16進数、ヘッダ `x-personal-access-token`) は**読み取り系 REST のみ**対応。
+PAT (`pat_` + 64桁小文字16進数、ヘッダ `x-personal-access-token`) の能力一覧は `src/core/auth/capabilities.ts` の `AUTH_CAPABILITIES.pat` が単一の事実ソース。
 
-- **書き込み不可**: `page edit`、`page pin`、`sync push` 等は `connect.sid` が必要
+概要:
+- **v2 AI ops API 書き込み可**: `page edit preview / submit`、`page append preview` 等 (v2 AI ops 移行済みコマンド)
+- **旧 WebSocket commit は不可**: `page delete`、`page pin`、`sync push` 等は `connect.sid` が必要
 - **csrfToken 欠落**: PAT セッションでは `/api/users/me` が csrfToken を返さない。`MeSchema.csrfToken` は `.optional()` にしてある
 - **`replaceLinks` ガード**: `csrfToken === undefined` のとき `AUTH_WRITE_NOT_SUPPORTED` を throw
 

--- a/src/core/auth/capabilities.ts
+++ b/src/core/auth/capabilities.ts
@@ -1,0 +1,122 @@
+/**
+ * capabilities.ts — 認証種別ごとの能力定義。
+ *
+ * coscli における認証要件の単一の事実ソース (Single Source of Truth)。
+ * CLAUDE.md・README・SKILL.md の認証要件記述はこのファイルを参照する。
+ *
+ * ## 背景
+ * coscli には 3 種類の認証方式があり、対応できる操作が異なる。
+ *
+ * - PAT (pat_xxxxx): v2 AI ops API (preview/submit 2 ステップ) への書き込みに対応。
+ *   旧 WebSocket commit (page.delete/rename/pin/unpin/sync.push) は不可。
+ *   CLAUDE.md の「PAT は読み取り系 REST のみ」という記述は移行前の状態であり、
+ *   v2 AI ops API 導入後は書き込みも PAT で可能。
+ *
+ * - SID (connect.sid): 旧 WebSocket commit に対応。
+ *   v2 AI ops API では requirePat() により exit 2 になるため不可。
+ *
+ * - SA (サービスアカウントキー): 読み取り系のみ対応。
+ */
+
+/** AuthKind は coscli が扱う認証種別。 */
+export type AuthKind = "pat" | "sid" | "sa" | "any" | "none"
+
+/**
+ * AuthCapabilities は各認証種別が対応できる操作カテゴリを定義する。
+ */
+export interface AuthCapabilities {
+  /** 認証種別 */
+  kind: AuthKind
+  /** 認証種別の説明 */
+  description: string
+  /** Cosense REST API 読み取りが可能か */
+  canRead: boolean
+  /**
+   * v2 AI ops API への書き込みが可能か。
+   *
+   * 対象コマンド: page.edit.preview / page.edit.submit /
+   * page.append.preview / page.prepend.preview / page.insert.preview /
+   * page.new.preview / page.line.replace.preview / page.line.delete.preview
+   */
+  canWriteV2OpsAPI: boolean
+  /**
+   * 旧 WebSocket commit への書き込みが可能か。
+   *
+   * 対象コマンド: page.delete / page.rename / page.pin / page.unpin / sync.push
+   */
+  canWriteWebSocket: boolean
+  /** ローカル設定ファイルの変更が可能か (Cosense API とは独立) */
+  canWriteLocalConfig: boolean
+}
+
+/** AUTH_CAPABILITIES は認証種別ごとの能力マップ。 */
+export const AUTH_CAPABILITIES: Record<AuthKind, AuthCapabilities> = {
+  pat: {
+    kind: "pat",
+    description:
+      "Personal Access Token (pat_ + 64桁小文字16進数)。" +
+      "読み取り系 REST と v2 AI ops API (preview/submit) への書き込みに対応。" +
+      "旧 WebSocket commit (delete/rename/pin/unpin/sync push) は使用不可。" +
+      "ヘッダ: x-personal-access-token",
+    canRead: true,
+    canWriteV2OpsAPI: true,
+    canWriteWebSocket: false,
+    canWriteLocalConfig: false,
+  },
+  sid: {
+    kind: "sid",
+    description:
+      "セッション Cookie (connect.sid)。" +
+      "読み取り系 REST と旧 WebSocket commit に対応。" +
+      "v2 AI ops API は requirePat() により PAT 専用のため使用不可 (exit 2)。",
+    canRead: true,
+    canWriteV2OpsAPI: false,
+    canWriteWebSocket: true,
+    canWriteLocalConfig: false,
+  },
+  sa: {
+    kind: "sa",
+    description:
+      "サービスアカウントキー (cs_<project> 形式でキーチェーンに保存)。" +
+      "読み取り系 REST のみ対応。v2 AI ops / WebSocket は使用不可。",
+    canRead: true,
+    canWriteV2OpsAPI: false,
+    canWriteWebSocket: false,
+    canWriteLocalConfig: false,
+  },
+  any: {
+    kind: "any",
+    description: "PAT / SID / SA のいずれかで利用可能。主に読み取り系コマンドで使用。",
+    canRead: true,
+    canWriteV2OpsAPI: false,
+    canWriteWebSocket: false,
+    canWriteLocalConfig: false,
+  },
+  none: {
+    kind: "none",
+    description:
+      "認証不要。Cosense API を呼び出さないコマンドで使用 (config.get / schema / exit-codes / page.icon 等)。",
+    canRead: false,
+    canWriteV2OpsAPI: false,
+    canWriteWebSocket: false,
+    canWriteLocalConfig: true,
+  },
+}
+
+/**
+ * canWriteV2OpsAPI は指定した認証種別が v2 AI ops API への書き込みに対応しているか返す。
+ *
+ * @param kind - 確認する認証種別
+ */
+export function canWriteV2OpsAPI(kind: AuthKind): boolean {
+  return AUTH_CAPABILITIES[kind].canWriteV2OpsAPI
+}
+
+/**
+ * canWriteWebSocket は指定した認証種別が旧 WebSocket commit に対応しているか返す。
+ *
+ * @param kind - 確認する認証種別
+ */
+export function canWriteWebSocket(kind: AuthKind): boolean {
+  return AUTH_CAPABILITIES[kind].canWriteWebSocket
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -28,6 +28,42 @@ export interface SchemaArg {
   valueHint?: string
 }
 
+/**
+ * SchemaCommandDeprecated はコマンドの非推奨情報。
+ *
+ * deprecated alias コマンドが持つ移行情報。エージェントが次のターンで
+ * 正規コマンドに切り替えるための情報を機械可読で提供する。
+ */
+export interface SchemaCommandDeprecated {
+  /** 非推奨になったバージョン (例: "v2.0.0") */
+  since: string
+  /** 移行先コマンド文字列 (例: "page get --format=text") */
+  replacement: string
+  /** 移行先コマンドに渡す追加引数マッピング (省略可) */
+  replacementArgs?: Record<string, string>
+}
+
+/** SchemaCommandConditionalArg は条件付き必須引数の定義。 */
+export interface SchemaCommandConditionalArg {
+  /** この条件が発動する引数と値の条件 */
+  when: {
+    /** 引数名 */
+    arg: string
+    /** いずれかに一致する値リスト */
+    equals: string[]
+  }
+  /** when の条件が満たされたとき必須となる引数名リスト */
+  required: string[]
+}
+
+/** SchemaCommandExample はコマンドの使用例。 */
+export interface SchemaCommandExample {
+  /** 使用例の説明 */
+  description: string
+  /** 使用例コマンド文字列 */
+  command: string
+}
+
 /** SchemaCommand はコマンド 1 つのスキーマ表現。 */
 export interface SchemaCommand {
   /** コマンド名（canonical） */
@@ -40,6 +76,59 @@ export interface SchemaCommand {
   args: SchemaArg[]
   /** サブコマンド一覧 */
   subCommands: SchemaCommand[]
+  /**
+   * フル識別子 (例: "page.get", "page.edit.preview")。
+   *
+   * sandbox の --enable-commands / --disable-commands と同じドット区切り形式。
+   * PR 5 で cos schema コマンドが出力する際に実際の ID を流し込む。
+   */
+  id?: string
+  /**
+   * 正規識別子 (deprecated alias の場合のみ設定)。
+   *
+   * 例: page.text の canonicalId は "page.get"。
+   * エージェントが学ぶべき正規コマンドを示す。
+   */
+  canonicalId?: string
+  /**
+   * 必要な認証種別。
+   *
+   * - "pat": PAT 専用 (v2 AI ops API 書き込み系)
+   * - "sid": SID 必須 (旧 WebSocket commit 系)
+   * - "any": PAT/SID/SA いずれかで可 (読み取り系)
+   * - "none": 認証不要 (ローカル情報参照系)
+   */
+  requiresAuthKind?: "pat" | "sid" | "any" | "none"
+  /**
+   * 操作の権限種別。
+   *
+   * - "read": 読み取りのみ
+   * - "write": 書き込み (非破壊的)
+   * - "destructive": 削除・上書き等の破壊的書き込み
+   * - "config": ローカル設定変更
+   * - "meta": メタ情報参照 (schema / exit-codes 等)
+   */
+  permissionKind?: "read" | "write" | "destructive" | "config" | "meta"
+  /**
+   * 非推奨情報 (deprecated alias の場合のみ設定)。
+   *
+   * エージェントが次のターンで正規コマンドに切り替えるための移行情報。
+   */
+  deprecated?: SchemaCommandDeprecated
+  /**
+   * 使用例リスト。
+   *
+   * AI エージェントが `--format=code` のような条件付き引数の正しい使い方を
+   * 学習するための具体的なコマンド例。
+   */
+  examples?: SchemaCommandExample[]
+  /**
+   * 条件付き必須引数の定義。
+   *
+   * 例: `--format=code` または `--format=table` のとき `--filename` が必須。
+   * citty の args では表現できない条件付き必須を機械可読で提供する。
+   */
+  conditionalArgs?: SchemaCommandConditionalArg[]
 }
 
 /**

--- a/src/presenter/json.ts
+++ b/src/presenter/json.ts
@@ -7,15 +7,40 @@
 
 import { randomUUID } from "node:crypto"
 
+/** ResponseEnvelopeMeta は CLI 出力 envelope の meta フィールド。 */
+export interface ResponseEnvelopeMeta {
+  /** 実行されたコマンド識別子 (deprecated alias の場合は旧識別子のまま) */
+  command: string
+  /** ミリ秒単位の実行時間 */
+  durationMs: number
+  /** リクエスト追跡用 UUID */
+  requestId: string
+  /** 警告メッセージリスト */
+  warnings: string[]
+  /**
+   * 正規コマンド識別子 (deprecated alias 経由で実行された場合のみ設定)。
+   *
+   * エージェントが次のターンで使うべき正規コマンド ID を示す。
+   * command フィールドとの使い分け:
+   *   - command: sandbox 識別子として使用 (後方互換を維持)
+   *   - canonicalCommand: エージェントが学ぶべき正規 ID
+   */
+  canonicalCommand?: string
+  /**
+   * 非推奨情報 (deprecated alias 経由で実行された場合のみ設定)。
+   *
+   * エージェントが次のターンで正規コマンドに切り替えるための移行情報。
+   */
+  deprecated?: {
+    since: string
+    replacement: string
+  }
+}
+
 /** ResponseEnvelope は CLI の標準出力 envelope 形式。 */
 export interface ResponseEnvelope<T> {
   data: T
-  meta: {
-    command: string
-    durationMs: number
-    requestId: string
-    warnings: string[]
-  }
+  meta: ResponseEnvelopeMeta
 }
 
 /** ErrorEnvelope はエラー時の出力形式。 */
@@ -38,12 +63,33 @@ export interface JsonOutputOptions {
   select?: string
 }
 
+/** WriteJsonMeta は writeJson に渡す meta 引数の型。 */
+export interface WriteJsonMeta {
+  /** コマンド識別子 */
+  command: string
+  /** 開始時刻 (Date.now()) */
+  startTime: number
+  /** 警告メッセージリスト */
+  warnings?: string[]
+  /**
+   * 正規コマンド識別子 (deprecated alias 経由の場合のみ指定)。
+   *
+   * 指定すると envelope の meta.canonicalCommand に出力される。
+   */
+  canonicalCommand?: string
+  /**
+   * 非推奨情報 (deprecated alias 経由の場合のみ指定)。
+   *
+   * 指定すると envelope の meta.deprecated に出力される。
+   */
+  deprecated?: {
+    since: string
+    replacement: string
+  }
+}
+
 /** writeJson は envelope を JSON として stdout に書き出す。 */
-export function writeJson<T>(
-  data: T,
-  meta: { command: string; startTime: number; warnings?: string[] },
-  opts: JsonOutputOptions = {},
-): void {
+export function writeJson<T>(data: T, meta: WriteJsonMeta, opts: JsonOutputOptions = {}): void {
   const stream = opts.stream ?? process.stdout
   const durationMs = Date.now() - meta.startTime
 
@@ -51,15 +97,20 @@ export function writeJson<T>(
   if (opts.resultsOnly) {
     output = applySelect(data, opts.select)
   } else {
-    const envelope: ResponseEnvelope<T> = {
-      data,
-      meta: {
-        command: meta.command,
-        durationMs,
-        requestId: randomUUID(),
-        warnings: meta.warnings ?? [],
-      },
+    const envelopeMeta: ResponseEnvelopeMeta = {
+      command: meta.command,
+      durationMs,
+      requestId: randomUUID(),
+      warnings: meta.warnings ?? [],
     }
+    // 省略可能フィールドは値がある場合のみ出力する (後方互換)
+    if (meta.canonicalCommand !== undefined) {
+      envelopeMeta.canonicalCommand = meta.canonicalCommand
+    }
+    if (meta.deprecated !== undefined) {
+      envelopeMeta.deprecated = meta.deprecated
+    }
+    const envelope: ResponseEnvelope<T> = { data, meta: envelopeMeta }
     output = opts.select ? applySelect(envelope.data, opts.select) : envelope
   }
 

--- a/tests/unit/core/auth/capabilities.test.ts
+++ b/tests/unit/core/auth/capabilities.test.ts
@@ -1,0 +1,121 @@
+/**
+ * capabilities.test.ts — 認証種別ごとの能力定義のテスト。
+ *
+ * AUTH_CAPABILITIES が認証の「単一の事実ソース」として
+ * 正しい能力マッピングを定義しているかを検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { AUTH_CAPABILITIES, canWriteV2OpsAPI, canWriteWebSocket } from "@/core/auth/capabilities"
+
+describe("AUTH_CAPABILITIES", () => {
+  it("すべての認証種別が定義されている", () => {
+    expect(AUTH_CAPABILITIES.pat).toBeDefined()
+    expect(AUTH_CAPABILITIES.sid).toBeDefined()
+    expect(AUTH_CAPABILITIES.sa).toBeDefined()
+    expect(AUTH_CAPABILITIES.any).toBeDefined()
+    expect(AUTH_CAPABILITIES.none).toBeDefined()
+  })
+
+  describe("PAT (Personal Access Token)", () => {
+    it("読み取りができる", () => {
+      expect(AUTH_CAPABILITIES.pat.canRead).toBe(true)
+    })
+
+    it("v2 AI ops API への書き込みができる", () => {
+      // v2 AI ops (preview/submit 2ステップ) は PAT 専用
+      expect(AUTH_CAPABILITIES.pat.canWriteV2OpsAPI).toBe(true)
+    })
+
+    it("旧 WebSocket commit への書き込みができない", () => {
+      // page.delete/rename/pin/unpin は SID が必要
+      expect(AUTH_CAPABILITIES.pat.canWriteWebSocket).toBe(false)
+    })
+
+    it("ローカル設定の変更はできない", () => {
+      expect(AUTH_CAPABILITIES.pat.canWriteLocalConfig).toBe(false)
+    })
+  })
+
+  describe("SID (connect.sid セッション Cookie)", () => {
+    it("読み取りができる", () => {
+      expect(AUTH_CAPABILITIES.sid.canRead).toBe(true)
+    })
+
+    it("旧 WebSocket commit への書き込みができる", () => {
+      // page.delete/rename/pin/unpin/sync.push は SID 必須
+      expect(AUTH_CAPABILITIES.sid.canWriteWebSocket).toBe(true)
+    })
+
+    it("v2 AI ops API への書き込みができない", () => {
+      // requirePat() で exit 2 になる
+      expect(AUTH_CAPABILITIES.sid.canWriteV2OpsAPI).toBe(false)
+    })
+  })
+
+  describe("SA (サービスアカウントキー)", () => {
+    it("読み取りができる", () => {
+      expect(AUTH_CAPABILITIES.sa.canRead).toBe(true)
+    })
+
+    it("v2 AI ops API への書き込みができない", () => {
+      expect(AUTH_CAPABILITIES.sa.canWriteV2OpsAPI).toBe(false)
+    })
+
+    it("旧 WebSocket commit への書き込みができない", () => {
+      expect(AUTH_CAPABILITIES.sa.canWriteWebSocket).toBe(false)
+    })
+  })
+
+  describe("any (PAT/SID/SA いずれか)", () => {
+    it("読み取りができる", () => {
+      expect(AUTH_CAPABILITIES.any.canRead).toBe(true)
+    })
+  })
+
+  describe("none (認証不要)", () => {
+    it("読み取りはできない (Cosense API 呼び出しなし)", () => {
+      expect(AUTH_CAPABILITIES.none.canRead).toBe(false)
+    })
+
+    it("ローカル設定の変更ができる", () => {
+      expect(AUTH_CAPABILITIES.none.canWriteLocalConfig).toBe(true)
+    })
+  })
+})
+
+describe("canWriteV2OpsAPI", () => {
+  it("PAT は v2 ops API に書き込みできる", () => {
+    expect(canWriteV2OpsAPI("pat")).toBe(true)
+  })
+
+  it("SID は v2 ops API に書き込みできない", () => {
+    expect(canWriteV2OpsAPI("sid")).toBe(false)
+  })
+
+  it("SA は v2 ops API に書き込みできない", () => {
+    expect(canWriteV2OpsAPI("sa")).toBe(false)
+  })
+
+  it("any は v2 ops API に書き込みできない", () => {
+    expect(canWriteV2OpsAPI("any")).toBe(false)
+  })
+
+  it("none は v2 ops API に書き込みできない", () => {
+    expect(canWriteV2OpsAPI("none")).toBe(false)
+  })
+})
+
+describe("canWriteWebSocket", () => {
+  it("SID は WebSocket commit に書き込みできる", () => {
+    expect(canWriteWebSocket("sid")).toBe(true)
+  })
+
+  it("PAT は WebSocket commit に書き込みできない", () => {
+    expect(canWriteWebSocket("pat")).toBe(false)
+  })
+
+  it("SA は WebSocket commit に書き込みできない", () => {
+    expect(canWriteWebSocket("sa")).toBe(false)
+  })
+})

--- a/tests/unit/core/schema.test.ts
+++ b/tests/unit/core/schema.test.ts
@@ -165,6 +165,65 @@ describe("buildSchema", () => {
   })
 })
 
+describe("SchemaCommand の拡張フィールド", () => {
+  it("SchemaCommand は省略可能な拡張フィールドを受け取れる", () => {
+    // TypeScript の型チェックを兼ねるランタイムテスト。
+    // SchemaCommand 型に新規フィールドが追加されているか検証する。
+    const extended: import("@/core/schema").SchemaCommand = {
+      name: "page.delete",
+      aliases: ["page.rm"],
+      args: [],
+      subCommands: [],
+      id: "page.delete",
+      requiresAuthKind: "sid",
+      permissionKind: "destructive",
+      examples: [{ description: "ページを削除する", command: "cos page delete タイトル" }],
+      conditionalArgs: [],
+    }
+    expect(extended.id).toBe("page.delete")
+    expect(extended.requiresAuthKind).toBe("sid")
+    expect(extended.permissionKind).toBe("destructive")
+    expect(extended.examples?.[0]?.description).toBe("ページを削除する")
+    expect(extended.conditionalArgs).toEqual([])
+  })
+
+  it("SchemaCommand は canonicalId を持てる (deprecated alias の場合)", () => {
+    const deprecatedCmd: import("@/core/schema").SchemaCommand = {
+      name: "page.text",
+      aliases: [],
+      args: [],
+      subCommands: [],
+      id: "page.text",
+      canonicalId: "page.get",
+      deprecated: {
+        since: "v2.0.0",
+        replacement: "page get --format=text",
+      },
+    }
+    expect(deprecatedCmd.canonicalId).toBe("page.get")
+    expect(deprecatedCmd.deprecated?.since).toBe("v2.0.0")
+    expect(deprecatedCmd.deprecated?.replacement).toBe("page get --format=text")
+  })
+
+  it("SchemaCommand は conditionalArgs を持てる (--format=code のとき --filename 必須)", () => {
+    const conditional: import("@/core/schema").SchemaCommand = {
+      name: "page.get",
+      aliases: [],
+      args: [],
+      subCommands: [],
+      conditionalArgs: [
+        {
+          when: { arg: "format", equals: ["code", "table"] },
+          required: ["filename"],
+        },
+      ],
+    }
+    expect(conditional.conditionalArgs?.[0]?.when.arg).toBe("format")
+    expect(conditional.conditionalArgs?.[0]?.when.equals).toEqual(["code", "table"])
+    expect(conditional.conditionalArgs?.[0]?.required).toEqual(["filename"])
+  })
+})
+
 describe("findCommandByPath", () => {
   it("空パスはルートを返す", async () => {
     const result = await findCommandByPath(rootCommand, "cos", [])

--- a/tests/unit/presenter/json.test.ts
+++ b/tests/unit/presenter/json.test.ts
@@ -85,6 +85,61 @@ describe("writeJson", () => {
     const parsed = JSON.parse(stream.output)
     expect(parsed).toEqual(["タイトルC"])
   })
+
+  it("canonicalCommand が指定された場合は meta.canonicalCommand に含める", () => {
+    const stream = createMockStream()
+    writeJson(
+      { title: "テストページ" },
+      {
+        command: "page.text",
+        startTime: Date.now(),
+        canonicalCommand: "page.get",
+      },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.meta.canonicalCommand).toBe("page.get")
+  })
+
+  it("deprecated が指定された場合は meta.deprecated に含める", () => {
+    const stream = createMockStream()
+    writeJson(
+      { title: "テストページ" },
+      {
+        command: "page.text",
+        startTime: Date.now(),
+        deprecated: { since: "v2.0.0", replacement: "page get --format=text" },
+      },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.meta.deprecated).toEqual({
+      since: "v2.0.0",
+      replacement: "page get --format=text",
+    })
+  })
+
+  it("canonicalCommand が未指定の場合は meta.canonicalCommand を含まない (後方互換)", () => {
+    const stream = createMockStream()
+    writeJson(
+      {},
+      { command: "page.get", startTime: Date.now() },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.meta.canonicalCommand).toBeUndefined()
+  })
+
+  it("deprecated が未指定の場合は meta.deprecated を含まない (後方互換)", () => {
+    const stream = createMockStream()
+    writeJson(
+      {},
+      { command: "page.get", startTime: Date.now() },
+      { stream: stream as unknown as NodeJS.WritableStream },
+    )
+    const parsed = JSON.parse(stream.output)
+    expect(parsed.meta.deprecated).toBeUndefined()
+  })
 })
 
 describe("writeErrorJson", () => {


### PR DESCRIPTION
## Summary

コマンド体系再編 7 本 PR 構成の **PR 0 (基盤拡張)**。
後続 PR (PR 1〜PR 6) の前提となる型拡張と認証要件の単一ソースを先行導入します。
この PR 単体では機能変更なし。既存出力は後方互換を維持します。

### 変更内容

- **`SchemaCommand` interface 拡張** (`src/core/schema.ts`)
  - `id`, `canonicalId`, `requiresAuthKind`, `permissionKind`, `deprecated`, `examples`, `conditionalArgs` を省略可能フィールドとして追加
  - PR 5 で `cos schema --json` がこれらを出力する際の型基盤

- **`ResponseEnvelopeMeta` 拡張** (`src/presenter/json.ts`)
  - `canonicalCommand?` と `deprecated?` を追加
  - deprecated alias 経由実行時にエージェントが次のターンで正規コマンドに切り替えられるよう移行情報を提供 (PR 3〜PR 4 で活用)
  - `WriteJsonMeta` 型を独立させ、呼び出し側が新フィールドを渡せるように

- **`src/core/auth/capabilities.ts` 新規追加**
  - PAT/SID/SA/any/none の各認証種別が対応できる操作カテゴリを定義する単一ソース
  - `canWriteV2OpsAPI()` / `canWriteWebSocket()` ヘルパ関数
  - **CLAUDE.md の認証要件矛盾を解消**: 「PAT は読み取り REST のみ」という記述が v2 AI ops 導入後の実態と矛盾していたため、capabilities.ts を真の単一ソースとして参照するよう CLAUDE.md を更新

### コンテキスト

codex レビューで指摘された最大リスク「schema 表現力・認証ドキュメント矛盾・envelope の二重状態」に対処する基盤整備。
[プランドキュメント参照](.claude/plans/api-coscli-websocket-api-ai-cli-shimmering-aurora.md)

## Test plan

- [x] `bun test` — 1672 pass / 0 fail
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — Lint 警告なし
- [x] 新規テスト `tests/unit/core/auth/capabilities.test.ts` (14 テスト)
- [x] `tests/unit/core/schema.test.ts` に型拡張テスト 3 件追加
- [x] `tests/unit/presenter/json.test.ts` に canonicalCommand/deprecated テスト 4 件追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * PAT 認証の権限説明を更新し、サポートされている操作を明確化しました。

* **New Features**
  * コマンドメタデータに非推奨情報、認証要件、使用例を追加しました。
  * API レスポンスに正規コマンド名と非推奨情報を含めるようになりました。

* **Tests**
  * 認証権限管理とコマンドメタデータの包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->