### PR TITLE
docs: CLI 体系再編の最終ドキュメント整備 (PR 7/7)

### DIFF
--- a/.agents/skills/coscli/SKILL.md
+++ b/.agents/skills/coscli/SKILL.md
@@ -37,6 +37,19 @@ cos exit-codes --json               # 終了コード一覧 (単一ソース)
 
 ---
 
+## トップレベル alias (よく使う操作)
+
+頻出コマンドはルートに alias が登録されている。`cos page get` と同じ動作。
+
+```bash
+cos get "ページ名" --format=ai -p myproj     # cos page get の alias
+cos ls -p myproj                              # cos page list の alias
+cos edit "ページ名" --op=append --text "行" -p myproj  # cos page edit preview の alias
+cos search "キーワード" -p myproj            # cos project search の alias (既存)
+```
+
+---
+
 ## 出力フォーマット
 
 | フラグ | 効果 |
@@ -300,6 +313,41 @@ COS_ENABLE_COMMANDS="page.list,page.get,search" cos page list --project <name>
 | `sync.pull` / `sync.diff` | 同期 (読み取り系) |
 | `convert` | 変換 |
 | `serve.rest` | REST サーバー |
+
+### `--enable-commands-exact` — 最小権限モード
+
+通常の `--enable-commands` は `page` (noun ワイルドカード) や `page.*` (glob) で一括許可できるが、
+`--enable-commands-exact` を付けるとワイルドカードが無効になり完全一致のみになる。
+
+```bash
+# glob 不使用: page.get と page.list だけを明示許可
+cos --enable-commands "page.get,page.list" \
+    --enable-commands-exact \
+    page get "タイトル" --project myproj --format=ai
+```
+
+### `--wrap-untrusted` — プロンプトインジェクション対策
+
+ページ本文などの外部取得テキストを `<external_content>` タグで囲む。
+悪意ある Cosense ページが指示を埋め込んでいても、タグ外の信頼コンテキストと分離できる。
+
+```bash
+# AI Markdown をラップして取得
+cos page get "タイトル" --format=ai --wrap-untrusted --project myproj
+
+# テキスト取得もラップ
+cos page get "タイトル" --format=text --wrap-untrusted --project myproj
+
+# JSON 形式でもラップされた文字列が data フィールドに入る
+cos page get "タイトル" --format=text --wrap-untrusted --json --project myproj
+```
+
+出力例:
+```
+<external_content source="cosense:myproject/タイトル">
+ページ本文...
+</external_content>
+```
 
 ### 設定ファイルによる永続制限
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,11 +79,22 @@ bun test                     # テスト全件 pass 必須
 
 ### alias ルール
 
-トップレベル alias は citty で別 command として二重登録している。
-alias を追加・変更する際は `src/cli.ts` の「エイリアス登録」セクションを必ず同時に更新すること。
-また `.agents/skills/coscli/SKILL.md` の該当 alias 記述 (`cos page snapshot ls`、`cos page line rm`、`cos auth me` など) も同時に更新すること。
+トップレベル alias は `src/commands/index.ts` の `rootSubCommands` に登録する (PR 6 以降の規約)。
+alias を追加・変更する際は `src/commands/index.ts` を更新すること。
+また `.agents/skills/coscli/SKILL.md` の該当 alias 記述も同時に更新すること。
 
-sandbox alias (`src/core/sandbox/aliases.ts`) が存在する場合、alias の追加・変更時には当該ファイルも同時に更新すること。
+**現在のトップレベル alias 一覧:**
+
+| alias | 委譲先 | 追加バージョン |
+|---|---|---|
+| `cos search` / `cos find` | `project search` | 初期 |
+| `cos login` | `auth login` | 初期 |
+| `cos me` | `auth whoami` | 初期 |
+| `cos get` | `page get` | v0.10.0 |
+| `cos ls` | `page list` | v0.10.0 |
+| `cos edit` | `page edit preview` | v0.10.0 |
+
+sandbox alias (`src/core/sandbox/aliases.ts`) が存在する場合、書き込み verb の alias 追加・変更時には当該ファイルも同時に更新すること。
 
 ## ディレクトリ構造
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,36 @@ ln -s "$(pwd)/.agents/skills/coscli" ~/.claude/skills/coscli
 
 最新コマンド定義は `cos schema --json` から動的取得できます。
 
