### PR TITLE
feat(sandbox): 旧書き込み verb を deprecated 化し sandbox alias の方向別解決を追加する (PR 4/7)

### DIFF
--- a/src/commands/page/append/preview.ts
+++ b/src/commands/page/append/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/append/preview.ts — `cos page append preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=append` を使用してください。
+ *
  * v2 AI ops API を使ってページ末尾に行を追加する preview を実行し previewId を取得する。
  * 確定は `cos page edit submit <previewId>` で行う。
  *
@@ -8,6 +10,7 @@
  * previewId は 5 分で expire するため、submitEdit を速やかに実行すること。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -61,6 +64,9 @@ export const pageAppendPreviewCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
+    const warnings: string[] = []
+    warnDeprecated("page append preview", "page edit preview --op=append", warnings)
+
     // PAT 必須チェック（SID・SA は HTTP 403 で弾かれるため事前ガード）
     await requirePat(a)
 
@@ -98,7 +104,17 @@ export const pageAppendPreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.append.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.append.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: { since: DEPRECATION_SINCE, replacement: "page edit preview --op=append" },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/commands/page/insert/preview.ts
+++ b/src/commands/page/insert/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/insert/preview.ts — `cos page insert preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=insert` を使用してください。
+ *
  * v2 AI ops API を使って指定行の後ろに行を挿入する preview を実行し previewId を取得する。
  * --after <n> (1-indexed) でページの行番号を指定するか、--after-id <lineId> で直接 lineId を指定する。
  * 最終行の後ろへの挿入は "_end" アンカーを使う。
