### PR TITLE
feat(page/edit): --op ディスパッチャで page edit preview に全書き込み操作を統合する (PR 2/7)

### DIFF
--- a/src/commands/page/edit/preview.ts
+++ b/src/commands/page/edit/preview.ts
@@ -240,7 +240,13 @@ export const pageEditPreviewCommand = defineCommand({
       const bodyLines = bodyText ? bodyText.split(/\r?\n|\\n/) : []
       const translateResult = buildNewPageChanges(a.title, bodyLines)
 
-      const response = await client.previewEditV2(project, { changes: translateResult.changes })
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, { changes: translateResult.changes })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
       const status = response.pagePreview?.persistent === false ? "create" : "update"
       const result = buildPreviewResult(
         response.previewId,
@@ -280,10 +286,16 @@ export const pageEditPreviewCommand = defineCommand({
 
       const page = await client.getPage(project, a.title)
       const translateResult = buildAppendChanges(lines)
-      const response = await client.previewEditV2(project, {
-        pageId: page.id,
-        changes: translateResult.changes,
-      })
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, {
+          pageId: page.id,
+          changes: translateResult.changes,
+        })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
       const status = response.pagePreview?.persistent === false ? "create" : "update"
       const result = buildPreviewResult(
         response.previewId,
@@ -325,10 +337,16 @@ export const pageEditPreviewCommand = defineCommand({
       // タイトル直後の行 ID をアンカーとする。タイトル行のみなら "_end"
       const anchorLineId = page.lines[1]?.id ?? "_end"
       const translateResult = buildPrependChanges(anchorLineId, lines)
-      const response = await client.previewEditV2(project, {
-        pageId: page.id,
-        changes: translateResult.changes,
-      })
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, {
+          pageId: page.id,
+          changes: translateResult.changes,
+        })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
       const status = response.pagePreview?.persistent === false ? "create" : "update"
       const result = buildPreviewResult(
         response.previewId,

--- a/src/commands/page/edit/preview.ts
+++ b/src/commands/page/edit/preview.ts
@@ -1,11 +1,24 @@
 /**
  * page/edit/preview.ts — `cos page edit preview <title>` コマンド。
  *
- * 既存ページへの ops ベース編集を dry-run して previewId を取得する。
- * --new フラグ指定時は新規ページ作成の preview を実行する。
+ * ページ編集 (既存/新規) を dry-run して previewId を取得する。
+ * --op で操作種別を切り替える。確定は `cos page edit submit <previewId>` で行う。
  *
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  * previewId は 5 分で expire するため、submitEdit を速やかに実行すること。
+ *
+ * --op の各値と動作:
+ *   ops          : --ops で ops JSON を渡す (既存動作、デフォルト)
+ *   append       : 末尾追加 (--text 必須)
+ *   prepend      : タイトル直後に挿入 (--text 必須)
+ *   insert       : 指定行の後ろに挿入 (--text 必須 + --after / --after-id)
+ *   line-replace : 行テキストを置換 (--line-number 必須 + --text 必須)
+ *   line-delete  : 行を削除 (--line-number または --range)
+ *   new-page     : 新規ページ作成 (--text でページ本文を指定)
+ *
+ * 後方互換:
+ *   --new --body : --op=new-page と同義
+ *   --ops        : --op=ops (省略時も含む) と同義
  */
 
 import {
@@ -14,14 +27,57 @@ import {
   buildRestClient,
   checkSandbox,
   exitWithError,
+  getRawFlagValue,
   handlePreviewEditV2Error,
+  readWriteInput,
   requirePat,
   requireProject,
+  runNotationLint,
 } from "@/commands/_shared"
 import { translateOps } from "@/core/edit-ops"
-import { buildPreviewResult } from "@/core/edit-v2"
+import {
+  buildAppendChanges,
+  buildDeleteChanges,
+  buildInsertChanges,
+  buildNewPageChanges,
+  buildPrependChanges,
+  buildPreviewResult,
+  buildReplaceChanges,
+} from "@/core/edit-v2"
+import { RangeSpecError, parseLineSpec } from "@/core/range"
 import { writeErrorJson, writeJson } from "@/presenter/json"
 import { defineCommand } from "citty"
+
+/** --op に指定できる有効な値 */
+const VALID_OPS = [
+  "ops",
+  "append",
+  "prepend",
+  "insert",
+  "line-replace",
+  "line-delete",
+  "new-page",
+] as const
+type OpKind = (typeof VALID_OPS)[number]
+
+/** プレーンテキスト出力のヘルパー */
+function outputPlainResult(result: ReturnType<typeof buildPreviewResult>): void {
+  const lines: string[] = [
+    `previewId: ${result.previewId}`,
+    `expireAt:  ${result.expireAt}`,
+    `status:    ${result.status}`,
+    `title:     ${result.title}`,
+  ]
+  if (result.lines.length > 0) {
+    lines.push("")
+    lines.push("page (after apply):")
+    for (const line of result.lines) {
+      const marker = line.marker === "new" ? "> " : line.marker === "updated" ? "* " : "  "
+      lines.push(`${marker}${line.text}`)
+    }
+  }
+  process.stdout.write(`${lines.join("\n")}\n`)
+}
 
 export const pageEditPreviewCommand = defineCommand({
   meta: { name: "preview", description: "ops をドライランして previewId を取得する (PAT 必須)" },
@@ -80,23 +136,79 @@ export const pageEditPreviewCommand = defineCommand({
       description: "ページタイトル",
       required: true,
     },
+    op: {
+      type: "string" as const,
+      description:
+        "操作種別 (ops|append|prepend|insert|line-replace|line-delete|new-page)。" +
+        "省略時は ops (--ops フラグが必要)。",
+    },
+    // コンテンツ入力 (append/prepend/insert/new-page/line-replace で使用)
+    text: {
+      type: "string" as const,
+      description:
+        "追加・挿入・置換するテキスト (複数行は \\n で区切る)。" +
+        "--op=line-replace では置換後テキスト (改行禁止)。",
+    },
+    "from-file": {
+      type: "string" as const,
+      description: "追加・挿入テキストのファイルパス (- で stdin)",
+    },
+    "strict-notation": {
+      type: "boolean" as const,
+      description: "Cosense 記法の lint を実行する",
+      default: false,
+    },
+    "allow-unsafe-read": {
+      type: "boolean" as const,
+      description: "--from-file で絶対パスや .. を許可する",
+      default: false,
+    },
+    // 行番号指定 (line-replace/line-delete で使用)
+    "line-number": {
+      type: "string" as const,
+      description: "対象行番号 (1-indexed、タイトル行=1)。--op=line-replace/line-delete で使用",
+    },
+    range: {
+      type: "string" as const,
+      description: "削除行範囲 (例: 3:7)。--op=line-delete で使用",
+    },
+    // 挿入位置 (insert で使用)
+    after: {
+      type: "string" as const,
+      description: "挿入位置の行番号 (1-indexed)。--op=insert で使用",
+    },
+    "after-id": {
+      type: "string" as const,
+      description: "挿入先アンカーの lineId。--op=insert で使用",
+    },
+    // 旧フラグ (後方互換)
     ops: {
       type: "string" as const,
-      description: "ops JSON 文字列（stdin の代わりにインラインで渡す場合）",
+      description: "[後方互換] ops JSON 文字列。--op=ops と同義",
     },
     new: {
       type: "boolean" as const,
-      description: "新規ページ作成モード（--body でページ本文を指定する）",
+      description: "[後方互換] 新規ページ作成モード。--op=new-page と同義",
       default: false,
     },
     body: {
       type: "string" as const,
-      description: "--new 時のページ本文（改行区切り）",
+      description: "[後方互換] --new 時のページ本文。--text と同義",
     },
   },
   async run({ args }) {
     const a = args as unknown as CommonArgs & {
       title: string
+      op?: string
+      text?: string
+      "from-file"?: string
+      "strict-notation"?: boolean
+      "allow-unsafe-read"?: boolean
+      "line-number"?: string
+      range?: string
+      after?: string
+      "after-id"?: string
+      // 後方互換
       ops?: string
       new: boolean
       body?: string
@@ -105,25 +217,28 @@ export const pageEditPreviewCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
-    // PAT 必須チェック（SID・SA は 403 で弾かれるため事前ガード）
     await requirePat(a)
+
+    // --op バリデーション (指定がある場合のみ)
+    if (a.op !== undefined && !(VALID_OPS as readonly string[]).includes(a.op)) {
+      writeErrorJson(
+        "VALIDATION_ERROR",
+        `--op=${a.op} は無効な値です`,
+        `有効な値: ${VALID_OPS.join(", ")}`,
+      )
+      exitWithError(5, "VALIDATION_ERROR")
+    }
+
+    // 後方互換: --new は --op=new-page として処理
+    const opKind: OpKind | undefined = a.new ? "new-page" : (a.op as OpKind | undefined)
 
     const client = await buildRestClient(a)
 
-    if (a.new) {
-      // 新規ページ作成モード
-      const bodyText = a.body ?? ""
-      const fullText = `${a.title}${bodyText ? `\n${bodyText}` : ""}`
-      let translateResult: ReturnType<typeof translateOps>
-      try {
-        translateResult = translateOps([{ insertBefore: "_end", text: fullText }])
-      } catch (err) {
-        writeErrorJson(
-          "INVALID_OPS",
-          `ops 変換エラー: ${err instanceof Error ? err.message : String(err)}`,
-        )
-        exitWithError(5, "INVALID_OPS")
-      }
+    // ======= --op=new-page (または --new --body) =======
+    if (opKind === "new-page") {
+      const bodyText = a.body ?? a.text ?? ""
+      const bodyLines = bodyText ? bodyText.split(/\r?\n|\\n/) : []
+      const translateResult = buildNewPageChanges(a.title, bodyLines)
 
       const response = await client.previewEditV2(project, { changes: translateResult.changes })
       const status = response.pagePreview?.persistent === false ? "create" : "update"
@@ -140,33 +255,360 @@ export const pageEditPreviewCommand = defineCommand({
         writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
         return
       }
-
-      const newLines: string[] = [
-        `previewId: ${result.previewId}`,
-        `expireAt:  ${result.expireAt}`,
-        `status:    ${result.status}`,
-        `title:     ${result.title}`,
-      ]
-      if (result.lines.length > 0) {
-        newLines.push("")
-        newLines.push("page (after apply):")
-        for (const line of result.lines) {
-          const marker = line.marker === "new" ? "> " : line.marker === "updated" ? "* " : "  "
-          newLines.push(`${marker}${line.text}`)
-        }
-      }
-      process.stdout.write(`${newLines.join("\n")}\n`)
+      outputPlainResult(result)
       return
     }
 
-    // 既存ページ編集モード
-    // ops JSON をパースする
+    // ======= --op=append =======
+    if (opKind === "append") {
+      const lines = readWriteInput(
+        {
+          ...(a.text !== undefined && { text: a.text }),
+          ...(a["from-file"] !== undefined && { "from-file": a["from-file"] }),
+          ...(a["allow-unsafe-read"] !== undefined && {
+            "allow-unsafe-read": a["allow-unsafe-read"],
+          }),
+        },
+        {
+          requireContentErrorCode: "CONTENT_REQUIRED",
+          requireContentMessage: "追加するテキストが指定されていません",
+          requireContentHint: "--text または --from-file でコンテンツを指定してください",
+        },
+      )
+      if (a["strict-notation"])
+        runNotationLint(lines, { "strict-notation": a["strict-notation"] ?? false })
+
+      const page = await client.getPage(project, a.title)
+      const translateResult = buildAppendChanges(lines)
+      const response = await client.previewEditV2(project, {
+        pageId: page.id,
+        changes: translateResult.changes,
+      })
+      const status = response.pagePreview?.persistent === false ? "create" : "update"
+      const result = buildPreviewResult(
+        response.previewId,
+        response.expireAt,
+        status,
+        a.title,
+        response.pagePreview,
+        [translateResult.newLineIds, translateResult.updatedLineIds],
+      )
+
+      if (a.json) {
+        writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
+        return
+      }
+      outputPlainResult(result)
+      return
+    }
+
+    // ======= --op=prepend =======
+    if (opKind === "prepend") {
+      const lines = readWriteInput(
+        {
+          ...(a.text !== undefined && { text: a.text }),
+          ...(a["from-file"] !== undefined && { "from-file": a["from-file"] }),
+          ...(a["allow-unsafe-read"] !== undefined && {
+            "allow-unsafe-read": a["allow-unsafe-read"],
+          }),
+        },
+        {
+          requireContentErrorCode: "CONTENT_REQUIRED",
+          requireContentMessage: "挿入するテキストが指定されていません",
+          requireContentHint: "--text または --from-file でコンテンツを指定してください",
+        },
+      )
+      if (a["strict-notation"])
+        runNotationLint(lines, { "strict-notation": a["strict-notation"] ?? false })
+
+      const page = await client.getPage(project, a.title)
+      // タイトル直後の行 ID をアンカーとする。タイトル行のみなら "_end"
+      const anchorLineId = page.lines[1]?.id ?? "_end"
+      const translateResult = buildPrependChanges(anchorLineId, lines)
+      const response = await client.previewEditV2(project, {
+        pageId: page.id,
+        changes: translateResult.changes,
+      })
+      const status = response.pagePreview?.persistent === false ? "create" : "update"
+      const result = buildPreviewResult(
+        response.previewId,
+        response.expireAt,
+        status,
+        a.title,
+        response.pagePreview,
+        [translateResult.newLineIds, translateResult.updatedLineIds],
+      )
+
+      if (a.json) {
+        writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
+        return
+      }
+      outputPlainResult(result)
+      return
+    }
+
+    // ======= --op=insert =======
+    if (opKind === "insert") {
+      const lines = readWriteInput(
+        {
+          ...(a.text !== undefined && { text: a.text }),
+          ...(a["from-file"] !== undefined && { "from-file": a["from-file"] }),
+          ...(a["allow-unsafe-read"] !== undefined && {
+            "allow-unsafe-read": a["allow-unsafe-read"],
+          }),
+        },
+        {
+          requireContentErrorCode: "CONTENT_REQUIRED",
+          requireContentMessage: "挿入するテキストが指定されていません",
+          requireContentHint: "--text または --from-file でコンテンツを指定してください",
+        },
+      )
+      if (a["strict-notation"])
+        runNotationLint(lines, { "strict-notation": a["strict-notation"] ?? false })
+
+      const afterId = a["after-id"]
+      let afterN: number | undefined
+
+      if (!afterId) {
+        if (a.after === undefined) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            "--after または --after-id のどちらかを指定してください",
+            "--after <n>: 1-indexed の行番号  /  --after-id <lineId>: 行 ID を直接指定",
+          )
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        const rawAfter = a.after !== "" ? a.after : (getRawFlagValue(process.argv, "after") ?? "")
+        if (!/^[1-9]\d*$/.test(rawAfter)) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `--after の値が無効です: "${rawAfter}"`,
+            "1 以上の整数を指定してください (タイトル行=1)",
+          )
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        afterN = Number.parseInt(rawAfter, 10)
+      }
+
+      const page = await client.getPage(project, a.title)
+
+      let anchorLineId: string
+      if (afterId) {
+        anchorLineId = afterId
+      } else {
+        if ((afterN as number) > page.lines.length) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `--after の値が範囲外です: ${afterN} (ページの行数: ${page.lines.length})`,
+          )
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        anchorLineId = page.lines[afterN as number]?.id ?? "_end"
+      }
+
+      const translateResult = buildInsertChanges(anchorLineId, lines)
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, {
+          pageId: page.id,
+          changes: translateResult.changes,
+        })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
+      const status = response.pagePreview?.persistent === false ? "create" : "update"
+      const result = buildPreviewResult(
+        response.previewId,
+        response.expireAt,
+        status,
+        a.title,
+        response.pagePreview,
+        [translateResult.newLineIds, translateResult.updatedLineIds],
+      )
+
+      if (a.json) {
+        writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
+        return
+      }
+      outputPlainResult(result)
+      return
+    }
+
+    // ======= --op=line-replace =======
+    if (opKind === "line-replace") {
+      // --line-number 必須
+      if (!a["line-number"]) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          "--line-number が指定されていません",
+          "--line-number <n> で対象行番号 (1-indexed) を指定してください",
+        )
+        exitWithError(5, "VALIDATION_ERROR")
+      }
+
+      let lineN: number
+      try {
+        const spec = parseLineSpec({ line: a["line-number"] })
+        lineN = spec.start
+      } catch (err) {
+        if (err instanceof RangeSpecError) {
+          writeErrorJson("VALIDATION_ERROR", err.message)
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        throw err
+      }
+
+      // --text 必須 (置換後テキスト)
+      const text = a.text ?? ""
+      if (!text) {
+        writeErrorJson(
+          "CONTENT_REQUIRED",
+          "置換後のテキストが指定されていません",
+          "--text で置換内容を指定してください",
+        )
+        exitWithError(5, "CONTENT_REQUIRED")
+      }
+
+      const page = await client.getPage(project, a.title)
+      const targetLine = page.lines[lineN - 1]
+      if (!targetLine) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          `--line-number の値が範囲外です: ${lineN} (ページの行数: ${page.lines.length})`,
+        )
+        exitWithError(5, "VALIDATION_ERROR")
+      }
+
+      let translateResult: ReturnType<typeof buildReplaceChanges>
+      try {
+        translateResult = buildReplaceChanges(targetLine.id, text)
+      } catch (err) {
+        writeErrorJson(
+          "INVALID_OPS",
+          err instanceof Error ? err.message : String(err),
+          "改行を含む置換には --op=ops を使用してください",
+        )
+        exitWithError(5, "INVALID_OPS")
+      }
+
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, {
+          pageId: page.id,
+          changes: translateResult.changes,
+        })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
+      const status = response.pagePreview?.persistent === false ? "create" : "update"
+      const result = buildPreviewResult(
+        response.previewId,
+        response.expireAt,
+        status,
+        a.title,
+        response.pagePreview,
+        [translateResult.newLineIds, translateResult.updatedLineIds],
+      )
+
+      if (a.json) {
+        writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
+        return
+      }
+      outputPlainResult(result)
+      return
+    }
+
+    // ======= --op=line-delete =======
+    if (opKind === "line-delete") {
+      // --line-number または --range が必要
+      if (!a["line-number"] && !a.range) {
+        writeErrorJson(
+          "VALIDATION_ERROR",
+          "--line-number または --range のどちらかを指定してください",
+          "--line-number <n>: 単一行  /  --range a:b: 行範囲",
+        )
+        exitWithError(5, "VALIDATION_ERROR")
+      }
+
+      let start: number
+      let end: number
+      try {
+        const spec = parseLineSpec({
+          ...(a["line-number"] !== undefined && { line: a["line-number"] }),
+          ...(a.range !== undefined && { range: a.range }),
+        })
+        start = spec.start
+        end = spec.end
+      } catch (err) {
+        if (err instanceof RangeSpecError) {
+          writeErrorJson("VALIDATION_ERROR", err.message)
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        throw err
+      }
+
+      // タイトル行 (1行目) の削除を禁止する
+      if (start === 1) {
+        writeErrorJson(
+          "TITLE_LINE_PROTECTED",
+          "タイトル行 (1行目) は削除できません",
+          "ページを削除する場合は `cos page delete` を使用してください",
+        )
+        exitWithError(5, "TITLE_LINE_PROTECTED")
+      }
+
+      const page = await client.getPage(project, a.title)
+      const lineIds: string[] = []
+      for (let i = start; i <= end; i++) {
+        const line = page.lines[i - 1]
+        if (!line) {
+          writeErrorJson(
+            "VALIDATION_ERROR",
+            `行番号 ${i} が範囲外です (ページの行数: ${page.lines.length})`,
+          )
+          exitWithError(5, "VALIDATION_ERROR")
+        }
+        lineIds.push(line.id)
+      }
+
+      const translateResult = buildDeleteChanges(lineIds)
+      let response: Awaited<ReturnType<typeof client.previewEditV2>>
+      try {
+        response = await client.previewEditV2(project, {
+          pageId: page.id,
+          changes: translateResult.changes,
+        })
+      } catch (err) {
+        handlePreviewEditV2Error(err, a.title)
+        throw err
+      }
+      const status = response.pagePreview?.persistent === false ? "create" : "update"
+      const result = buildPreviewResult(
+        response.previewId,
+        response.expireAt,
+        status,
+        a.title,
+        response.pagePreview,
+        [translateResult.newLineIds, translateResult.updatedLineIds],
+      )
+
+      if (a.json) {
+        writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
+        return
+      }
+      outputPlainResult(result)
+      return
+    }
+
+    // ======= --op=ops または op 未指定 (既存の --ops 動作) =======
     const opsRaw = a.ops
     if (!opsRaw) {
       writeErrorJson(
         "OPS_REQUIRED",
         "ops が指定されていません",
-        "--ops フラグで ops JSON を指定してください",
+        "--ops フラグで ops JSON を指定するか、--op=append/prepend/... で操作種別を指定してください",
       )
       exitWithError(5, "OPS_REQUIRED")
     }
@@ -183,7 +625,6 @@ export const pageEditPreviewCommand = defineCommand({
       exitWithError(5, "INVALID_OPS_JSON")
     }
 
-    // null や配列など非オブジェクトは拒否する
     if (!parsedInput || typeof parsedInput !== "object" || Array.isArray(parsedInput)) {
       writeErrorJson(
         "INVALID_OPS_JSON",
@@ -205,7 +646,6 @@ export const pageEditPreviewCommand = defineCommand({
       exitWithError(5, "INVALID_OPS")
     }
 
-    // ページの pageId を取得する
     const page = await client.getPage(project, a.title)
     let response: Awaited<ReturnType<typeof client.previewEditV2>>
     try {
@@ -232,22 +672,6 @@ export const pageEditPreviewCommand = defineCommand({
       writeJson(result, { command: "page.edit.preview", startTime }, buildJsonOpts(a))
       return
     }
-
-    // プレーンテキスト出力
-    const lines: string[] = [
-      `previewId: ${result.previewId}`,
-      `expireAt:  ${result.expireAt}`,
-      `status:    ${result.status}`,
-      `title:     ${result.title}`,
-    ]
-    if (result.lines.length > 0) {
-      lines.push("")
-      lines.push("page (after apply):")
-      for (const line of result.lines) {
-        const marker = line.marker === "new" ? "> " : line.marker === "updated" ? "* " : "  "
-        lines.push(`${marker}${line.text}`)
-      }
-    }
-    process.stdout.write(`${lines.join("\n")}\n`)
+    outputPlainResult(result)
   },
 })

--- a/tests/unit/commands/page/edit/preview.op.test.ts
+++ b/tests/unit/commands/page/edit/preview.op.test.ts
@@ -1,0 +1,431 @@
+/**
+ * preview.op.test.ts — `cos page edit preview <title> --op=<op>` のテスト。
+ *
+ * PR 2 で追加した --op ディスパッチャの振る舞いを検証する。
+ * 各 op が対応する buildXxxChanges を呼ぶこと、および
+ * バリデーションエラーのケースを確認する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import * as sharedModule from "@/commands/_shared"
+import { pageEditPreviewCommand } from "@/commands/page/edit/preview"
+import type * as restModule from "@/core/api/rest"
+import * as editV2Module from "@/core/edit-v2"
+
+/** テスト用 PAT フォーマット */
+const TEST_PAT = `pat_${"a".repeat(64)}`
+
+/** previewEditV2 の成功レスポンスフィクスチャ */
+const PREVIEW_RESPONSE = {
+  previewId: "プレビューID-xyz",
+  expireAt: "2026-06-20T12:00:00.000Z",
+  pagePreview: {
+    title: "テストページ",
+    persistent: true,
+    lines: [
+      { id: "行001", text: "テストページ" },
+      { id: "行002", text: "既存の行" },
+    ],
+  },
+}
+
+/** getPage のレスポンスフィクスチャ (3 行構成) */
+const PAGE_RESPONSE = {
+  id: "ページID-001",
+  title: "テストページ",
+  lines: [
+    { id: "行001", text: "テストページ", userId: "u1", created: 0, updated: 0 },
+    { id: "行002", text: "2行目", userId: "u1", created: 0, updated: 0 },
+    { id: "行003", text: "3行目", userId: "u1", created: 0, updated: 0 },
+  ],
+}
+
+let exitMock: ReturnType<typeof spyOn>
+let stdoutMock: ReturnType<typeof spyOn>
+let stderrMock: ReturnType<typeof spyOn>
+let requirePatSpy: ReturnType<typeof spyOn> | undefined
+let buildRestClientSpy: ReturnType<typeof spyOn> | undefined
+
+async function runPreview(args: Record<string, unknown>) {
+  const defaults = {
+    json: false,
+    plain: false,
+    "results-only": false,
+    quiet: false,
+    "dry-run": false,
+    "strict-notation": false,
+    "allow-unsafe-read": false,
+    new: false,
+  }
+  await (
+    pageEditPreviewCommand.run as (ctx: {
+      args: unknown
+      cmd: never
+      rawArgs: string[]
+    }) => Promise<void>
+  )({
+    args: { ...defaults, ...args },
+    cmd: {} as never,
+    rawArgs: [],
+  })
+}
+
+function setupMocks(previewResult = PREVIEW_RESPONSE, getPageResult = PAGE_RESPONSE) {
+  requirePatSpy = spyOn(sharedModule, "requirePat").mockResolvedValue(TEST_PAT)
+  const mockClient = {
+    previewEditV2: async () => previewResult,
+    getPage: async () => getPageResult,
+  }
+  buildRestClientSpy = spyOn(sharedModule, "buildRestClient").mockResolvedValue(
+    mockClient as unknown as restModule.CosenseRestClient,
+  )
+}
+
+beforeEach(() => {
+  exitMock = spyOn(process, "exit").mockImplementation((() => {}) as () => never)
+  stdoutMock = spyOn(process.stdout, "write").mockImplementation(() => true)
+  stderrMock = spyOn(process.stderr, "write").mockImplementation(() => true)
+  Reflect.deleteProperty(process.env, "COS_PROJECT")
+  Reflect.deleteProperty(process.env, "COS_PERSONAL_ACCESS_TOKEN")
+})
+
+afterEach(() => {
+  exitMock.mockRestore()
+  stdoutMock.mockRestore()
+  stderrMock.mockRestore()
+  requirePatSpy?.mockRestore()
+  buildRestClientSpy?.mockRestore()
+  requirePatSpy = undefined
+  buildRestClientSpy = undefined
+})
+
+describe("pageEditPreviewCommand --op ディスパッチャ", () => {
+  describe("--op=append", () => {
+    it("buildAppendChanges を呼んで previewId を出力する", async () => {
+      setupMocks()
+      const appendSpy = spyOn(editV2Module, "buildAppendChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "append",
+          text: "追加する行テキスト",
+        })
+      } catch {}
+
+      expect(appendSpy).toHaveBeenCalledTimes(1)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("プレビューID-xyz")
+      appendSpy.mockRestore()
+    })
+
+    it("--text が未指定の場合は CONTENT_REQUIRED で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "append",
+          text: undefined,
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("CONTENT_REQUIRED")
+    })
+  })
+
+  describe("--op=prepend", () => {
+    it("buildPrependChanges をタイトル直後のアンカーで呼ぶ", async () => {
+      setupMocks()
+      const prependSpy = spyOn(editV2Module, "buildPrependChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "prepend",
+          text: "先頭に挿入する行",
+        })
+      } catch {}
+
+      expect(prependSpy).toHaveBeenCalledTimes(1)
+      // anchorLineId は PAGE_RESPONSE.lines[1].id = "行002" (タイトル直後)
+      expect(prependSpy).toHaveBeenCalledWith("行002", expect.any(Array))
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("プレビューID-xyz")
+      prependSpy.mockRestore()
+    })
+
+    it("--text が未指定の場合は CONTENT_REQUIRED で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "prepend",
+          text: undefined,
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("--op=insert", () => {
+    it("--after <n> で行番号指定したとき buildInsertChanges を呼ぶ", async () => {
+      setupMocks()
+      const insertSpy = spyOn(editV2Module, "buildInsertChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "insert",
+          text: "挿入する行",
+          after: "2", // 2行目の後ろ → anchorLineId は lines[2].id = "行003"
+        })
+      } catch {}
+
+      expect(insertSpy).toHaveBeenCalledTimes(1)
+      // after=2 の場合、次行は lines[2] = "行003"
+      expect(insertSpy).toHaveBeenCalledWith("行003", expect.any(Array))
+      insertSpy.mockRestore()
+    })
+
+    it("--after も --after-id も未指定の場合は VALIDATION_ERROR で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "insert",
+          text: "挿入する行",
+          // after / after-id を指定しない
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("VALIDATION_ERROR")
+    })
+
+    it("--text が未指定の場合は CONTENT_REQUIRED で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "insert",
+          text: undefined,
+          after: "1",
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("--op=line-replace", () => {
+    it("buildReplaceChanges を --line-number と --text で呼ぶ", async () => {
+      setupMocks()
+      const replaceSpy = spyOn(editV2Module, "buildReplaceChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-replace",
+          "line-number": "2", // 2行目 → lines[1].id = "行002"
+          text: "新しいテキスト",
+        })
+      } catch {}
+
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+      expect(replaceSpy).toHaveBeenCalledWith("行002", "新しいテキスト")
+      replaceSpy.mockRestore()
+    })
+
+    it("--line-number が未指定の場合は VALIDATION_ERROR で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-replace",
+          text: "新しいテキスト",
+          // line-number を指定しない
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("VALIDATION_ERROR")
+    })
+
+    it("--text が未指定の場合は CONTENT_REQUIRED で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-replace",
+          "line-number": "2",
+          text: undefined,
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("--op=line-delete", () => {
+    it("buildDeleteChanges を --line-number で呼ぶ", async () => {
+      setupMocks()
+      const deleteSpy = spyOn(editV2Module, "buildDeleteChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-delete",
+          "line-number": "2", // 2行目 → lines[1].id = "行002"
+        })
+      } catch {}
+
+      expect(deleteSpy).toHaveBeenCalledTimes(1)
+      expect(deleteSpy).toHaveBeenCalledWith(["行002"])
+      deleteSpy.mockRestore()
+    })
+
+    it("buildDeleteChanges を --range で呼ぶ", async () => {
+      setupMocks()
+      const deleteSpy = spyOn(editV2Module, "buildDeleteChanges")
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-delete",
+          range: "2:3", // 2〜3行目 → "行002","行003"
+        })
+      } catch {}
+
+      expect(deleteSpy).toHaveBeenCalledTimes(1)
+      expect(deleteSpy).toHaveBeenCalledWith(["行002", "行003"])
+      deleteSpy.mockRestore()
+    })
+
+    it("--line-number も --range も未指定の場合は VALIDATION_ERROR で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "line-delete",
+          // line-number も range も未指定
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+    })
+  })
+
+  describe("--op=new-page", () => {
+    it("buildNewPageChanges をタイトルと --text で呼ぶ", async () => {
+      setupMocks()
+      const newPageSpy = spyOn(editV2Module, "buildNewPageChanges")
+
+      try {
+        await runPreview({
+          title: "新しいページ",
+          project: "テストプロジェクト",
+          op: "new-page",
+          text: "1行目の本文\n2行目の本文",
+        })
+      } catch {}
+
+      expect(newPageSpy).toHaveBeenCalledTimes(1)
+      expect(newPageSpy).toHaveBeenCalledWith("新しいページ", ["1行目の本文", "2行目の本文"])
+      newPageSpy.mockRestore()
+    })
+
+    it("既存の --new --body フラグも new-page と同じ動作をする (後方互換)", async () => {
+      setupMocks()
+      const newPageSpy = spyOn(editV2Module, "buildNewPageChanges")
+
+      try {
+        await runPreview({
+          title: "新しいページ",
+          project: "テストプロジェクト",
+          new: true,
+          body: "本文行",
+        })
+      } catch {}
+
+      expect(newPageSpy).toHaveBeenCalledTimes(1)
+      newPageSpy.mockRestore()
+    })
+  })
+
+  describe("--op=ops", () => {
+    it("--ops JSON を使った既存の編集動作と同じ結果になる", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "ops",
+          ops: JSON.stringify({ ops: [{ insertBefore: "_end", text: "末尾追加" }] }),
+        })
+      } catch {}
+
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("プレビューID-xyz")
+    })
+
+    it("--op 未指定で --ops を使う既存動作も引き続き動作する (後方互換)", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          ops: JSON.stringify({ ops: [{ insertBefore: "_end", text: "末尾追加" }] }),
+        })
+      } catch {}
+
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("プレビューID-xyz")
+    })
+  })
+
+  describe("--op バリデーション", () => {
+    it("未知の --op 値は VALIDATION_ERROR で exit 5", async () => {
+      setupMocks()
+
+      try {
+        await runPreview({
+          title: "テストページ",
+          project: "テストプロジェクト",
+          op: "unknown-op",
+          text: "テキスト",
+        })
+      } catch {}
+
+      expect(exitMock).toHaveBeenCalledWith(5)
+      const output = (stdoutMock.mock.calls as unknown[][]).map((c) => String(c[0])).join("")
+      expect(output).toContain("VALIDATION_ERROR")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

コマンド体系再編 7 本 PR 構成の **PR 2 — 書き込み統合エントリの実装**。

`cos page edit preview` を書き込み系のメインエントリとして拡張し、`--op` で操作種別を切り替えられるようにします。

### 変更内容

- **`src/commands/page/edit/preview.ts`** — `--op` ディスパッチャを追加:
  - `ops`: 既存の `--ops` JSON 動作 (後方互換、デフォルト)
  - `append`: 末尾追加 (`--text` 必須)
  - `prepend`: タイトル直後に挿入 (`--text` 必須)
  - `insert`: 指定行の後ろに挿入 (`--text` 必須 + `--after` / `--after-id`)
  - `line-replace`: 行テキスト置換 (`--line-number` 必須 + `--text` 必須)
  - `line-delete`: 行削除 (`--line-number` または `--range`)
  - `new-page`: 新規ページ作成 (`--text` でページ本文)

- **語彙の分離 (codex 指摘 #4 反映)**: 正規コマンドでは `--text` (本文・改行 OK) と `--line-number` (行番号) を独立フラグとして提供。旧 verb では `--line` が「内容」と「行番号」の二重の意味を持っていたが、統合後の正規コマンドでは意味の衝突を排除。旧 wrapper (PR 4 で作成) が `--line` を `--text` / `--line-number` に変換。

- **後方互換の維持**:
  - `--new --body` → `--op=new-page` と同義
  - `--ops` → `--op=ops` (省略時) と同義

### 既存コマンドへの影響

`page append preview` / `page prepend preview` / `page insert preview` / `page new preview` / `page line replace preview` / `page line delete preview` は一切変更なし。PR 4 で deprecated ラッパー化予定。

## Test plan

- [x] `bun test` — 1709 pass / 0 fail (新規テスト 18 件追加)
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — Lint 警告なし
- [x] 新規テスト `tests/unit/commands/page/edit/preview.op.test.ts` (18 テスト)
  - 各 `--op` が対応する `buildXxxChanges` を spy 経由で呼ぶことを検証
  - バリデーションエラー (`--text` 未指定、`--line-number` 未指定等) を検証
  - 後方互換 (`--new --body`, `--ops`) を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended `page edit preview` command to support multiple operation types (append, prepend, insert, line-replace, line-delete, new-page) via `--op` option with dry-run capability.
  * Added new options: `--text`, `--from-file`, `--line-number`, `--range`, and related parameters for flexible content input and targeting.

* **Tests**
  * Added comprehensive unit tests for `--op` dispatcher behavior and operation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->