### PR TITLE
feat(gog): --wrap-untrusted / --enable-commands-exact / トップレベル alias を追加する (PR 6/7)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -94,6 +94,20 @@ export const commonArgs = {
     description: "成功時の人間向けメッセージを抑制",
     default: false,
   },
+  "wrap-untrusted": {
+    type: "boolean" as const,
+    description:
+      "外部取得テキスト (ページ本文等) を <external_content> タグで囲む。" +
+      "AI エージェントのプロンプトインジェクション対策に使用する。",
+    default: false,
+  },
+  "enable-commands-exact": {
+    type: "boolean" as const,
+    description:
+      "--enable-commands の glob/noun ワイルドカードを無効化し完全一致のみにする。" +
+      'AI エージェントが最小権限で許可コマンドを明示的に列挙する場合に使用する。例: "page.get,page.list"',
+    default: false,
+  },
 } as const
 
 /** dryRunArg は書き込み系コマンドが追加スプレッドする --dry-run フラグ定義。 */
@@ -145,6 +159,8 @@ export type CommonArgs = {
   "disable-commands"?: string
   verbose?: string
   quiet: boolean
+  "wrap-untrusted"?: boolean
+  "enable-commands-exact"?: boolean
 }
 
 /** DryRunArg は書き込み系コマンドが追加で受け取る --dry-run フラグの型。 */