@@ -9,6 +11,7 @@
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -73,6 +76,9 @@ export const pageInsertPreviewCommand = defineCommand({
     checkSandbox("page.insert.preview", a)
     const project = requireProject(a)
     const startTime = Date.now()
+
+    const warnings: string[] = []
+    warnDeprecated("page insert preview", "page edit preview --op=insert", warnings)
 
     await requirePat(a)
 
@@ -156,7 +162,17 @@ export const pageInsertPreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.insert.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.insert.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: { since: DEPRECATION_SINCE, replacement: "page edit preview --op=insert" },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/commands/page/line/delete/preview.ts
+++ b/src/commands/page/line/delete/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/line/delete/preview.ts — `cos page line delete preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=line-delete` を使用してください。
+ *
  * v2 AI ops API を使って指定行 (--line n) または行範囲 (--range a:b) を削除する
  * preview を実行し previewId を取得する。
  * 確定は `cos page edit submit <previewId>` で行う。
@@ -8,6 +10,7 @@
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -54,6 +57,9 @@ export const pageLineDeletePreviewCommand = defineCommand({
     checkSandbox("page.line.delete.preview", a)
     const project = requireProject(a)
     const startTime = Date.now()
+
+    const warnings: string[] = []
+    warnDeprecated("page line delete preview", "page edit preview --op=line-delete", warnings)
 
     await requirePat(a)
 
@@ -126,7 +132,20 @@ export const pageLineDeletePreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.line.delete.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.line.delete.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: {
+            since: DEPRECATION_SINCE,
+            replacement: "page edit preview --op=line-delete",
+          },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/commands/page/line/replace/preview.ts
+++ b/src/commands/page/line/replace/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/line/replace/preview.ts — `cos page line replace preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=line-replace` を使用してください。
+ *
  * v2 AI ops API を使って指定行 (--line n) のテキストを置換する preview を実行し previewId を取得する。
  * --text に改行が含まれる場合は INVALID_OPS (exit 5) で終了する（API 制約）。
  * 確定は `cos page edit submit <previewId>` で行う。
@@ -8,6 +10,7 @@
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -54,6 +57,9 @@ export const pageLineReplacePreviewCommand = defineCommand({
     checkSandbox("page.line.replace.preview", a)
     const project = requireProject(a)
     const startTime = Date.now()
+
+    const warnings: string[] = []
+    warnDeprecated("page line replace preview", "page edit preview --op=line-replace", warnings)
 
     await requirePat(a)
 
@@ -130,7 +136,20 @@ export const pageLineReplacePreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.line.replace.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.line.replace.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: {
+            since: DEPRECATION_SINCE,
+            replacement: "page edit preview --op=line-replace",
+          },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/commands/page/new/preview.ts
+++ b/src/commands/page/new/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/new/preview.ts — `cos page new preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=new-page` を使用してください。
+ *
  * v2 AI ops API を使って新しいページを作成する preview を実行し previewId を取得する。
  * タイトルと本文を `insertBefore: "_end"` ops に変換して pageId なしで送信する。
  * 確定は `cos page edit submit <previewId>` で行う。
@@ -8,6 +10,7 @@
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -61,6 +64,9 @@ export const pageNewPreviewCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
+    const warnings: string[] = []
+    warnDeprecated("page new preview", "page edit preview --op=new-page", warnings)
+
     await requirePat(a)
 
     const bodyLines = readWriteInput(a, {
@@ -87,7 +93,17 @@ export const pageNewPreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.new.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.new.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: { since: DEPRECATION_SINCE, replacement: "page edit preview --op=new-page" },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/commands/page/prepend/preview.ts
+++ b/src/commands/page/prepend/preview.ts
@@ -1,6 +1,8 @@
 /**
  * page/prepend/preview.ts — `cos page prepend preview <title>` コマンド。
  *
+ * @deprecated `cos page edit preview --op=prepend` を使用してください。
+ *
  * v2 AI ops API を使ってページのタイトル直後に行を挿入する preview を実行し previewId を取得する。
  * タイトル行のみのページでは "_end" をアンカーとして使う。
  * 確定は `cos page edit submit <previewId>` で行う。
@@ -8,6 +10,7 @@
  * 認証: PAT 必須（SID・SA では HTTP 403）。
  */
 
+import { DEPRECATION_SINCE, warnDeprecated } from "@/commands/_deprecation"
 import {
   type CommonArgs,
   buildJsonOpts,
@@ -62,6 +65,9 @@ export const pagePrependPreviewCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
+    const warnings: string[] = []
+    warnDeprecated("page prepend preview", "page edit preview --op=prepend", warnings)
+
     await requirePat(a)
 
     const lines = readWriteInput(a, {
@@ -100,7 +106,17 @@ export const pagePrependPreviewCommand = defineCommand({
     )
 
     if (a.json) {
-      writeJson(result, { command: "page.prepend.preview", startTime }, buildJsonOpts(a))
+      writeJson(
+        result,
+        {
+          command: "page.prepend.preview",
+          startTime,
+          warnings,
+          canonicalCommand: "page.edit.preview",
+          deprecated: { since: DEPRECATION_SINCE, replacement: "page edit preview --op=prepend" },
+        },
+        buildJsonOpts(a),
+      )
       return
     }
 

--- a/src/core/sandbox.ts
+++ b/src/core/sandbox.ts
@@ -8,7 +8,13 @@
  *   1. enable リストが指定された場合、そのリストのみ許可 (ワイルドカード "page" で "page.*" 全体)
  *   2. disable リストが指定された場合、そのエントリを拒否
  *   3. 両方指定時: enable で絞ってから disable で削る
+ *
+ * alias 解決 (PR 4 で追加):
+ *   - enable は双方向: 旧 alias ↔ 新識別子 (例: "page.append.preview" ↔ "page.edit.preview")
+ *   - disable は旧→新の単方向のみ: 旧 alias が disable にあれば新識別子も阻止するが逆は不可
  */
+
+import { WRITE_DEPRECATED_ALIASES, WRITE_DEPRECATED_ALIASES_REVERSE } from "@/core/sandbox/aliases"
 
 /** PolicyError は sandbox ポリシー違反を表すエラー。 */
 export class PolicyError extends Error {
@@ -49,12 +55,12 @@ export function createPolicy(opts: PolicyOptions): Policy {
 
   return {
     allow(command: string): PolicyError | undefined {
-      // enable リストが空でなければ、許可リストでフィルタ
-      if (enable.length > 0 && !isAllowed(command, enable)) {
+      // enable リストが空でなければ、許可リストでフィルタ (双方向 alias 解決)
+      if (enable.length > 0 && !isAllowedBidirectional(command, enable)) {
         return new PolicyError(command)
       }
-      // disable リストに含まれていれば拒否
-      if (disable.length > 0 && isAllowed(command, disable)) {
+      // disable リストに含まれていれば拒否 (旧→新 単方向 alias 解決)
+      if (disable.length > 0 && isAllowedWithOldToNewAlias(command, disable)) {
         return new PolicyError(command)
       }
       return undefined
@@ -92,6 +98,7 @@ function mergeList(list: string[] | undefined, str: string | undefined): string[
  * - `page.list`: 完全一致のみマッチ
  *
  * 比較前に両辺を normalizeCommand で正規化するため、大文字小文字・Unicode 空白文字を区別しない。
+ * alias 解決は含まない。alias 解決が必要な場合は isAllowedBidirectional / isAllowedWithOldToNewAlias を使う。
  */
 function isAllowed(command: string, patterns: string[]): boolean {
   const normalizedCmd = normalizeCommand(command)
@@ -111,4 +118,48 @@ function isAllowed(command: string, patterns: string[]): boolean {
       return true
     return false
   })
+}
+
+/**
+ * isAllowedBidirectional は双方向 alias を解決してコマンドがパターンにマッチするか判定する。
+ *
+ * enable チェックで使用する。旧 alias ↔ 新識別子の両方向を解決する。
+ * 例: command = "page.edit.preview", patterns = ["page.append.preview"] → true
+ *     command = "page.append.preview", patterns = ["page.edit.preview"] → true
+ */
+function isAllowedBidirectional(command: string, patterns: string[]): boolean {
+  if (isAllowed(command, patterns)) return true
+  // command が新識別子の場合: 旧 alias がパターンにあればマッチ
+  const oldAliases = WRITE_DEPRECATED_ALIASES_REVERSE[command]
+  if (oldAliases) {
+    for (const oldAlias of oldAliases) {
+      if (isAllowed(oldAlias, patterns)) return true
+    }
+  }
+  // command が旧 alias の場合: 新識別子がパターンにあればマッチ
+  const newCanonical = WRITE_DEPRECATED_ALIASES[command]
+  if (newCanonical && isAllowed(newCanonical, patterns)) return true
+  return false
+}
+
+/**
+ * isAllowedWithOldToNewAlias は旧→新の単方向 alias を解決してコマンドがパターンにマッチするか判定する。
+ *
+ * disable チェックで使用する。旧 alias がパターンにある場合のみ新識別子もマッチする。
+ * 逆方向 (新識別子がパターンにある場合に旧 alias もマッチ) は適用しない。
+ *
+ * 例: command = "page.edit.preview", patterns = ["page.append.preview"] → true (旧→新)
+ *     command = "page.append.preview", patterns = ["page.edit.preview"] → false (逆方向は不可)
+ */
+function isAllowedWithOldToNewAlias(command: string, patterns: string[]): boolean {
+  if (isAllowed(command, patterns)) return true
+  // command が新識別子の場合: 旧 alias がパターンにあればマッチ (旧→新 方向)
+  const oldAliases = WRITE_DEPRECATED_ALIASES_REVERSE[command]
+  if (oldAliases) {
+    for (const oldAlias of oldAliases) {
+      if (isAllowed(oldAlias, patterns)) return true
+    }
+  }
+  // NOTE: command が旧 alias の場合は新識別子へ展開しない (逆方向は適用しない)
+  return false
 }

--- a/src/core/sandbox/aliases.ts
+++ b/src/core/sandbox/aliases.ts
@@ -1,0 +1,40 @@
+/**
+ * sandbox/aliases.ts — sandbox 識別子の旧→新エイリアスマップ。
+ *
+ * deprecated 書き込み verb の旧識別子と新識別子 (`page.edit.preview`) の対応を定義する。
+ * sandbox の enable/disable チェックで方向別 alias 解決に使用する。
+ *
+ * enable: 双方向 (旧 alias ↔ 新識別子)
+ * disable: 旧→新の単方向のみ (旧 alias → 新識別子。逆方向は適用しない)
+ */
+
+/**
+ * WRITE_DEPRECATED_ALIASES は旧書き込み verb の sandbox 識別子 → 新識別子マップ。
+ *
+ * キー: deprecated alias (旧識別子)
+ * 値: 対応する新正規識別子
+ */
+export const WRITE_DEPRECATED_ALIASES: Readonly<Record<string, string>> = {
+  "page.append.preview": "page.edit.preview",
+  "page.prepend.preview": "page.edit.preview",
+  "page.insert.preview": "page.edit.preview",
+  "page.new.preview": "page.edit.preview",
+  "page.line.replace.preview": "page.edit.preview",
+  "page.line.delete.preview": "page.edit.preview",
+}
+
+/**
+ * WRITE_DEPRECATED_ALIASES_REVERSE は新識別子 → 旧識別子セットの逆引きマップ。
+ *
+ * enable の双方向解決で使用する。
+ */
+export const WRITE_DEPRECATED_ALIASES_REVERSE: Readonly<Record<string, readonly string[]>> = {
+  "page.edit.preview": [
+    "page.append.preview",
+    "page.prepend.preview",
+    "page.insert.preview",
+    "page.new.preview",
+    "page.line.replace.preview",
+    "page.line.delete.preview",
+  ],
+}

--- a/tests/unit/core/sandbox/aliases.test.ts
+++ b/tests/unit/core/sandbox/aliases.test.ts
@@ -1,0 +1,95 @@
+/**
+ * sandbox/aliases.test.ts — sandbox 識別子の方向別 alias 解決テスト。
+ *
+ * PR 4 で追加した旧→新の alias 解決ルールを検証する。
+ *
+ * enable は双方向:
+ *   - enableCommands: ["page.append.preview"] → page.edit.preview も enable
+ *   - enableCommands: ["page.edit.preview"]  → page.append.preview も enable
+ *
+ * disable は旧→新の単方向のみ:
+ *   - disableCommands: ["page.append.preview"] → page.edit.preview も disable
+ *   - disableCommands: ["page.edit.preview"]   → page.append.preview は disable しない
+ *     (逆方向伝播なし: disableCommands: ["page.get"] が page.text を止めないのと同じ)
+ */
+
+import { describe, expect, it } from "bun:test"
+import { PolicyError, createPolicy } from "@/core/sandbox"
+
+describe("sandbox alias — enable は双方向", () => {
+  it("旧識別子 page.append.preview を enable すると page.edit.preview も許可される", () => {
+    const policy = createPolicy({ enable: ["page.append.preview"] })
+    // 新識別子も enable に含まれているとみなされる
+    expect(policy.allow("page.edit.preview")).toBeUndefined()
+  })
+
+  it("新識別子 page.edit.preview を enable すると旧識別子 page.append.preview も許可される", () => {
+    const policy = createPolicy({ enable: ["page.edit.preview"] })
+    expect(policy.allow("page.append.preview")).toBeUndefined()
+  })
+
+  it("新識別子 page.edit.preview を enable すると page.prepend.preview, page.insert.preview なども許可される", () => {
+    const policy = createPolicy({ enable: ["page.edit.preview"] })
+    expect(policy.allow("page.prepend.preview")).toBeUndefined()
+    expect(policy.allow("page.insert.preview")).toBeUndefined()
+    expect(policy.allow("page.new.preview")).toBeUndefined()
+    expect(policy.allow("page.line.replace.preview")).toBeUndefined()
+    expect(policy.allow("page.line.delete.preview")).toBeUndefined()
+  })
+
+  it("alias と無関係なコマンドは enable されない", () => {
+    const policy = createPolicy({ enable: ["page.append.preview"] })
+    // page.delete は alias ではないので enable されない
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+  })
+})
+
+describe("sandbox alias — disable は旧→新の単方向のみ", () => {
+  it("旧識別子 page.append.preview を disable すると page.edit.preview も阻止される", () => {
+    const policy = createPolicy({ disable: ["page.append.preview"] })
+    // 旧→新方向: 旧 alias が disable に含まれれば新コマンドも阻止
+    expect(policy.allow("page.edit.preview")).toBeInstanceOf(PolicyError)
+  })
+
+  it("新識別子 page.edit.preview を disable しても page.append.preview は阻止されない", () => {
+    const policy = createPolicy({ disable: ["page.edit.preview"] })
+    // 逆方向は適用しない (新→旧は伝播しない)
+    expect(policy.allow("page.append.preview")).toBeUndefined()
+    expect(policy.allow("page.prepend.preview")).toBeUndefined()
+    expect(policy.allow("page.insert.preview")).toBeUndefined()
+  })
+
+  it("page.line.replace.preview を disable すると page.edit.preview も阻止される", () => {
+    const policy = createPolicy({ disable: ["page.line.replace.preview"] })
+    expect(policy.allow("page.edit.preview")).toBeInstanceOf(PolicyError)
+  })
+
+  it("alias と無関係なコマンドへの disable は影響しない", () => {
+    const policy = createPolicy({ disable: ["page.append.preview"] })
+    // page.delete など関係ないコマンドは通す
+    expect(policy.allow("page.delete")).toBeUndefined()
+    expect(policy.allow("page.list")).toBeUndefined()
+  })
+})
+
+describe("sandbox alias — 既存動作の温存", () => {
+  it("page.* glob は引き続き page 配下全体にマッチする", () => {
+    const policy = createPolicy({ enable: ["page.*"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.edit.preview")).toBeUndefined()
+    expect(policy.allow("page.append.preview")).toBeUndefined()
+  })
+
+  it("noun ワイルドカード page は引き続き page.* 全体にマッチする (後方互換)", () => {
+    const policy = createPolicy({ enable: ["page"] })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.edit.preview")).toBeUndefined()
+  })
+
+  it("page.delete の disable は alias に関係なくそのまま機能する", () => {
+    const policy = createPolicy({ disable: ["page.delete"] })
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+    expect(policy.allow("page.list")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

コマンド体系再編 7 本 PR 構成の **PR 4 — 書き込み verb の非推奨化と sandbox 後方互換**。

### 変更内容

#### sandbox alias 解決 (`src/core/sandbox/aliases.ts` 新規 + `src/core/sandbox.ts` 拡張)

- 旧→新マップ `WRITE_DEPRECATED_ALIASES` を定義 (6 件: `page.append.preview` → `page.edit.preview` 等)
- `createPolicy` の enable/disable チェックを alias 対応の関数に差し替え:
  - **enable は双方向** (`isAllowedBidirectional`): 旧 alias ↔ 新識別子を相互に解決。既存の `enableCommands: ["page.append.preview"]` 設定が新コマンドでも動き続ける
  - **disable は旧→新の単方向のみ** (`isAllowedWithOldToNewAlias`): 旧 alias が disable にあれば新コマンドも阻止するが、逆方向は適用しない (codex 指摘 #2 対応)

#### 書き込み verb 6 つを deprecated ラッパー化

`page append/prepend/insert/new (preview)` と `page line replace/delete (preview)`:
- 実行時に `warnDeprecated()` を呼んで stderr に `[deprecated]` 警告を出力
- `--json` 出力に `meta.canonicalCommand: "page.edit.preview"` と `meta.deprecated` を追加
- `meta.command` は旧識別子 (`page.append.preview` 等) を維持して後方互換を保つ

### 既存テストへの影響

append/prepend/insert/new/line replace/line delete の既存テスト全件 pass のまま (meta.command が変わらないため)。

## Test plan

- [x] `bun test` — 1738 pass / 0 fail (sandbox alias 新規 11 テスト追加)
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — Lint 警告なし
- [x] 新規テスト `tests/unit/core/sandbox/aliases.test.ts` (11 テスト)
  - enable 双方向 / disable 単方向の両方を検証
  - 既存の glob/noun ワイルドカード挙動が温存されることを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)