+### `--wrap-untrusted` — プロンプトインジェクション対策
+
+ページ本文など外部取得テキストを `<external_content>` タグで囲んで出力します。悪意ある Cosense ページが指示を埋め込んでいても、タグ外の信頼コンテキストと分離できます。
+
+```bash
+# AI Markdown 取得時にラップ
+cos page get "ページ名" --format=ai --wrap-untrusted --project myproject
+
+# テキスト取得時にラップ
+cos page get "ページ名" --format=text --wrap-untrusted --project myproject
+```
+
+### `--enable-commands-exact` — 最小権限の明示的許可
+
+`--enable-commands` のワイルドカード (`page` / `page.*`) を無効化し、完全一致のみ許可します。AI エージェントが最小権限で動作させる場合に使用します。
+
+```bash
+cos --enable-commands "page.get,page.list" \
+    --enable-commands-exact \
+    page get "ページ名" --project myproject --format=ai
+```
+
+### トップレベル alias — よく使う操作の短縮コマンド
+
+```bash
+cos get "ページ名" --format=ai -p myproject    # cos page get の alias
+cos ls -p myproject --json                      # cos page list の alias
+cos edit "ページ名" --op=append --text "行" -p myproject  # cos page edit preview の alias
+```
+
 ### infobox でページ構造データを取得
 
 `cos page infobox` は Cosense が LLM で生成した infobox データ（キー・バリュー構造）を取得します。infobox はすべてのページに存在するわけではなく、Cosense 側が生成済みのページでのみ有効です。存在しない場合は空のリストが返ります。

--- a/tests/unit/commands/skill-doc.test.ts
+++ b/tests/unit/commands/skill-doc.test.ts
@@ -174,6 +174,13 @@ describe("SKILL.md と citty コマンドツリーの整合性", () => {
     const schema = await buildSchema(testRoot, "cos")
     const knownPaths = collectAllPaths(schema)
 
+    // rootSubCommands のキー名 (citty が直接解決する alias) も追加する
+    // 例: get/ls/edit など同一参照ではない単純 alias は buildSchema の aliases に
+    // まとめられないため、ここで補完する
+    for (const key of Object.keys(rootSubCommands)) {
+      knownPaths.add(key)
+    }
+
     // SKILL.md からコマンドパスを抽出する
     const skillText = await Bun.file(".agents/skills/coscli/SKILL.md").text()
     const usedPaths = extractCommandsFromSkillDoc(skillText)


### PR DESCRIPTION
## Summary

コマンド体系再編 7 本 PR 構成の **最終 PR — ドキュメント整備**。

PR 4〜6 で追加した機能 (sandbox alias 方向別解決 / 旧書き込み verb deprecated 化 / `--wrap-untrusted` / `--enable-commands-exact` / トップレベル alias) をドキュメントに反映します。

### 変更内容

#### `CLAUDE.md`
- alias ルール節に **トップレベル alias 一覧表** を追加
  - `cos search/find/login/me` (初期から存在)
  - `cos get/ls/edit` (v0.10.0 で PR 6 追加)
- alias を `src/cli.ts` ではなく `src/commands/index.ts` の `rootSubCommands` で管理する規約を明文化

#### `.agents/skills/coscli/SKILL.md`
- 冒頭に **「トップレベル alias (よく使う操作)」** セクション追加
- AI エージェント向け安全運用に以下を追加:
  - `--enable-commands-exact` — 最小権限の明示的許可モード
  - `--wrap-untrusted` — `<external_content>` タグでプロンプトインジェクション対策

#### `README.md`
- AI エージェント向け使い方に新機能 3 件を追加 (上記と同様)

#### `tests/unit/commands/skill-doc.test.ts`
- `collectAllPaths` が拾えないトップレベル alias (`get`/`ls`/`edit` のような同一参照ではない単純キー) を `rootSubCommands` のキー名から補完する整合性テスト改善

### コマンド体系再編 完了

| PR | 内容 |
|---|---|
| 0 | 基盤拡張 (SchemaCommand / ResponseEnvelope / AuthCapabilities) |
| 1 | `page get --format` 統合 (読み取り) |
| 2 | `page edit preview --op` 統合 (書き込み) |
| 3 | 旧読み取り verb の deprecated 化 |
| 4 | 旧書き込み verb の deprecated 化 + sandbox alias 方向別解決 |
| 5 | schema 出力拡張 + 認証メタデータ単一ソース + ドキュメント全面改訂 |
| 6 | `--wrap-untrusted` / `--enable-commands-exact` / トップレベル alias |
| **7** | **最終ドキュメント整備 (本 PR)** |

## Test plan

- [x] `bun test` — 1782 pass / 0 fail
- [x] `bun run typecheck` — 型エラーなし
- [x] `bunx biome check src tests` — Lint 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)