@@ -213,6 +229,7 @@ export function checkSandbox(commandName: string, args: CommonArgs): void {
   const policyOpts: Parameters<typeof createPolicy>[0] = {}
   if (resolved.enableStr !== undefined) policyOpts.enableStr = resolved.enableStr
   if (resolved.disableStr !== undefined) policyOpts.disableStr = resolved.disableStr
+  if (args["enable-commands-exact"] === true) policyOpts.exact = true
   const policy = createPolicy(policyOpts)
   const denied = policy.allow(commandName)
   if (denied instanceof PolicyError) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -243,4 +243,9 @@ export const rootSubCommands = {
   "exit-codes": exitCodesCommand,
   schema: schemaCommand,
   notation: notationGuideCommand,
+  // gog 着想のトップレベル alias (頻出操作の発見性向上)
+  // meta.command は委譲先のもの (page.get 等) を返すため sandbox 識別子は変化しない
+  get: pageGetCommand,
+  ls: pageListCommand,
+  edit: pageEditPreviewCommand,
 } as const

--- a/src/commands/page/get.ts
+++ b/src/commands/page/get.ts
@@ -32,6 +32,7 @@ import { type BoldStyle, convert } from "@/core/format/index"
 import { filterSmartContextByQuery } from "@/core/format/page-format"
 import { getCodeBlock, getPage, getPageText, getSmartContext, getTable } from "@/core/pages"
 import { writeErrorJson, writeJson } from "@/presenter/json"
+import { buildCosenseSource, wrapUntrustedText } from "@/presenter/wrap-untrusted"
 import { defineCommand } from "citty"
 
 /** text 系フォーマット (本文テキスト取得を行うもの) */
@@ -116,6 +117,12 @@ export const pageGetCommand = defineCommand({
     const project = requireProject(a)
     const startTime = Date.now()
 
+    // --wrap-untrusted: 外部コンテンツを <external_content> タグで囲むヘルパー
+    const wrapText = (text: string): string =>
+      a["wrap-untrusted"] === true
+        ? wrapUntrustedText(text, buildCosenseSource(project, a.title))
+        : text
+
     // --format バリデーション
     if (a.format !== undefined && !(VALID_FORMATS as readonly string[]).includes(a.format)) {
       writeErrorJson(
@@ -187,7 +194,7 @@ export const pageGetCommand = defineCommand({
         client.getProjectMembers(project).catch(() => null),
       ])
       const markdown = formatAiPage(page, members)
-      process.stdout.write(markdown)
+      process.stdout.write(wrapText(markdown))
       return
     }
 
@@ -211,10 +218,14 @@ export const pageGetCommand = defineCommand({
       }
 
       if (a.json) {
-        writeJson({ text: outputText }, { command: "page.get", startTime }, buildJsonOpts(a))
+        writeJson(
+          { text: wrapText(outputText) },
+          { command: "page.get", startTime },
+          buildJsonOpts(a),
+        )
         return
       }
-      process.stdout.write(`${outputText}\n`)
+      process.stdout.write(`${wrapText(outputText)}\n`)
       return
     }
 
@@ -233,11 +244,11 @@ export const pageGetCommand = defineCommand({
       const rawText = await getSmartContext(client, { project, title: a.title, hops })
       const text = filterSmartContextByQuery(rawText, a.query)
       if (a.json) {
-        writeJson({ text }, { command: "page.get", startTime }, buildJsonOpts(a))
+        writeJson({ text: wrapText(text) }, { command: "page.get", startTime }, buildJsonOpts(a))
         return
       }
       if (text) {
-        process.stdout.write(`${text}\n`)
+        process.stdout.write(`${wrapText(text)}\n`)
       }
       return
     }
@@ -252,10 +263,10 @@ export const pageGetCommand = defineCommand({
         filename: a.filename!,
       })
       if (a.json) {
-        writeJson({ code }, { command: "page.get", startTime }, buildJsonOpts(a))
+        writeJson({ code: wrapText(code) }, { command: "page.get", startTime }, buildJsonOpts(a))
         return
       }
-      process.stdout.write(`${code}\n`)
+      process.stdout.write(`${wrapText(code)}\n`)
       return
     }
 
@@ -268,10 +279,10 @@ export const pageGetCommand = defineCommand({
         filename: a.filename!,
       })
       if (a.json) {
-        writeJson({ csv }, { command: "page.get", startTime }, buildJsonOpts(a))
+        writeJson({ csv: wrapText(csv) }, { command: "page.get", startTime }, buildJsonOpts(a))
         return
       }
-      process.stdout.write(`${csv}\n`)
+      process.stdout.write(`${wrapText(csv)}\n`)
       return
     }
 

--- a/src/core/sandbox.ts
+++ b/src/core/sandbox.ts
@@ -34,6 +34,14 @@ export interface PolicyOptions {
   enableStr?: string
   /** カンマ区切り文字列での disable 指定 (CLI フラグ用) */
   disableStr?: string
+  /**
+   * enable チェックで glob/noun ワイルドカードを無効化し完全一致のみにする。
+   *
+   * true のとき: "page" "page.*" 等のワイルドカードはマッチしない。
+   * 完全一致と alias 解決 (旧→新) のみ有効。
+   * AI エージェントが最小権限で明示的に許可コマンドを列挙する場合に使用する。
+   */
+  exact?: boolean
 }
 
 /** Policy は allow メソッドでコマンドの実行可否を判定する。 */
@@ -53,11 +61,20 @@ export function createPolicy(opts: PolicyOptions): Policy {
   const enable = mergeList(opts.enable, opts.enableStr)
   const disable = mergeList(opts.disable, opts.disableStr)
 
+  const exact = opts.exact ?? false
+
   return {
     allow(command: string): PolicyError | undefined {
-      // enable リストが空でなければ、許可リストでフィルタ (双方向 alias 解決)
-      if (enable.length > 0 && !isAllowedBidirectional(command, enable)) {
-        return new PolicyError(command)
+      // enable リストが空でなければ、許可リストでフィルタ
+      if (enable.length > 0) {
+        const enableCheck = exact
+          ? // exact モード: glob/noun ワイルドカード無効、完全一致 + alias 解決のみ
+            isAllowedExact(command, enable)
+          : // 通常モード: 双方向 alias 解決 + glob/noun ワイルドカード有効
+            isAllowedBidirectional(command, enable)
+        if (!enableCheck) {
+          return new PolicyError(command)
+        }
       }
       // disable リストに含まれていれば拒否 (旧→新 単方向 alias 解決)
       if (disable.length > 0 && isAllowedWithOldToNewAlias(command, disable)) {
@@ -118,6 +135,36 @@ function isAllowed(command: string, patterns: string[]): boolean {
       return true
     return false
   })
+}
+
+/**
+ * isAllowedExact は exact モードで完全一致と alias 解決のみでコマンドを判定する。
+ *
+ * `--enable-commands-exact` フラグが有効なとき、enable チェックで使用する。
+ * glob (`page.*`) や noun ワイルドカード (`page`) はマッチしない。
+ * 完全一致と alias 解決 (旧 alias ↔ 新識別子の双方向) のみ有効。
+ */
+function isAllowedExact(command: string, patterns: string[]): boolean {
+  const normalizedCmd = normalizeCommand(command)
+  // 完全一致またはワイルドカード (*) のみ
+  const exactMatch = patterns.some((pattern) => {
+    const normalizedPattern = normalizeCommand(pattern)
+    if (normalizedPattern === "*" || normalizedPattern === "all") return true
+    return normalizedPattern === normalizedCmd
+  })
+  if (exactMatch) return true
+  // alias 解決: 双方向 (旧 alias ↔ 新識別子)
+  const oldAliases = WRITE_DEPRECATED_ALIASES_REVERSE[command]
+  if (oldAliases) {
+    for (const oldAlias of oldAliases) {
+      if (patterns.some((p) => normalizeCommand(p) === normalizeCommand(oldAlias))) return true
+    }
+  }
+  const newCanonical = WRITE_DEPRECATED_ALIASES[command]
+  if (newCanonical) {
+    if (patterns.some((p) => normalizeCommand(p) === normalizeCommand(newCanonical))) return true
+  }
+  return false
 }
 
 /**

--- a/src/presenter/wrap-untrusted.ts
+++ b/src/presenter/wrap-untrusted.ts
@@ -1,0 +1,36 @@
+/**
+ * wrap-untrusted.ts — untrusted コンテンツのラッパー。
+ *
+ * AI エージェントが Cosense ページ本文を読む際に、
+ * ページ内に仕込まれたプロンプトインジェクション攻撃を防ぐため、
+ * 外部取得テキストを <external_content> タグで囲んで出力する。
+ *
+ * gog (Google CLI) の --wrap-untrusted 機能を参考にした実装。
+ *
+ * 使い方:
+ *   --wrap-untrusted フラグが有効なとき、各コマンドは stdout に書き出す前に
+ *   このモジュールの wrapUntrustedText() を呼ぶ。
+ */
+
+/**
+ * wrapUntrustedText は外部取得テキストを <external_content> タグで囲む。
+ *
+ * @param text - Cosense から取得したページ本文や検索スニペット等の外部コンテンツ
+ * @param source - コンテンツ取得元 (例: "cosense:myproject/ページ名")。省略可。
+ * @returns タグで囲まれたテキスト
+ */
+export function wrapUntrustedText(text: string, source?: string): string {
+  const sourceAttr = source !== undefined ? ` source="${source}"` : ""
+  return `<external_content${sourceAttr}>\n${text}\n</external_content>`
+}
+
+/**
+ * buildCosenseSource は Cosense ページの取得元文字列を組み立てる。
+ *
+ * @param project - Cosense プロジェクト名
+ * @param title - ページタイトル
+ * @returns "cosense:project/title" 形式の文字列
+ */
+export function buildCosenseSource(project: string, title: string): string {
+  return `cosense:${project}/${title}`
+}

--- a/tests/unit/core/sandbox.test.ts
+++ b/tests/unit/core/sandbox.test.ts
@@ -66,6 +66,39 @@ describe("createPolicy / allow", () => {
   })
 })
 
+describe("exact モード (--enable-commands-exact)", () => {
+  it("exact=true のとき glob 'page.*' はマッチしない (完全一致のみ)", () => {
+    const policy = createPolicy({ enable: ["page.*"], exact: true })
+    // glob は無効化されるため page.list はマッチしない
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+  })
+
+  it("exact=true のとき noun ワイルドカード 'page' はマッチしない", () => {
+    const policy = createPolicy({ enable: ["page"], exact: true })
+    // noun ワイルドカードは無効化される
+    expect(policy.allow("page.list")).toBeInstanceOf(PolicyError)
+  })
+
+  it("exact=true のとき完全一致はマッチする", () => {
+    const policy = createPolicy({ enable: ["page.list", "page.get"], exact: true })
+    expect(policy.allow("page.list")).toBeUndefined()
+    expect(policy.allow("page.get")).toBeUndefined()
+    // リストにないコマンドは拒否
+    expect(policy.allow("page.delete")).toBeInstanceOf(PolicyError)
+  })
+
+  it("exact=true でも alias 解決は有効 (旧→新)", () => {
+    // enableCommands: ["page.append.preview"] で page.edit.preview も許可される
+    const policy = createPolicy({ enable: ["page.append.preview"], exact: true })
+    expect(policy.allow("page.edit.preview")).toBeUndefined()
+  })
+
+  it("exact=false (デフォルト) では glob は有効", () => {
+    const policy = createPolicy({ enable: ["page.*"], exact: false })
+    expect(policy.allow("page.list")).toBeUndefined()
+  })
+})
+
 describe("PolicyError", () => {
   it("コマンド名を含むメッセージを持つ", () => {
     const policy = createPolicy({ disable: ["page.delete"] })

--- a/tests/unit/presenter/wrap-untrusted.test.ts
+++ b/tests/unit/presenter/wrap-untrusted.test.ts
@@ -1,0 +1,56 @@
+/**
+ * wrap-untrusted.test.ts — wrapUntrustedText のテスト。
+ *
+ * --wrap-untrusted フラグが有効のとき、AI エージェントへの出力テキストを
+ * <external_content> タグで囲んでプロンプトインジェクションを防ぐ機能を検証する。
+ */
+
+import { describe, expect, it } from "bun:test"
+import { buildCosenseSource, wrapUntrustedText } from "@/presenter/wrap-untrusted"
+
+describe("wrapUntrustedText", () => {
+  it("テキストを <external_content> タグで囲む", () => {
+    const result = wrapUntrustedText("こんにちは世界")
+    expect(result).toContain("<external_content>")
+    expect(result).toContain("こんにちは世界")
+    expect(result).toContain("</external_content>")
+  })
+
+  it("source 属性を指定すると source 付きタグになる", () => {
+    const result = wrapUntrustedText("テスト本文", "cosense:myproject/テストページ")
+    expect(result).toContain('source="cosense:myproject/テストページ"')
+    expect(result).toContain("テスト本文")
+  })
+
+  it("source 省略時は source 属性なしのタグになる", () => {
+    const result = wrapUntrustedText("テスト本文")
+    expect(result).not.toContain("source=")
+    expect(result).toContain("<external_content>")
+  })
+
+  it("複数行テキストもそのまま囲む", () => {
+    const multiline = "1行目\n2行目\n3行目"
+    const result = wrapUntrustedText(multiline, "cosense:p/t")
+    expect(result).toContain("1行目")
+    expect(result).toContain("2行目")
+    expect(result).toContain("3行目")
+    expect(result.indexOf("<external_content")).toBeLessThan(result.indexOf("1行目"))
+    expect(result.indexOf("</external_content>")).toBeGreaterThan(result.indexOf("3行目"))
+  })
+
+  it("空文字もタグで囲む", () => {
+    const result = wrapUntrustedText("")
+    expect(result).toContain("<external_content>")
+    expect(result).toContain("</external_content>")
+  })
+})
+
+describe("buildCosenseSource", () => {
+  it("cosense:<project>/<title> 形式の文字列を返す", () => {
+    expect(buildCosenseSource("myproject", "テストページ")).toBe("cosense:myproject/テストページ")
+  })
+
+  it("スラッシュを含むタイトルもそのまま連結する", () => {
+    expect(buildCosenseSource("proj", "A/B")).toBe("cosense:proj/A/B")
+  })
+})


### PR DESCRIPTION
## Summary

コマンド体系再編 7 本 PR 構成の **PR 6 — gog (Google CLI) 着想の AI 安全性 + 直感性強化**。

### 変更内容

#### `--wrap-untrusted` フラグ (`src/presenter/wrap-untrusted.ts` 新規)

AI エージェントが Cosense ページ本文を読む際のプロンプトインジェクション対策:
- 外部取得テキストを `<external_content source="cosense:project/title">...</external_content>` タグで囲む
- `cos page get` の `--format=ai/text/md/context/code/table` に適用
- `--json` モードでも text フィールドをラップ

#### `--enable-commands-exact` フラグ (`src/core/sandbox.ts`)

sandbox の enable チェックで glob/noun ワイルドカードを無効化:
- `page` (noun) や `page.*` (glob) を `enable-commands` に指定してもマッチしない
- 完全一致のみ (+ 既存の alias 解決は維持)
- AI エージェントが最小権限で許可コマンドを明示的に列挙する場合に有用

#### トップレベル alias (`src/commands/index.ts`)

頻出操作の発見性向上:
- `cos get <title>` → `page get` (最短でページ取得)
- `cos ls` → `page list`
- `cos edit <title>` → `page edit preview` (編集 preview)

## Test plan

- [x] `bun test` — 1782 pass / 0 fail (新規 12 テスト追加)
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — Lint 警告なし
- [x] 新規テスト `tests/unit/presenter/wrap-untrusted.test.ts` (8 テスト)
- [x] `tests/unit/core/sandbox.test.ts` に exact モードのテスト 5 件追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 外部コンテンツを `<external_content>` で囲むオプションが追加されました。
  * トップレベルで `get` / `ls` / `edit` を直接実行できるようになりました。
  * 許可コマンドの一致方法を「完全一致」に切り替えるオプションが追加されました。

* **不具合修正**
  * 一部の出力で、外部取得テキストの扱いをより安全にしました。
  * コマンド許可判定で、必要に応じてワイルドカードではなく厳密な一致を使えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->