### PR TITLE
docs: 公式 CLI へ移行案内を追加し、リポジトリをアーカイブする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # coscli
 
+> [!WARNING]
+> **このリポジトリはアーカイブされています。**
+>
+> 公式 CLI [cosense-cli](https://github.com/helpfeel/cosense-cli) が公開されました。
+> 新規インストールには公式 CLI の使用を推奨します。
+
 **Cosense in your terminal.**
 
 [Cosense](https://cosen.se/) (旧 Scrapbox) を端末・スクリプト・AI エージェントから操作するための CLI。バイナリ名 `cos`。


### PR DESCRIPTION
## Summary

- helpfeel/cosense-cli として Cosense 公式 CLI が公開されたため、README 先頭にアーカイブ通知を追加
- GitHub の `[!WARNING]` callout を使用し、公式リポジトリへのリンクを明示

## 変更内容

README.md の先頭に以下の通知を追加:

> ⚠️ **このリポジトリはアーカイブされています。**
> 公式 CLI cosense-cli が公開されました。新規インストールには公式 CLI の使用を推奨します。

## マージ後

このPRのマージ後、GitHubリポジトリを手動でアーカイブしてください。

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README の冒頭に注意書きを追加し、このリポジトリがアーカイブされていることを明記しました。
  * 新規利用には公式 CLI「cosense-cli」を推奨する案内を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->